### PR TITLE
[FIX] Fix shard crashing when loading room with invalid data

### DIFF
--- a/pandora-client-web/src/components/chatroomSelect/chatroomSelect.tsx
+++ b/pandora-client-web/src/components/chatroomSelect/chatroomSelect.tsx
@@ -2,7 +2,6 @@ import { noop } from 'lodash';
 import { EMPTY, GetLogger, IChatRoomListInfo, IChatRoomExtendedInfoResponse, IClientDirectoryNormalResult, RoomId, AssertNotNullable } from 'pandora-common';
 import React, { ReactElement, useCallback, useEffect, useReducer, useState } from 'react';
 import { Link, Navigate, useNavigate } from 'react-router-dom';
-import { useErrorHandler } from '../../common/useErrorHandler';
 import { PersistentToast } from '../../persistentToast';
 import { Button } from '../common/button/button';
 import { useChatRoomInfo } from '../gameContext/chatRoomContextProvider';
@@ -276,7 +275,6 @@ type ChatRoomEnterResult = IClientDirectoryNormalResult['chatRoomEnter']['result
 
 function useJoinRoom(): (id: RoomId, password?: string) => Promise<ChatRoomEnterResult> {
 	const directoryConnector = useDirectoryConnector();
-	const handleError = useErrorHandler();
 
 	return useCallback(async (id, password) => {
 		try {
@@ -292,10 +290,9 @@ function useJoinRoom(): (id: RoomId, password?: string) => Promise<ChatRoomEnter
 			GetLogger('JoinRoom').warning('Error during room join', err);
 			RoomJoinProgress.show('error',
 				`Error during room join:\n${ err instanceof Error ? err.message : String(err) }`);
-			handleError(err);
-			throw err;
+			return 'failed';
 		}
-	}, [directoryConnector, handleError]);
+	}, [directoryConnector]);
 }
 
 function useRoomList(): IChatRoomListInfo[] | undefined {

--- a/pandora-common/src/assets/state/roomState.ts
+++ b/pandora-common/src/assets/state/roomState.ts
@@ -8,9 +8,10 @@ import { Logger } from '../../logging';
 import { ROOM_INVENTORY_BUNDLE_DEFAULT } from '../roomInventory';
 import { RoomInventoryLoadAndValidate, ValidateRoomInventoryItems } from '../roomValidation';
 import type { IExportOptions } from '../modules/common';
+import { ZodArrayWithInvalidDrop } from '../../validation';
 
 export const RoomInventoryBundleSchema = z.object({
-	items: z.array(ItemBundleSchema),
+	items: ZodArrayWithInvalidDrop(ItemBundleSchema, z.record(z.unknown())),
 	clientOnly: z.boolean().optional(),
 });
 

--- a/pandora-common/src/chatroom/room.ts
+++ b/pandora-common/src/chatroom/room.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { ArrayToTruthyMap, ZodTrimedRegex, ZodTemplateString, HexColorStringSchema, HexColorString } from '../validation';
 import { cloneDeep } from 'lodash';
-import { AssetManager } from '../assets';
+import { AssetManager, ROOM_INVENTORY_BUNDLE_DEFAULT } from '../assets';
 import { CharacterId } from '../character';
 import { AccountId, AccountIdSchema } from '../account/account';
 import { RoomInventoryBundleSchema } from '../assets/state/roomState';
@@ -159,7 +159,7 @@ export const ChatRoomDataSchema = z.object({
 	/** Account IDs of accounts owning this room */
 	owners: AccountIdSchema.array(),
 	config: ChatRoomDirectoryConfigSchema,
-	inventory: RoomInventoryBundleSchema,
+	inventory: RoomInventoryBundleSchema.default(() => cloneDeep(ROOM_INVENTORY_BUNDLE_DEFAULT)),
 });
 /** Room data stored in database */
 export type IChatRoomData = z.infer<typeof ChatRoomDataSchema>;

--- a/pandora-common/src/networking/connection.ts
+++ b/pandora-common/src/networking/connection.ts
@@ -119,7 +119,7 @@ export abstract class ConnectionBase<
 					if (MESSAGE_HANDLER_DEBUG_ALL || MESSAGE_HANDLER_DEBUG_MESSAGES.has(messageType)) {
 						this.logger.warning(`\u25BC message '${messageType}' socket error:`, socketError);
 					}
-					return reject(socketError);
+					return reject(socketError instanceof Error ? socketError : new Error(String(socketError)));
 				}
 				if (error != null) {
 					if (MESSAGE_HANDLER_DEBUG_ALL || MESSAGE_HANDLER_DEBUG_MESSAGES.has(messageType)) {
@@ -128,7 +128,7 @@ export abstract class ConnectionBase<
 					if (typeof error !== 'string') {
 						return reject(new Error(`Invalid error type: ${typeof error}`));
 					}
-					return reject(error);
+					return reject(new Error(error));
 				}
 				if (!IsObject(response)) {
 					return reject(new Error(`Invalid response type: ${typeof response}`));


### PR DESCRIPTION
This PR fixes (most) crashes in all three components when there is a room with invalid data being loaded. This brings the flow very close to how characters are currently handled. (with exception of Directory's state management, that will need few more tweaks, but right now errors that happen from race conditions there can be safely ignored as they result in valid state of everyone involved being unloaded and can be safely loaded again)

It also updates room inventory bundle to behave more like character bundle - dropping invalid items, and defaulting to default one if there is none present.

Another small change is in core, where instead of throwing string errors a proper error is thrown to get full stack in case of uncaught exception.