### PR TITLE
[FIX] Fix blindness affecting player in a device and in wardrobe

### DIFF
--- a/pandora-client-web/src/character/character.ts
+++ b/pandora-client-web/src/character/character.ts
@@ -8,6 +8,7 @@ export type AppearanceContainer<T extends ICharacterPublicData = ICharacterPubli
 	readonly id: CharacterId;
 	readonly name: string;
 	readonly data: Readonly<T>;
+	isPlayer(): boolean;
 	getAppearance(state: AssetFrameworkCharacterState): CharacterAppearance;
 	getRestrictionManager(state: AssetFrameworkCharacterState, roomContext: ActionRoomContext | null): CharacterRestrictionsManager;
 };

--- a/pandora-client-web/src/components/chatroom/chatRoomCharacter.tsx
+++ b/pandora-client-web/src/components/chatroom/chatRoomCharacter.tsx
@@ -1,5 +1,5 @@
 import { AssetFrameworkCharacterState, CalculateCharacterMaxYForBackground, CharacterSize, ICharacterRoomData, IChatroomBackgroundData, IChatRoomFullInfo } from 'pandora-common';
-import PIXI, { FederatedPointerEvent, Filter, Point, Rectangle, TextStyle } from 'pixi.js';
+import PIXI, { FederatedPointerEvent, Point, Rectangle, TextStyle } from 'pixi.js';
 import React, { ReactElement, useCallback, useEffect, useMemo, useRef } from 'react';
 import { Character, useCharacterAppearanceView } from '../../character/character';
 import { ShardConnector } from '../../networking/shardConnector';
@@ -11,6 +11,7 @@ import { useAppearanceConditionEvaluator } from '../../graphics/appearanceCondit
 import { useEvent } from '../../common/useEvent';
 import { MASK_SIZE } from '../../graphics/graphicsLayer';
 import { ChatRoom, useCharacterRestrictionsManager, useCharacterState } from '../gameContext/chatRoomContextProvider';
+import { usePlayerVisionFilters } from './chatRoomScene';
 
 type ChatRoomCharacterProps = {
 	character: Character<ICharacterRoomData>;
@@ -20,7 +21,6 @@ type ChatRoomCharacterProps = {
 	background: IChatroomBackgroundData;
 	shard: ShardConnector | null;
 	menuOpen: (target: Character<ICharacterRoomData>, data: FederatedPointerEvent) => void;
-	filters: readonly Filter[];
 };
 
 type ChatRoomCharacterPropsWithState = ChatRoomCharacterProps & {
@@ -80,9 +80,10 @@ function ChatRoomCharacterDisplay({
 	background,
 	shard,
 	menuOpen,
-	filters,
 }: ChatRoomCharacterPropsWithState): ReactElement | null {
 	const app = useApp();
+
+	const filters = usePlayerVisionFilters(character.isPlayer());
 
 	const setPositionRaw = useEvent((newX: number, newY: number): void => {
 		const maxY = CalculateCharacterMaxYForBackground(background);

--- a/pandora-client-web/src/components/wardrobe/wardrobeGraphics.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobeGraphics.tsx
@@ -61,9 +61,11 @@ export function WardrobeCharacterPreview({ character, characterState }: {
 		</div>
 	);
 
+	const filters = usePlayerVisionFilters(character.isPlayer());
+
 	return (
 		<GraphicsScene className='characterPreview' divChildren={ overlay } sceneOptions={ sceneOptions }>
-			<GraphicsCharacter characterState={ characterState } />
+			<GraphicsCharacter characterState={ characterState } filters={ filters } />
 			{
 				roomBackground ? (
 					<WardrobeRoomBackground character={ character } characterState={ characterState } roomBackground={ roomBackground } />

--- a/pandora-client-web/src/components/wardrobe/wardrobeGraphics.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobeGraphics.tsx
@@ -18,8 +18,7 @@ import { useCurrentAccountSettings, useDirectoryConnector } from '../gameContext
 import { useAssetManager } from '../../assets/assetManager';
 import { useCharacterIsInChatroom, useChatRoomInfo } from '../gameContext/chatRoomContextProvider';
 import { useChatRoomCharacterPosition } from '../chatroom/chatRoomCharacter';
-import { useCharacterVisionFilters } from '../chatroom/chatRoomScene';
-import { usePlayerState } from '../gameContext/playerContextProvider';
+import { usePlayerVisionFilters } from '../chatroom/chatRoomScene';
 
 export function WardrobeCharacterPreview({ character, characterState }: {
 	character: AppearanceContainer<ICharacterRoomData>;
@@ -83,9 +82,8 @@ function WardrobeRoomBackground({
 	character: AppearanceContainer<ICharacterRoomData>;
 	characterState: AssetFrameworkCharacterState;
 }): ReactElement {
-	const { player, playerState } = usePlayerState();
 	const characterPosition = useChatRoomCharacterPosition(character.data.position, characterState, roomBackground);
-	const filters = useCharacterVisionFilters(player, playerState);
+	const filters = usePlayerVisionFilters(false);
 
 	const scale = 1 / characterPosition.scale;
 

--- a/pandora-client-web/src/editor/graphics/character/appearanceEditor.ts
+++ b/pandora-client-web/src/editor/graphics/character/appearanceEditor.ts
@@ -122,6 +122,10 @@ export class EditorCharacter implements AppearanceContainer<ICharacterRoomData> 
 		};
 	}
 
+	public isPlayer(): boolean {
+		return true;
+	}
+
 	public getAppearance(state?: AssetFrameworkCharacterState): AppearanceEditor {
 		state ??= this.editor.globalState.currentState.getCharacterState(this.id) ?? undefined;
 		Assert(state != null && state.id === this.id);


### PR DESCRIPTION
~~Depends on: #311 (reuses the refactor of background handling and blindness filters)~~

This PR fixes two problems:
- Player character graphics shouldn't be affected by blindness, but this wasn't the case while in a device, now they are not affected as intended
- Other characters should be affected when looking at them in wardrobe to avoid cheating