### PR TITLE
[FIX] Prevent hover element from rendering under other elements

### DIFF
--- a/pandora-client-web/src/components/hoverElement/hoverElement.tsx
+++ b/pandora-client-web/src/components/hoverElement/hoverElement.tsx
@@ -3,6 +3,9 @@ import React, { ReactElement, useEffect, useState } from 'react';
 import { CommonProps } from '../../common/reactTypes';
 import { useContextMenuPosition } from '../contextMenu/contextMenu';
 import './hoverElement.scss';
+import { createHtmlPortalNode, InPortal, OutPortal } from 'react-reverse-portal';
+
+const hoverPortal = createHtmlPortalNode();
 
 type HoverElementProps = CommonProps & {
 	parent: HTMLElement | null;
@@ -43,8 +46,14 @@ export function HoverElement({ children, className, parent }: HoverElementProps)
 		return null;
 
 	return (
-		<div className={ classNames('hover-element', className) } ref={ positionRef }>
-			{ children }
-		</div>
+		<InPortal node={ hoverPortal }>
+			<div className={ classNames('hover-element', className) } ref={ positionRef }>
+				{ children }
+			</div>
+		</InPortal>
 	);
+}
+
+export function HoverElementsPortal(): ReactElement {
+	return <OutPortal node={ hoverPortal } />;
 }

--- a/pandora-client-web/src/editor/editorContextProvider.tsx
+++ b/pandora-client-web/src/editor/editorContextProvider.tsx
@@ -7,6 +7,7 @@ import { DebugContextProvider, useDebugContext } from '../components/error/debug
 import { RootErrorBoundary } from '../components/error/rootErrorBoundary';
 import { Editor } from './editor';
 import { AssetFrameworkGlobalState } from 'pandora-common';
+import { HoverElementsPortal } from '../components/hoverElement/hoverElement';
 
 export const EditorContext = createContext({
 	editor: null as Editor | null,
@@ -26,6 +27,7 @@ export function EditorContextProvider({ children }: ChildrenProps): ReactElement
 		<DebugContextProvider>
 			<EditorErrorBoundry>
 				<Dialogs />
+				<HoverElementsPortal />
 				<EditorContext.Provider value={ context }>
 					{ children }
 				</EditorContext.Provider>

--- a/pandora-client-web/src/index.tsx
+++ b/pandora-client-web/src/index.tsx
@@ -12,6 +12,7 @@ import './index.scss';
 import './styles/globalUtils.scss';
 import { PandoraRoutes } from './routing/Routes';
 import { Dialogs } from './components/dialog/dialog';
+import { HoverElementsPortal } from './components/hoverElement/hoverElement';
 
 const logger = GetLogger('init');
 
@@ -31,6 +32,7 @@ function Start(): void {
 	createRoot(document.querySelector('#pandora-root') as HTMLElement).render(
 		<React.StrictMode>
 			<Dialogs />
+			<HoverElementsPortal />
 			<EulaGate>
 				<BrowserRouter>
 					<GameContextProvider>


### PR DESCRIPTION
This can be currently seen in wardrobe on drop elements that report the action isn't possible.