### PR TITLE
[CHANGE] friend list renaming

### DIFF
--- a/pandora-client-web/src/components/Eula/privacyPolicy.tsx
+++ b/pandora-client-web/src/components/Eula/privacyPolicy.tsx
@@ -46,7 +46,7 @@ export function PrivacyPolicyContent(): ReactElement {
 			</p>
 			<ul>
 				<li>
-					Contacts list: We store the Pandora accounts You have added to your contacts and share Your online status in Pandora with them, when You consent to it.
+					Contacts list: We store the Pandora accounts You have added to your Pandora contacts list and share Your online status in Pandora with them, when You consent to it.
 				</li>
 				<li>
 					Direct/Private Messaging: We store the history of the direct messages You exchanged with other Pandora Accounts, but We store this data encrypted and are not able to see the contents of these messages.

--- a/pandora-client-web/src/components/Eula/privacyPolicy.tsx
+++ b/pandora-client-web/src/components/Eula/privacyPolicy.tsx
@@ -46,7 +46,7 @@ export function PrivacyPolicyContent(): ReactElement {
 			</p>
 			<ul>
 				<li>
-					Friendlist: We store the Pandora accounts You have friended and share Your online status in Pandora with them, when You consent to it.
+					Contacts list: We store the Pandora accounts You have added to your contacts and share Your online status in Pandora with them, when You consent to it.
 				</li>
 				<li>
 					Direct/Private Messaging: We store the history of the direct messages You exchanged with other Pandora Accounts, but We store this data encrypted and are not able to see the contents of these messages.

--- a/pandora-client-web/src/components/chatroom/commands.ts
+++ b/pandora-client-web/src/components/chatroom/commands.ts
@@ -150,10 +150,10 @@ export const COMMANDS: readonly IClientCommand[] = [
 			}),
 	},
 	{
-		key: ['addfriend'],
+		key: ['addcontact'],
 		usage: '<target>',
-		description: 'Adds a user to your friends list',
-		longDescription: 'Adds a user to your friends list.',
+		description: 'Adds a user to your contacts list',
+		longDescription: 'Sends the user a request to add the user account to your contacts list.',
 		handler: CreateClientCommand()
 			.argument('target', ACCOUNT_ID_PARSER)
 			.handler(({ directoryConnector }, { target }) => {

--- a/pandora-client-web/src/components/chatroom/contextMenus/characterContextMenu.tsx
+++ b/pandora-client-web/src/components/chatroom/contextMenus/characterContextMenu.tsx
@@ -120,7 +120,7 @@ function FriendRequestMenu({ action, text }: { action: 'initiate' | 'accept' | '
 	const { character } = useCharacterMenuContext();
 
 	const request = useCallback(() => {
-		if (confirm(`Are you sure you want to ${action} a friend request with ${character.data.name}?`)) {
+		if (confirm(`Are you sure you want to ${action} adding the account behind ${character.data.name} to your contacts list?`)) {
 			directory.awaitResponse('friendRequest', { action, id: character.data.accountId })
 				.then(({ result }) => HandleResult(result))
 				.catch((err) => toast(err instanceof Error ? err.message : 'An unknown error occurred', TOAST_OPTIONS_ERROR));
@@ -139,7 +139,7 @@ function UnfriendRequestMenu(): ReactElement {
 	const { character } = useCharacterMenuContext();
 
 	const request = useCallback(() => {
-		if (confirm(`Are you sure you want to unfriend ${character.data.name}?`)) {
+		if (confirm(`Are you sure you want to remove the account behind ${character.data.name} from your contacts list?`)) {
 			directory.awaitResponse('unfriend', { id: character.data.accountId })
 				.then(({ result }) => HandleResult(result))
 				.catch((err) => toast(err instanceof Error ? err.message : 'An unknown error occurred', TOAST_OPTIONS_ERROR));

--- a/pandora-client-web/src/components/chatroom/contextMenus/characterContextMenu.tsx
+++ b/pandora-client-web/src/components/chatroom/contextMenus/characterContextMenu.tsx
@@ -104,7 +104,7 @@ function BlockMenu({ action, text }: { action: 'add' | 'remove'; text: ReactNode
 	const { character } = useCharacterMenuContext();
 
 	const block = useCallback(() => {
-		if (confirm(`Are you sure you want to ${action} ${character.data.name} from your block list?`))
+		if (confirm(`Are you sure you want to ${action} the account behind ${character.data.name} from your block list?`))
 			directory.sendMessage('blockList', { action, id: character.data.accountId });
 	}, [action, character, directory]);
 
@@ -161,7 +161,7 @@ function RelationshipActionContextMenuInner(): ReactElement | null {
 		case undefined:
 			return (
 				<>
-					<FriendRequestMenu action='initiate' text='Add Friend' />
+					<FriendRequestMenu action='initiate' text='Add to contacts' />
 					<BlockMenu action='add' text='Block' />
 				</>
 			);

--- a/pandora-client-web/src/components/header/Header.tsx
+++ b/pandora-client-web/src/components/header/Header.tsx
@@ -143,8 +143,8 @@ function FriendsHeaderButton(): ReactElement {
 	return (
 		<HeaderButton
 			icon={ friendsIcon }
-			iconAlt={ `${ notificationCount } Friends` }
-			title='Friends'
+			iconAlt={ `${ notificationCount } Contacts` }
+			title='Contacts'
 			badge={ notificationCount }
 			onClick={ () => navigate('/relationships') } />
 	);

--- a/pandora-client-web/src/components/releationships/relationships.tsx
+++ b/pandora-client-web/src/components/releationships/relationships.tsx
@@ -200,13 +200,13 @@ function PendingRequestActions({ id }: { id: AccountId; }) {
 function IncomingRequestActions({ id }: { id: AccountId; }) {
 	const directory = useDirectoryConnector();
 	const [accept, acceptInProgress] = useAsyncEvent(async () => {
-		if (confirm(`Accept friend request from ${id}?`)) {
+		if (confirm(`Accept the request to add ${id} to your contacts?`)) {
 			return await directory.awaitResponse('friendRequest', { id, action: 'accept' });
 		}
 		return undefined;
 	}, (r) => HandleResult(r?.result));
 	const [decline, declineInProgress] = useAsyncEvent(async () => {
-		if (confirm(`Decline friend request from ${id}?`)) {
+		if (confirm(`Decline the request to add ${id} to your contacts?`)) {
 			return await directory.awaitResponse('friendRequest', { id, action: 'decline' });
 		}
 		return undefined;
@@ -272,7 +272,7 @@ function FriendRow({
 	const directory = useDirectoryConnector();
 
 	const [unfriend, processing] = useAsyncEvent(async () => {
-		if (confirm(`Are you sure you want to remove ${name} from your friends list?`)) {
+		if (confirm(`Are you sure you want to remove ${name} from your contacts list?`)) {
 			return await directory.awaitResponse('unfriend', { id });
 		}
 		return undefined;

--- a/pandora-client-web/src/components/wiki/pages/intro.tsx
+++ b/pandora-client-web/src/components/wiki/pages/intro.tsx
@@ -92,6 +92,15 @@ export function WikiIntroduction(): ReactElement {
 				resulting in everyone having the same experience.
 			</p>
 
+			<h4>A direct messaging system</h4>
+			<p>
+				To write someone a DM, you have to click the contacts icon at the top and then under the "DMs"-tab,
+				you have to either look for the account name of the user you want to exchange messages with on the left, or
+				you have to search for them via the bottom left input field using their <b>account ID</b>. You can find the account
+				ID either under the "Contacts"-tab or in the "Room"-tab while with a character in the same room. The account ID is
+				the rightmost number behind the character name.
+			</p>
+
 			<h4>No safeword feature, but a safemode that makes it harder to be misused</h4>
 			<p>
 				You can access the safemode feature by clicking on your character name in the top left of the screen and then entering safemode in the menu.


### PR DESCRIPTION
Feedback was that the the mixture of character and account level functionality is confusing, especially the friend list feature as you are not becoming friends with the character you know and you send the friend request to but with an account name you do not know. The question was how your character can become friends with specific characters and if you cannot send DMs per character to support different RPs etc.

To make it clear that this feature is not to be seen as a de facto relationship feature like in a certain other plattform, I discussed with Jomshir to rename the friend list to contacts list to make it more neutral and OOC, which will hopefully make it clear that you will be able to become friends or any other type of relationship with a character later with a future feature.

I hope I was able to find all spots where the user sees the word "friend".