### PR TITLE
[ADD] Basic sorting for assets in the wardrobe

### DIFF
--- a/pandora-client-web/src/components/wardrobe/wardrobe.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobe.tsx
@@ -10,6 +10,7 @@ import {
 	AssertNotNullable,
 	Asset,
 	AssetsPosePresets,
+	ASSET_SLOT_DEFINITIONS,
 	BoneName,
 	BoneState,
 	BONE_MAX,
@@ -52,28 +53,8 @@ const assetSorters = {
 		 * Provides the sorting of assets or items by slot that they occupy.
 		 * If an asset uses more than one slot, e.g. the maids dress, the first slot in its
 		 * definition is used.
-		 * TODO: Find a convenient way to make sure the sorting array is consistant to the definition of "AssetSlotDefinition"
 		 */
-		const sortingArray = [
-			'frontHair',
-			'backHair',
-			'head',
-			'eyes',
-			'nose',
-			'mouth',
-			'neck',
-			'breasts',
-			'top',
-			'crotch',
-			'bottom',
-			'torso',
-			'arms',
-			'wrists',
-			'hands',
-			'legs',
-			'ankles',
-			'feet',
-		];
+		const sortArray = ASSET_SLOT_DEFINITIONS;
 		const itemA = (a instanceof Asset) ? a : a.asset;
 		const itemB = (b instanceof Asset) ? b : b.asset;
 		let ret = 0;
@@ -84,7 +65,7 @@ const assetSorters = {
 		else {
 			const testA = Array.isArray(itemA.definition.occupies) ? itemA.definition.occupies[0] : itemA.definition.occupies;
 			const testB = Array.isArray(itemB.definition.occupies) ? itemB.definition.occupies[0] : itemB.definition.occupies;
-			ret = sortingArray.indexOf(testA) - sortingArray.indexOf(testB);
+			ret = sortArray.indexOf(testA) - sortArray.indexOf(testB);
 			if (ret === 0) ret = ((itemA.definition.name < itemB.definition.name) ? -1 : ((itemA.definition.name > itemB.definition.name) ? 1 : 0));
 		}
 		return (ret);

--- a/pandora-common/src/assets/definitions.ts
+++ b/pandora-common/src/assets/definitions.ts
@@ -7,25 +7,27 @@ import { AssetModuleDefinition } from './modules';
 import { AssetProperties } from './properties';
 
 export type AssetTypeDefinition = 'clothing' | 'restraint';
-export type AssetSlotDefinition =
-	'frontHair' |
-	'backHair' |
-	'eyes' |
-	'nose' |
-	'mouth' |
-	'head' |
-	'neck' |
-	'breasts' |
-	'top' |
-	'crotch' |
-	'bottom' |
-	'torso' |
-	'arms' |
-	'wrists' |
-	'hands' |
-	'legs' |
-	'ankles' |
-	'feet';
+export const ASSET_SLOT_DEFINITIONS = [
+	'frontHair',
+	'backHair',
+	'head',
+	'eyes',
+	'nose',
+	'mouth',
+	'neck',
+	'breasts',
+	'top',
+	'crotch',
+	'bottom',
+	'torso',
+	'arms',
+	'wrists',
+	'hands',
+	'legs',
+	'ankles',
+	'feet',
+] as const;
+export type AssetSlotDefinition = typeof ASSET_SLOT_DEFINITIONS[number];
 
 export const AssetIdSchema = zTemplateString<`a/${string}`>(z.string(), /^a\//);
 export type AssetId = z.infer<typeof AssetIdSchema>;


### PR DESCRIPTION
I kinda thought the last commit message was copied here...
So: This adds two new property definition for assets ('kind' and 'occupies').
`Kind` can be used to say, if this asset is best described as clothing or restraint and `occupies` provides a list of slots, the asset uses, when worn.
Items in the wardrobe (not the worn ones) are sorted by their slot now.