### PR TITLE
[FIX] Fix editor crash when creating a new asset

### DIFF
--- a/pandora-common/src/character/characterTypes.ts
+++ b/pandora-common/src/character/characterTypes.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { ZodMatcher, ZodTemplateString } from '../validation';
 
-export const CharacterIdSchema = ZodTemplateString<`c${number}`>(z.string(), /^c[1-9][0-9]{0,15}$/);
+export const CharacterIdSchema = ZodTemplateString<`c${number}`>(z.string(), /^c[0-9]+$/);
 export type CharacterId = z.infer<typeof CharacterIdSchema>;
 
 /**


### PR DESCRIPTION
This changes character id matching to recognize `c0` as a valid character id - it is id used by editor.