### PR TITLE
[FIX] Allow disabling pose offset in room device

### DIFF
--- a/pandora-client-web/src/components/chatroom/chatRoomDevice.tsx
+++ b/pandora-client-web/src/components/chatroom/chatRoomDevice.tsx
@@ -324,16 +324,18 @@ function RoomDeviceGraphicsLayerSlotCharacter({ item, layer, character, characte
 		baseScale *= 0.9;
 	}
 
-	const scale = baseScale * layer.characterPosition.relativeScale;
+	const scale = baseScale * (layer.characterPosition.relativeScale ?? 1);
 
 	const backView = useCharacterAppearanceView(characterState) === 'back';
 
 	const scaleX = backView ? -1 : 1;
 
-	const yOffset = 0
+	const yOffsetPose = 0
 		+ 1.75 * evaluator.getBoneLikeValue('kneeling')
 		+ 0.75 * evaluator.getBoneLikeValue('sitting')
 		+ (evaluator.getBoneLikeValue('kneeling') === 0 ? -0.2 : 0) * evaluator.getBoneLikeValue('tiptoeing');
+
+	const yOffset = layer.characterPosition.disablePoseOffset ? 0 : yOffsetPose;
 
 	// Character must be in this device, otherwise we skip rendering it here
 	// (could happen if character left and rejoined the room without device equipped)

--- a/pandora-common/src/assets/definitions.ts
+++ b/pandora-common/src/assets/definitions.ts
@@ -184,9 +184,17 @@ export type IRoomDeviceGraphicsLayerSlot = {
 		offsetX: number;
 		offsetY: number;
 		/**
-		 * Is the factor by which the character is made bigger or smaller inside the room device slot compared to this room device scaled inside the room
+		 * Is the factor by which the character is made bigger or smaller inside the room device slot,
+		 * compared to this room device scaled inside the room
+		 * @default 1
 		 */
-		relativeScale: number;
+		relativeScale?: number;
+		/**
+		 * Prevents pose from changing character's offset while inside this room device slot
+		 * (for slots that allow different poses, but require precision)
+		 * @default false
+		 */
+		disablePoseOffset?: boolean;
 	};
 };
 


### PR DESCRIPTION
Allows room devices to specify, that character inside shouldn't be affected by pose offset. This allow creating room devices where wearable part and main part interact in precise manner.

Also makes `relativeScale` option optional.