### PR TITLE
[FIX] Prevent background previews from overflowing if too big

### DIFF
--- a/pandora-client-web/src/components/chatroomAdmin/chatroomAdmin.scss
+++ b/pandora-client-web/src/components/chatroomAdmin/chatroomAdmin.scss
@@ -140,8 +140,9 @@
 			}
 
 			.preview {
-				flex: 1;
 				@include center-flex;
+				flex: 1;
+				overflow: hidden;
 
 				img {
 					max-width: 100%;


### PR DESCRIPTION
Prevents images in background select from overflowing if they are larger than the allocated size for them - mainly seen if assets were not built in production mode (where previews point to the images themselves)