### PR TITLE
[DEV] Fix which files are included in pandora-common bundle

### DIFF
--- a/pandora-common/package.json
+++ b/pandora-common/package.json
@@ -11,8 +11,10 @@
 	"types": "./dist/index.d.ts",
 	"files": [
 		"/dist/**/*",
+		"/src/**/*",
 		".eslintrc.json",
-		"tsconfig.base.json"
+		"tsconfig.base.json",
+		"tsconfig.json"
 	],
 	"scripts": {
 		"clean": "rimraf dist",


### PR DESCRIPTION
This is done in preparation for pnpm v8, which is stricter about files that are included in a bundle when installing external package that needs to be built first.
This should fix installability of `pandora-common` using pnpm v8.