### PR TITLE
[FEATURE] Show color ribbon on items in wardrobe

### DIFF
--- a/pandora-client-web/src/components/wardrobe/wardrobe.scss
+++ b/pandora-client-web/src/components/wardrobe/wardrobe.scss
@@ -264,6 +264,13 @@ $drop-overlay-gap: 0.3em;
 		background-color: #999;
 	}
 
+	>.colorRibbon {
+		position: absolute;
+		display: inline-block;
+		inset: 0;
+		clip-path: polygon(0 0, 0.75em 0, 0 0.75em);
+	}
+
 	.itemPreview {
 		&.missing {
 			border: solid $black 1px;

--- a/pandora-client-web/src/components/wardrobe/wardrobe.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobe.tsx
@@ -89,7 +89,7 @@ import { Select } from '../common/select/select';
 import { useCurrentAccount, useDirectoryConnector } from '../gameContext/directoryConnectorContextProvider';
 import { Immutable } from 'immer';
 import { useUpdatedUserInput } from '../../common/useSyncUserInput';
-import { useItemColorString } from '../../graphics/graphicsLayer';
+import { useItemColorString, useItemColorRibbon } from '../../graphics/graphicsLayer';
 import { Scrollbar } from '../common/scrollbar/scrollbar';
 
 export function GenerateRandomItemId(): ItemId {
@@ -934,6 +934,8 @@ function RoomInventoryViewListItem({ room, item, characterContainer }: {
 	const { setHeldItem, targetSelector, showExtraActionButtons } = useWardrobeContext();
 	const inventoryItem = EvalItemPath(room.items, item);
 
+	const ribbonColor = useItemColorRibbon([], inventoryItem ?? null);
+
 	if (!inventoryItem) {
 		return <div className='inventoryViewItem listMode blocked'>[ ERROR: ITEM NOT FOUND ]</div>;
 	}
@@ -952,6 +954,15 @@ function RoomInventoryViewListItem({ room, item, characterContainer }: {
 				});
 			} }
 		>
+			{
+				ribbonColor ?
+					<span
+						className='colorRibbon'
+						style={ {
+							backgroundColor: ribbonColor,
+						} }
+					/> : null
+			}
 			<InventoryAssetPreview asset={ asset } />
 			<span className='itemName'>{ asset.definition.name }</span>
 			<div className='quickActions'>
@@ -1437,6 +1448,8 @@ function InventoryItemViewList({ item, selected = false, setFocus, singleItemCon
 	const wornItem = useWardrobeTargetItem(target, item);
 	const extraActions = useObservable(extraItemActions);
 
+	const ribbonColor = useItemColorRibbon([], wornItem ?? null);
+
 	if (!wornItem) {
 		return <div className='inventoryViewItem listMode blocked'>[ ERROR: ITEM NOT FOUND ]</div>;
 	}
@@ -1452,6 +1465,15 @@ function InventoryItemViewList({ item, selected = false, setFocus, singleItemCon
 				itemId: selected ? null : item.itemId,
 			});
 		} }>
+			{
+				ribbonColor ?
+					<span
+						className='colorRibbon'
+						style={ {
+							backgroundColor: ribbonColor,
+						} }
+					/> : null
+			}
 			<InventoryAssetPreview asset={ asset } />
 			<span className='itemName'>{ asset.definition.name }</span>
 			<div className='quickActions'>

--- a/pandora-client-web/src/graphics/graphicsLayer.tsx
+++ b/pandora-client-web/src/graphics/graphicsLayer.tsx
@@ -279,6 +279,28 @@ export function useItemColor(items: AppearanceItems, item: Item | null, coloriza
 	return { color, alpha };
 }
 
+export function useItemColorRibbon(items: AppearanceItems, item: Item | null): HexColorString | undefined {
+	const currentRoomDevice = useContext(RoomDeviceRenderContext);
+
+	let color: HexColorString | undefined;
+
+	if (item == null) {
+		color = undefined;
+	} else if (item.isType('personal')) {
+		color = item.getColorRibbon(items);
+	} else if (item.isType('roomDevice')) {
+		color = item.getColorRibbon();
+	} else if (item.isType('roomDeviceWearablePart')) {
+		color = item.getColorRibbon(currentRoomDevice);
+	} else if (item.isType('lock')) {
+		color = undefined;
+	} else {
+		AssertNever(item);
+	}
+
+	return (color?.substring(0, 7) as HexColorString | undefined);
+}
+
 const MASK_X_OVERSCAN = 250;
 export const MASK_SIZE: Readonly<PandoraRectangle> = {
 	x: MASK_X_OVERSCAN,

--- a/pandora-common/src/assets/definitions.ts
+++ b/pandora-common/src/assets/definitions.ts
@@ -143,6 +143,9 @@ export interface PersonalAssetDefinition<A extends AssetDefinitionExtraArgs = As
 	/** Configuration of user-configurable asset colorization */
 	colorization?: Record<string, AssetColorization<A>>;
 
+	/** Which colorization group should be used for item's ribbon in inventory (if not specified defaults to first color group) */
+	colorRibbonGroup?: string;
+
 	/**
 	 * Modules this asset has
 	 */
@@ -205,6 +208,8 @@ export type IRoomDeviceGraphicsLayer = IRoomDeviceGraphicsLayerSprite | IRoomDev
 export interface RoomDeviceAssetDefinition<A extends AssetDefinitionExtraArgs = AssetDefinitionExtraArgs> extends AssetBaseDefinition<'roomDevice', A> {
 	/** Configuration of user-configurable asset colorization */
 	colorization?: Record<string, Omit<AssetColorization<A>, 'group'>>;
+	/** Which colorization group should be used for item's ribbon in inventory (if not specified defaults to first color group) */
+	colorRibbonGroup?: string;
 	/** Position of centerpoint relative to top-left corner of assets */
 	pivot: Coordinates;
 	/** Slots that can be entered by characters */

--- a/pandora-common/src/assets/item.ts
+++ b/pandora-common/src/assets/item.ts
@@ -1,5 +1,5 @@
 import { Immutable } from 'immer';
-import _ from 'lodash';
+import _, { first } from 'lodash';
 import { z } from 'zod';
 import { Logger } from '../logging';
 import { Assert, AssertNever, MemoizeNoArg, Satisfies, Writeable } from '../utility';
@@ -449,6 +449,15 @@ export class ItemPersonal extends ItemBase<'personal'> {
 
 		return this._resolveColorGroup(items, colorizationKey, colorization)?.color ?? colorization.default;
 	}
+
+	public getColorRibbon(items: AppearanceItems): HexRGBAColorString | undefined {
+		return this.resolveColor(
+			items,
+			this.asset.definition.colorRibbonGroup ??
+			first(Object.keys(this.asset.definition.colorization ?? {})) ??
+			'',
+		);
+	}
 }
 
 export class ItemRoomDevice extends ItemBase<'roomDevice'> {
@@ -547,6 +556,14 @@ export class ItemRoomDevice extends ItemBase<'roomDevice'> {
 
 		return colorization.default;
 	}
+
+	public getColorRibbon(): HexRGBAColorString | undefined {
+		return this.resolveColor(
+			this.asset.definition.colorRibbonGroup ??
+			first(Object.keys(this.asset.definition.colorization ?? {})) ??
+			'',
+		);
+	}
 }
 
 export class ItemRoomDeviceWearablePart extends ItemBase<'roomDeviceWearablePart'> {
@@ -608,6 +625,10 @@ export class ItemRoomDeviceWearablePart extends ItemBase<'roomDeviceWearablePart
 
 	public resolveColor(colorizationKey: string, roomDevice: ItemRoomDevice | null): HexRGBAColorString | undefined {
 		return roomDevice?.resolveColor(colorizationKey);
+	}
+
+	public getColorRibbon(roomDevice: ItemRoomDevice | null): HexRGBAColorString | undefined {
+		return roomDevice?.getColorRibbon();
 	}
 }
 


### PR DESCRIPTION
Adds a color ribbon to the corner of items in wardrobe (both worn and room inventory view) to allow more easily identifying same items that differ by color.
Note, that currently it may happen that there is a 1px gap. Fixing this would require bigger CSS rework of wardrobe that is planned in the future anyway.