### PR TITLE
[CHANGE] Make room inventory tab the default

### DIFF
--- a/pandora-client-web/src/components/common/tabs/tabs.tsx
+++ b/pandora-client-web/src/components/common/tabs/tabs.tsx
@@ -19,7 +19,7 @@ export function TabContainer({ children, id, className, collapsable }: {
 
 	const [currentTab, setTab] = useState(() => {
 		const defaultTab = children.findIndex((c) => c && c.props.default);
-		return defaultTab < 0 ? 0 : defaultTab;
+		return defaultTab >= 0 ? defaultTab : children.findIndex((c) => !!c);
 	});
 
 	const [collapsed, setCollapsed] = useState(false);

--- a/pandora-client-web/src/components/wardrobe/wardrobe.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobe.tsx
@@ -460,7 +460,7 @@ export function useWardrobeItems(): {
 }
 
 function WardrobeItemManipulation({ className }: { className?: string; }): ReactElement {
-	const { target, assetList } = useWardrobeContext();
+	const { globalState, target, assetList } = useWardrobeContext();
 	const { currentFocus, setFocus, preFilter, containerContentsFilter } = useWardrobeItems();
 
 	const assetManager = useAssetManager();
@@ -482,6 +482,13 @@ function WardrobeItemManipulation({ className }: { className?: string; }): React
 				setFocus={ setFocus }
 			/>
 			<TabContainer className={ classNames('flex-1', WardrobeFocusesItem(currentFocus) && 'hidden') }>
+				{
+					globalState.room != null && !isRoomInventory ? (
+						<Tab name='Room inventory'>
+							<RoomInventoryView title='Use items in room inventory' container={ currentFocus.container } />
+						</Tab>
+					) : null
+				}
 				<Tab name='Create new item'>
 					<InventoryAssetView
 						title='Create and use a new item'
@@ -492,13 +499,6 @@ function WardrobeItemManipulation({ className }: { className?: string; }): React
 						container={ currentFocus.container }
 					/>
 				</Tab>
-				{
-					!isRoomInventory ? (
-						<Tab name='Room inventory'>
-							<RoomInventoryView title='Use items in room inventory' container={ currentFocus.container } />
-						</Tab>
-					) : null
-				}
 				<Tab name='Recent items'>
 					<div className='inventoryView'>
 						<div className='center-flex flex-1'>


### PR DESCRIPTION
Changes the default tab while inside room to be room inventory, to avoid accidentally deleting worn items when one wants to only strip them.
Outside of room the tab is hidden altogether.
Also fixes a bug that if first tab is `null`, the selection of default tab would fail.