### PR TITLE
[FEATURE] Assets automation actions

### DIFF
--- a/pandora-common/src/assets/appearanceAutomation.ts
+++ b/pandora-common/src/assets/appearanceAutomation.ts
@@ -1,0 +1,82 @@
+import { AssertNever } from '../utility';
+import type { AppearanceRootManipulator } from './appearanceHelpers';
+import type { ItemModuleAction } from './modules';
+
+interface AppearanceAutomaticActionBase<T extends string> {
+	type: T;
+	/**
+	 * Failure mode for this action. Possible values are:
+	 * - `required`: Must apply to at least one item and all invocations must succeed
+	 * - `optional`: All invocations must succeed, but not doing anything is valid result
+	 * - `ignorable`: Doesn't matter if it does something or not or even if it tries and fails
+	 */
+	mode: 'required' | 'optional' | 'ignorable';
+}
+
+interface AppearanceAutomaticActionSetExpression extends AppearanceAutomaticActionBase<'setExpression'> {
+	/** Exact name of the expression to modify */
+	expression: string;
+	/** Module-action to do on the expression module */
+	action: ItemModuleAction;
+}
+
+function AssetAutomationRunSetExpression(
+	manipulator: AppearanceRootManipulator,
+	{ mode, expression, action }: AppearanceAutomaticActionSetExpression,
+): boolean {
+	let match = false;
+	for (const item of manipulator.getItems()) {
+		for (const [moduleName, module] of item.modules) {
+			if (module.config.expression === expression) {
+				match = true;
+				if (
+					!manipulator.modifyItem(item.id, (it) => it.moduleAction(
+						moduleName,
+						action,
+						(m) => manipulator.queueMessage({
+							item: {
+								assetId: it.asset.id,
+							},
+							...m,
+						}),
+					)) &&
+					mode !== 'ignorable'
+				) {
+					return false;
+				}
+			}
+		}
+	}
+	return mode === 'required' ? match : true;
+}
+
+export type AppearanceAutomaticAction =
+	| AppearanceAutomaticActionSetExpression;
+
+/** Actions that get run on specific asset interactions, meant to make using items easier, like automating some prerequisites */
+export interface AssetAutomaticActions {
+	/** Actions run before the item is added */
+	beforeAdd?: AppearanceAutomaticAction[];
+	/** Actions run after the item is removed (before validation happens) */
+	afterRemove?: AppearanceAutomaticAction[];
+}
+
+export type AssetAutomationEvent = (keyof AssetAutomaticActions) & string;
+
+export function AssetAutomationRun(manipulator: AppearanceRootManipulator, automation: AppearanceAutomaticAction[] | undefined): boolean {
+	if (!automation)
+		return true;
+
+	for (const action of automation) {
+		switch (action.type) {
+			case 'setExpression':
+				if (!AssetAutomationRunSetExpression(manipulator, action))
+					return false;
+				break;
+			default:
+				AssertNever(action.type);
+		}
+	}
+
+	return true;
+}

--- a/pandora-common/src/assets/definitions.ts
+++ b/pandora-common/src/assets/definitions.ts
@@ -2,9 +2,10 @@ import { z } from 'zod';
 import type { IChatroomBackgroundData } from '../chatroom';
 import { HexColorString, zTemplateString } from '../validation';
 import type { ArmsPose, BoneName } from './appearance';
+import type { AssetAutomaticActions } from './appearanceAutomation';
 import type { BoneDefinitionCompressed } from './graphics';
-import { AssetModuleDefinition } from './modules';
-import { AssetProperties } from './properties';
+import type { AssetModuleDefinition } from './modules';
+import type { AssetProperties } from './properties';
 
 export const AssetIdSchema = zTemplateString<`a/${string}`>(z.string(), /^a\//);
 export type AssetId = z.infer<typeof AssetIdSchema>;
@@ -97,6 +98,9 @@ export interface AssetDefinition<A extends AssetDefinitionExtraArgs = AssetDefin
 	 * Modules this asset has
 	 */
 	modules?: Record<string, AssetModuleDefinition<A>>;
+
+	/** Automation on specific events to make using the item easier for users */
+	automation?: AssetAutomaticActions;
 
 	/** If this item has any graphics to be loaded or is only virtual */
 	hasGraphics: boolean;

--- a/pandora-common/src/assets/modules/typed.ts
+++ b/pandora-common/src/assets/modules/typed.ts
@@ -50,6 +50,7 @@ const ModuleItemDataTypedScheme = z.object({
 
 export const ItemModuleTypedActionSchema = z.object({
 	moduleType: z.literal('typed'),
+	/** ID if an variant to set this module to */
 	setVariant: z.string(),
 });
 type ItemModuleTypedAction = z.infer<typeof ItemModuleTypedActionSchema>;


### PR DESCRIPTION
Adds way for assets to automate some small actions (like changing expression - to open mouth before being put on) so users don't have to do those manually before adding or after removing the item.