### PR TITLE
[DEV] Add global jest config that links individual projects

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,36 @@
+const path = require('path');
+
+/**
+ * Function that loads the target project config, deleting options not usable in the config
+ * @param {string} dir - Path to the subproject
+ */
+function loadProjectConfig(dir) {
+	const config = require(`./${dir}/jest.config.js`);
+
+	/** @type { Exclude<import('jest').Config['projects'], undefined>[number] } */
+	const resultConfig = {
+		...config,
+		displayName: dir,
+		rootDir: path.join('./', dir, config.rootDir ?? '.'),
+	};
+
+	delete resultConfig.collectCoverageFrom;
+	delete resultConfig.coverageDirectory;
+
+	return resultConfig;
+}
+
+/**
+ * For a detailed explanation regarding each configuration property and type check, visit:
+ * https://jestjs.io/docs/configuration
+ * @type { import('jest').Config }
+ */
+module.exports = {
+	projects: [
+		loadProjectConfig('pandora-common'),
+		loadProjectConfig('pandora-server-directory'),
+		loadProjectConfig('pandora-server-shard'),
+		loadProjectConfig('pandora-client-web'),
+	],
+	errorOnDeprecated: true,
+};

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
 	},
 	"dependencies": {
 		"js-yaml": "^4.1.0"
+	},
+	"devDependencies": {
+		"jest": "^29.5.0"
 	}
 }

--- a/pandora-client-web/jest.config.js
+++ b/pandora-client-web/jest.config.js
@@ -1,7 +1,8 @@
 /* eslint-env node */
-/*
+/**
  * For a detailed explanation regarding each configuration property and type check, visit:
  * https://jestjs.io/docs/configuration
+ * @type { import('jest').Config }
  */
 module.exports = {
 	clearMocks: true,

--- a/pandora-common/jest.config.js
+++ b/pandora-common/jest.config.js
@@ -1,7 +1,8 @@
 /* eslint-env node */
-/*
+/**
  * For a detailed explanation regarding each configuration property and type check, visit:
  * https://jestjs.io/docs/configuration
+ * @type { import('jest').Config }
  */
 module.exports = {
 	clearMocks: true,

--- a/pandora-server-directory/jest.config.js
+++ b/pandora-server-directory/jest.config.js
@@ -1,6 +1,7 @@
-/*
+/**
  * For a detailed explanation regarding each configuration property and type check, visit:
  * https://jestjs.io/docs/configuration
+ * @type { import('jest').Config }
  */
 module.exports = {
 	clearMocks: true,

--- a/pandora-server-shard/jest.config.js
+++ b/pandora-server-shard/jest.config.js
@@ -1,6 +1,7 @@
-/*
+/**
  * For a detailed explanation regarding each configuration property and type check, visit:
  * https://jestjs.io/docs/configuration
+ * @type { import('jest').Config }
  */
 module.exports = {
 	clearMocks: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,10 @@ importers:
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
+    devDependencies:
+      jest:
+        specifier: ^29.5.0
+        version: 29.5.0
 
   pandora-client-web:
     dependencies:
@@ -7122,6 +7126,34 @@ packages:
       - supports-color
     dev: true
 
+  /jest-cli@29.5.0:
+    resolution: {integrity: sha512-L1KcP1l4HtfwdxXNFCL5bmUbLQiKrakMUriBEcc1Vfz6gx31ORKdreuWvmQVBit+1ss9NNR3yxjwfwzZNdQXJw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 29.5.0
+      '@jest/test-result': 29.5.0
+      '@jest/types': 29.5.0
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      import-local: 3.1.0
+      jest-config: 29.5.0
+      jest-util: 29.5.0
+      jest-validate: 29.5.0
+      prompts: 2.4.2
+      yargs: 17.7.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+      - ts-node
+    dev: true
+
   /jest-cli@29.5.0(@types/node@18.15.3):
     resolution: {integrity: sha512-L1KcP1l4HtfwdxXNFCL5bmUbLQiKrakMUriBEcc1Vfz6gx31ORKdreuWvmQVBit+1ss9NNR3yxjwfwzZNdQXJw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -7176,6 +7208,44 @@ packages:
       - '@types/node'
       - supports-color
       - ts-node
+    dev: true
+
+  /jest-config@29.5.0:
+    resolution: {integrity: sha512-kvDUKBnNJPNBmFFOhDbm59iu1Fii1Q6SxyhXfvylq3UTHbg6o7j/g8k2dZyXWLvfdKB1vAPxNZnMgtKJcmu3kA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      '@babel/core': 7.21.3
+      '@jest/test-sequencer': 29.5.0
+      '@jest/types': 29.5.0
+      babel-jest: 29.5.0(@babel/core@7.21.3)
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.5.0
+      jest-environment-node: 29.5.0
+      jest-get-type: 29.4.3
+      jest-regex-util: 29.4.3
+      jest-resolve: 29.5.0
+      jest-runner: 29.5.0
+      jest-util: 29.5.0
+      jest-validate: 29.5.0
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 29.5.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /jest-config@29.5.0(@types/node@18.15.3):
@@ -7573,6 +7643,26 @@ packages:
       jest-util: 29.5.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
+    dev: true
+
+  /jest@29.5.0:
+    resolution: {integrity: sha512-juMg3he2uru1QoXX078zTa7pO85QyB9xajZc6bU+d9yEGwrKX6+vGmJQ3UdVZsvTEUARIdObzH68QItim6OSSQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 29.5.0
+      '@jest/types': 29.5.0
+      import-local: 3.1.0
+      jest-cli: 29.5.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+      - ts-node
     dev: true
 
   /jest@29.5.0(@types/node@18.15.3):


### PR DESCRIPTION
This PR adds a global jest config to the monorepo.
Purpose of this is not to use it in CI or similar (although in theory we could), but mainly to make IDE extensions that expect such setup happy and able to execute the tests properly, showing test results in GUI.