### PR TITLE
[FIX] use secure connection for SMTP

### DIFF
--- a/pandora-server-directory/src/services/email/smtpEmail.ts
+++ b/pandora-server-directory/src/services/email/smtpEmail.ts
@@ -15,6 +15,8 @@ export default class SmtpEmail implements IEmailSender {
 		this._transporter = createTransport({
 			service,
 			host,
+			port: 465,
+			secure: true,
 			auth: {
 				user,
 				pass: EMAIL_SMTP_PASSWORD,


### PR DESCRIPTION
SFP is invalid if the secure flag is not set