### PR TITLE
[REFACTOR] enum for legs pose

### DIFF
--- a/pandora-client-web/src/components/chatroom/chatRoomCharacter.tsx
+++ b/pandora-client-web/src/components/chatroom/chatRoomCharacter.tsx
@@ -1,4 +1,4 @@
-import { AssetFrameworkCharacterState, CalculateCharacterMaxYForBackground, CharacterSize, ICharacterRoomData, IChatroomBackgroundData, IChatRoomFullInfo } from 'pandora-common';
+import { AssetFrameworkCharacterState, CalculateCharacterMaxYForBackground, CharacterSize, ICharacterRoomData, IChatroomBackgroundData, IChatRoomFullInfo, LegsPose } from 'pandora-common';
 import PIXI, { DEG_TO_RAD, FederatedPointerEvent, Point, Rectangle, TextStyle } from 'pixi.js';
 import React, { ReactElement, useCallback, useEffect, useMemo, useRef } from 'react';
 import { Character, useCharacterAppearanceView, useCharacterData } from '../../character/character';
@@ -46,21 +46,17 @@ export function useChatRoomCharacterOffsets(characterState: AssetFrameworkCharac
 	const evaluator = useAppearanceConditionEvaluator(characterState);
 
 	let baseScale = 1;
-	if (evaluator.getBoneLikeValue('sitting') > 0) {
+	if (evaluator.legs === 'sitting') {
 		baseScale *= 0.9;
 	}
 
-	const legPose = evaluator.getBoneLikeValue('kneeling') !== 0 ? 'kneeling' :
-	evaluator.getBoneLikeValue('sitting') !== 0 ? 'sitting' :
-	'normal';
-
-	const legEffectMap: Record<typeof legPose, number> = {
-		normal: 600,
+	const legEffectMap: Record<LegsPose, number> = {
+		standing: 600,
 		sitting: 0,
 		kneeling: 300,
 	};
-	const legEffectCharacterOffsetBase = legPose === 'sitting' ? 135 : legEffectMap.normal;
-	const legEffect = legEffectMap[legPose]
+	const legEffectCharacterOffsetBase = evaluator.legs === 'sitting' ? 135 : legEffectMap.standing;
+	const legEffect = legEffectMap[evaluator.legs]
 		+ (evaluator.getBoneLikeValue('kneeling') === 0 ? 0.2 : 0) * evaluator.getBoneLikeValue('tiptoeing');
 
 	const effectiveLegAngle = Math.min(Math.abs(evaluator.getBoneLikeValue('leg_l')), Math.abs(evaluator.getBoneLikeValue('leg_r')), 90);

--- a/pandora-client-web/src/components/chatroom/chatRoomCharacter.tsx
+++ b/pandora-client-web/src/components/chatroom/chatRoomCharacter.tsx
@@ -57,7 +57,7 @@ export function useChatRoomCharacterOffsets(characterState: AssetFrameworkCharac
 	};
 	const legEffectCharacterOffsetBase = evaluator.legs === 'sitting' ? 135 : legEffectMap.standing;
 	const legEffect = legEffectMap[evaluator.legs]
-		+ (evaluator.getBoneLikeValue('kneeling') === 0 ? 0.2 : 0) * evaluator.getBoneLikeValue('tiptoeing');
+		+ (evaluator.legs !== 'kneeling' ? 0.2 : 0) * evaluator.getBoneLikeValue('tiptoeing');
 
 	const effectiveLegAngle = Math.min(Math.abs(evaluator.getBoneLikeValue('leg_l')), Math.abs(evaluator.getBoneLikeValue('leg_r')), 90);
 

--- a/pandora-client-web/src/components/wardrobe/views/wardrobePoseView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobePoseView.tsx
@@ -13,6 +13,8 @@ import {
 	BoneState,
 	CharacterAppearance,
 	CharacterArmsPose,
+	LegsPose,
+	LegsPoseSchema,
 	MergePartialAppearancePoses,
 	PartialAppearancePose,
 } from 'pandora-common';
@@ -240,6 +242,36 @@ export function WardrobeArmPoses({ setPose, armsPose, limits }: {
 	);
 }
 
+export function WardrobeLegsPose({ setPose, legs, limits }: {
+	limits?: AppearanceLimitTree;
+	legs: LegsPose;
+	setPose: (_: Omit<AssetsPosePreset, 'name'>) => void;
+}) {
+	return (
+		<div>
+			<label htmlFor='pose-legs'>Legs pose</label>
+			<Select value={ legs } id='pose-legs' onChange={ (e) => {
+				setPose({
+					legs: LegsPoseSchema.parse(e.target.value),
+				});
+			} }>
+				{
+					LegsPoseSchema.options
+						.map((r) => (
+							<option
+								key={ r }
+								value={ r }
+								disabled={ limits != null && !limits.validate({ legs: r }) }
+							>
+								{ _.capitalize(r) }
+							</option>
+						))
+				}
+			</Select>
+		</div>
+	);
+}
+
 export function WardrobePoseGui({ character, characterState }: {
 	character: AppearanceContainer;
 	characterState: AssetFrameworkCharacterState;
@@ -288,6 +320,7 @@ export function WardrobePoseGui({ character, characterState }: {
 				<WardrobePoseCategoriesInternal poses={ poses } setPose={ setPose } />
 				<FieldsetToggle legend='Manual pose' persistent='bone-ui-dev-pose'>
 					<WardrobeArmPoses armsPose={ armsPose } limits={ limits } setPose={ setPose } />
+					<WardrobeLegsPose legs={ characterState.legs } limits={ limits } setPose={ setPose } />
 					<br />
 					{
 						currentBones

--- a/pandora-client-web/src/components/wardrobe/views/wardrobePoseView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobePoseView.tsx
@@ -9,9 +9,7 @@ import {
 	AssetsPosePreset,
 	BONE_MAX,
 	BONE_MIN,
-	BoneName,
 	BoneState,
-	CharacterAppearance,
 	CharacterArmsPose,
 	LegsPose,
 	LegsPoseSchema,
@@ -19,7 +17,6 @@ import {
 	PartialAppearancePose,
 } from 'pandora-common';
 import React, { ReactElement, useCallback, useId, useMemo } from 'react';
-import { AssetManagerClient, useAssetManager } from '../../../assets/assetManager';
 import { AppearanceContainer, useCharacterAppearanceArmsPose, useCharacterAppearancePose, useCharacterAppearanceView } from '../../../character/character';
 import { FieldsetToggle } from '../../common/fieldsetToggle';
 import { Button } from '../../common/button/button';
@@ -39,12 +36,14 @@ type CheckedAssetsPosePresets = {
 	poses: CheckedPosePreset[];
 }[];
 
-function GetFilteredAssetsPosePresets(items: AppearanceItems, roomItems: AppearanceItems, bonesStates: readonly BoneState[], { leftArm, rightArm }: CharacterArmsPose, assetManager: AssetManagerClient): {
+function GetFilteredAssetsPosePresets(characterState: AssetFrameworkCharacterState, roomItems: AppearanceItems): {
 	poses: CheckedAssetsPosePresets;
 	limits: AppearanceLimitTree;
 } {
+	const { leftArm, rightArm } = characterState.arms;
+	const assetManager = characterState.assetManager;
 	const presets = assetManager.getPosePresets();
-	for (const item of items) {
+	for (const item of characterState.items) {
 		if (!item.isType('roomDeviceWearablePart') || item.roomDeviceLink == null)
 			continue;
 
@@ -65,10 +64,12 @@ function GetFilteredAssetsPosePresets(items: AppearanceItems, roomItems: Appeara
 		});
 	}
 
-	const limits = AppearanceItemProperties(items).limits;
-	const bones = new Map<BoneName, number>(bonesStates.map((bone) => [bone.definition.name, bone.rotation]));
+	const limits = AppearanceItemProperties(characterState.items).limits;
 
 	const isActive = (preset: PartialAppearancePose) => {
+		if (preset.legs != null && preset.legs !== characterState.legs)
+			return false;
+
 		const left = { ...preset.arms, ...preset.leftArm };
 		const right = { ...preset.arms, ...preset.rightArm };
 		for (const name of ['position', 'rotation', 'fingers'] as const) {
@@ -82,7 +83,7 @@ function GetFilteredAssetsPosePresets(items: AppearanceItems, roomItems: Appeara
 			if (value === undefined)
 				continue;
 
-			if (bones.get(boneName) !== value)
+			if (characterState.pose.get(boneName)?.rotation !== value)
 				return false;
 		}
 
@@ -125,10 +126,9 @@ function WardrobePoseCategoriesInternal({ poses, setPose }: { poses: CheckedAsse
 	);
 }
 
-export function WardrobePoseCategories({ appearance, bones, armsPose, setPose }: { appearance: CharacterAppearance; bones: readonly BoneState[]; armsPose: CharacterArmsPose; setPose: (pose: PartialAppearancePose) => void; }): ReactElement {
-	const assetManager = useAssetManager();
+export function WardrobePoseCategories({ characterState, setPose }: { characterState: AssetFrameworkCharacterState; setPose: (pose: PartialAppearancePose) => void; }): ReactElement {
 	const roomItems = useWardrobeContext().globalState.getItems({ type: 'roomInventory' });
-	const { poses } = useMemo(() => GetFilteredAssetsPosePresets(appearance.getAllItems(), roomItems ?? [], bones, armsPose, assetManager), [appearance, bones, armsPose, assetManager, roomItems]);
+	const { poses } = useMemo(() => GetFilteredAssetsPosePresets(characterState, roomItems ?? []), [characterState, roomItems]);
 	return (
 		<WardrobePoseCategoriesInternal poses={ poses } setPose={ setPose } />
 	);
@@ -276,7 +276,6 @@ export function WardrobePoseGui({ character, characterState }: {
 	character: AppearanceContainer;
 	characterState: AssetFrameworkCharacterState;
 }): ReactElement {
-	const assetManager = useAssetManager();
 	const [execute, processing] = useWardrobeExecuteCallback();
 	const roomItems = useWardrobeContext().globalState.getItems({ type: 'roomInventory' });
 
@@ -284,17 +283,18 @@ export function WardrobePoseGui({ character, characterState }: {
 	const armsPose = useCharacterAppearanceArmsPose(characterState);
 	const view = useCharacterAppearanceView(characterState);
 
-	const setPoseDirect = useEvent(({ bones, arms, leftArm, rightArm }: PartialAppearancePose) => {
+	const setPoseDirect = useEvent(({ bones, arms, leftArm, rightArm, legs }: PartialAppearancePose) => {
 		execute({
 			type: 'pose',
 			target: character.id,
 			bones,
 			leftArm: { ...arms, ...leftArm },
 			rightArm: { ...arms, ...rightArm },
+			legs,
 		});
 	});
 
-	const { poses, limits } = useMemo(() => GetFilteredAssetsPosePresets(characterState.items, roomItems ?? [], currentBones, armsPose, assetManager), [characterState, currentBones, armsPose, assetManager, roomItems]);
+	const { poses, limits } = useMemo(() => GetFilteredAssetsPosePresets(characterState, roomItems ?? []), [characterState, roomItems]);
 
 	const setPose = useMemo(() => _.throttle(setPoseDirect, 100), [setPoseDirect]);
 

--- a/pandora-client-web/src/editor/components/bones/bones.tsx
+++ b/pandora-client-web/src/editor/components/bones/bones.tsx
@@ -52,7 +52,7 @@ export function BoneUI(): ReactElement {
 				/>
 			</div>
 			<FieldsetToggle legend='Pose presets' persistent={ 'bone-ui-poses' } className='slim-padding' open={ false }>
-				<WardrobePoseCategories appearance={ character.getAppearance() } bones={ bones } armsPose={ characterState.arms } setPose={ setPose } />
+				<WardrobePoseCategories characterState={ characterState } setPose={ setPose } />
 			</FieldsetToggle>
 			<FieldsetToggle legend='Expressions' persistent={ 'expressions' } className='no-padding' open={ false }>
 				<WardrobeExpressionGui character={ character } characterState={ characterState } />

--- a/pandora-client-web/src/editor/components/layer/layer.tsx
+++ b/pandora-client-web/src/editor/components/layer/layer.tsx
@@ -10,7 +10,6 @@ import { Button } from '../../../components/common/button/button';
 import { Select } from '../../../components/common/select/select';
 import { Scrollbar } from '../../../components/common/scrollbar/scrollbar';
 import { ContextHelpButton } from '../../../components/help/contextHelpButton';
-import { FAKE_BONES } from '../../../graphics/appearanceConditionEvaluator';
 import { StripAssetIdPrefix } from '../../../graphics/utility';
 import { useObservable } from '../../../observable';
 import { useEditor } from '../../editorContextProvider';
@@ -598,7 +597,7 @@ function LayerImageOverridesTextarea({ layer, stop, asAlpha = false }: { layer: 
 	const onChange = useEvent((e: React.ChangeEvent<HTMLTextAreaElement>) => {
 		setValue(e.target.value);
 		try {
-			const result = ParseLayerImageOverrides(e.target.value, assetManager.getAllBones().map((b) => b.name).concat(FAKE_BONES));
+			const result = ParseLayerImageOverrides(e.target.value, assetManager.getAllBones().map((b) => b.name));
 			setError(null);
 			if (asAlpha) {
 				layer.setAlphaOverrides(result, stop);

--- a/pandora-client-web/src/editor/parsing.ts
+++ b/pandora-client-web/src/editor/parsing.ts
@@ -1,5 +1,5 @@
 import { Immutable } from 'immer';
-import { AppearanceLegPoseSchema, ArmFingersSchema, ArmRotationSchema, Assert, AssertNever, AtomicCondition, Condition, ConditionOperatorSchema, LayerImageOverride, TransformDefinition, ZodMatcher } from 'pandora-common';
+import { LegsPoseSchema, ArmFingersSchema, ArmRotationSchema, Assert, AssertNever, AtomicCondition, Condition, ConditionOperatorSchema, LayerImageOverride, TransformDefinition, ZodMatcher } from 'pandora-common';
 
 const IsConditionOperator = ZodMatcher(ConditionOperatorSchema);
 
@@ -59,7 +59,7 @@ function ParseAtomicCondition(input: string, validBones: string[]): AtomicCondit
 		if (!legs) {
 			throw new Error(`Failed to parse legs condition '${input}'`);
 		}
-		if (!ZodMatcher(AppearanceLegPoseSchema)(legs[1])) {
+		if (!ZodMatcher(LegsPoseSchema)(legs[1])) {
 			throw new Error(`Invalid legs pose '${legs[1]}'`);
 		}
 		return {

--- a/pandora-client-web/src/editor/parsing.ts
+++ b/pandora-client-web/src/editor/parsing.ts
@@ -1,5 +1,5 @@
 import { Immutable } from 'immer';
-import { ArmFingersSchema, ArmRotationSchema, Assert, AssertNever, AtomicCondition, Condition, ConditionOperatorSchema, LayerImageOverride, TransformDefinition, ZodMatcher } from 'pandora-common';
+import { AppearanceLegPoseSchema, ArmFingersSchema, ArmRotationSchema, Assert, AssertNever, AtomicCondition, Condition, ConditionOperatorSchema, LayerImageOverride, TransformDefinition, ZodMatcher } from 'pandora-common';
 
 const IsConditionOperator = ZodMatcher(ConditionOperatorSchema);
 
@@ -36,6 +36,9 @@ export function SerializeAtomicCondition(condition: Immutable<AtomicCondition>):
 	} else if ('attribute' in condition) {
 		Assert(condition.attribute != null);
 		return `a_${condition.attribute}`;
+	} else if ('legs' in condition) {
+		Assert(condition.legs != null);
+		return `legs_${condition.legs}`;
 	} else {
 		AssertNever(condition);
 	}
@@ -49,6 +52,18 @@ function ParseAtomicCondition(input: string, validBones: string[]): AtomicCondit
 		}
 		return {
 			attribute: attribute[1],
+		};
+	}
+	if (input.startsWith('legs_')) {
+		const legs = /^legs_([-_a-z0-9]+)$/i.exec(input);
+		if (!legs) {
+			throw new Error(`Failed to parse legs condition '${input}'`);
+		}
+		if (!ZodMatcher(AppearanceLegPoseSchema)(legs[1])) {
+			throw new Error(`Invalid legs pose '${legs[1]}'`);
+		}
+		return {
+			legs: legs[1],
 		};
 	}
 	const parsed = /^([-_a-z0-9]+)([=<>!]+)\s*(-?[-_a-z0-9.]+)$/i.exec(input);

--- a/pandora-client-web/src/editor/parsing.ts
+++ b/pandora-client-web/src/editor/parsing.ts
@@ -1,5 +1,5 @@
 import { Immutable } from 'immer';
-import { LegsPoseSchema, ArmFingersSchema, ArmRotationSchema, Assert, AssertNever, AtomicCondition, Condition, ConditionOperatorSchema, LayerImageOverride, TransformDefinition, ZodMatcher } from 'pandora-common';
+import { ArmFingersSchema, ArmRotationSchema, Assert, AssertNever, AtomicCondition, Condition, ConditionOperatorSchema, LayerImageOverride, TransformDefinition, ZodMatcher, AtomicConditionLegsSchema } from 'pandora-common';
 
 const IsConditionOperator = ZodMatcher(ConditionOperatorSchema);
 
@@ -55,11 +55,11 @@ function ParseAtomicCondition(input: string, validBones: string[]): AtomicCondit
 		};
 	}
 	if (input.startsWith('legs_')) {
-		const legs = /^legs_([-_a-z0-9]+)$/i.exec(input);
+		const legs = /^legs_(!?[-_a-z0-9]+)$/i.exec(input);
 		if (!legs) {
 			throw new Error(`Failed to parse legs condition '${input}'`);
 		}
-		if (!ZodMatcher(LegsPoseSchema)(legs[1])) {
+		if (!ZodMatcher(AtomicConditionLegsSchema.shape.legs)(legs[1])) {
 			throw new Error(`Invalid legs pose '${legs[1]}'`);
 		}
 		return {

--- a/pandora-client-web/src/editor/parsing.ts
+++ b/pandora-client-web/src/editor/parsing.ts
@@ -1,5 +1,5 @@
 import { Immutable } from 'immer';
-import { ArmFingersSchema, ArmRotationSchema, Assert, AssertNever, AtomicCondition, Condition, ConditionOperatorSchema, LayerImageOverride, TransformDefinition, ZodMatcher, AtomicConditionLegsSchema } from 'pandora-common';
+import { ArmFingersSchema, ArmRotationSchema, Assert, AssertNever, AtomicCondition, Condition, ConditionOperatorSchema, LayerImageOverride, TransformDefinition, ZodMatcher, AtomicConditionLegsSchema, CharacterViewSchema } from 'pandora-common';
 
 const IsConditionOperator = ZodMatcher(ConditionOperatorSchema);
 
@@ -39,6 +39,9 @@ export function SerializeAtomicCondition(condition: Immutable<AtomicCondition>):
 	} else if ('legs' in condition) {
 		Assert(condition.legs != null);
 		return `legs_${condition.legs}`;
+	} else if ('view' in condition) {
+		Assert(condition.view != null);
+		return `view_${condition.view}`;
 	} else {
 		AssertNever(condition);
 	}
@@ -64,6 +67,18 @@ function ParseAtomicCondition(input: string, validBones: string[]): AtomicCondit
 		}
 		return {
 			legs: legs[1],
+		};
+	}
+	if (input.startsWith('view_')) {
+		const view = /^view_([-_a-z0-9]+)$/i.exec(input);
+		if (!view) {
+			throw new Error(`Failed to parse view condition '${input}'`);
+		}
+		if (!ZodMatcher(CharacterViewSchema)(view[1])) {
+			throw new Error(`Invalid view '${view[1]}'`);
+		}
+		return {
+			view: view[1],
 		};
 	}
 	const parsed = /^([-_a-z0-9]+)([=<>!]+)\s*(-?[-_a-z0-9.]+)$/i.exec(input);

--- a/pandora-client-web/src/graphics/appearanceConditionEvaluator.ts
+++ b/pandora-client-web/src/graphics/appearanceConditionEvaluator.ts
@@ -67,6 +67,9 @@ export class AppearanceConditionEvaluator {
 				return this.legs !== condition.legs.slice(1);
 			}
 			return this.legs === condition.legs;
+		} else if ('view' in condition) {
+			Assert(condition.view != null);
+			return this.view === condition.view;
 		} else {
 			AssertNever(condition);
 		}

--- a/pandora-client-web/src/graphics/appearanceConditionEvaluator.ts
+++ b/pandora-client-web/src/graphics/appearanceConditionEvaluator.ts
@@ -1,4 +1,4 @@
-import { AppearanceItemProperties, LegsPose, Assert, AssertNever, AssetFrameworkCharacterState, AssetManager, AtomicCondition, BoneName, BoneState, CharacterArmsPose, CharacterView, ConditionOperator, Item, TransformDefinition } from 'pandora-common';
+import { AppearanceItemProperties, LegsPose, Assert, AssertNever, AssetFrameworkCharacterState, AtomicCondition, BoneName, BoneState, CharacterArmsPose, CharacterView, ConditionOperator, Item, TransformDefinition } from 'pandora-common';
 import { useMemo } from 'react';
 import { EvaluateCondition, RotateVector } from './utility';
 import type { Immutable } from 'immer';
@@ -15,9 +15,6 @@ export class AppearanceConditionEvaluator {
 		for (const bone of character.pose.values()) {
 			poseResult.set(bone.definition.name, bone);
 		}
-		poseResult.set('kneeling', this.createLegsBoneState(character.assetManager, 'kneeling', character.legs));
-		poseResult.set('sitting', this.createLegsBoneState(character.assetManager, 'sitting', character.legs));
-		poseResult.set('backView', { definition: character.assetManager.getBoneByName('backView'), rotation: character.view === 'back' ? 1 : 0 });
 		this.pose = poseResult;
 		this.view = character.view;
 		this.arms = character.arms;
@@ -149,13 +146,6 @@ export class AppearanceConditionEvaluator {
 
 	public getBoneLikeValue(name: string): number {
 		return this.getBone(name).rotation;
-	}
-
-	public createLegsBoneState(assetManager: AssetManager, name: Omit<LegsPose, 'standing'> & string, legs: LegsPose): BoneState {
-		return {
-			definition: assetManager.getBoneByName(name),
-			rotation: legs === name ? 180 : 0,
-		};
 	}
 }
 

--- a/pandora-client-web/src/graphics/appearanceConditionEvaluator.ts
+++ b/pandora-client-web/src/graphics/appearanceConditionEvaluator.ts
@@ -14,6 +14,8 @@ export class AppearanceConditionEvaluator {
 		for (const bone of character.pose.values()) {
 			poseResult.set(bone.definition.name, bone);
 		}
+		poseResult.set('kneeling', this.createLegsBoneState(character.assetManager, 'kneeling', character.legs));
+		poseResult.set('sitting', this.createLegsBoneState(character.assetManager, 'sitting', character.legs));
 		poseResult.set('backView', { definition: character.assetManager.getBoneByName('backView'), rotation: character.view === 'back' ? 1 : 0 });
 		this.pose = poseResult;
 		this.view = character.view;
@@ -136,6 +138,13 @@ export class AppearanceConditionEvaluator {
 
 	public getBoneLikeValue(name: string): number {
 		return this.getBone(name).rotation;
+	}
+
+	public createLegsBoneState(assetManager: AssetManager, name: Omit<AppearanceLegPose, 'standing'> & string, legs: AppearanceLegPose): BoneState {
+		return {
+			definition: assetManager.getBoneByName(name),
+			rotation: legs === name ? 180 : 0,
+		};
 	}
 }
 

--- a/pandora-client-web/src/graphics/appearanceConditionEvaluator.ts
+++ b/pandora-client-web/src/graphics/appearanceConditionEvaluator.ts
@@ -102,6 +102,9 @@ export class AppearanceConditionEvaluator {
 		let [resX, resY] = [x, y];
 		for (const transform of transforms) {
 			const { type, condition } = transform;
+			if (valueOverrides != null && (type === 'const-shift' || type === 'const-rotate')) {
+				continue;
+			}
 			if (condition && !EvaluateCondition(condition, (c) => this.evalCondition(c, item))) {
 				continue;
 			}

--- a/pandora-client-web/src/graphics/appearanceConditionEvaluator.ts
+++ b/pandora-client-web/src/graphics/appearanceConditionEvaluator.ts
@@ -4,8 +4,6 @@ import { useCharacterAppearanceArmsPose, useCharacterAppearancePose, useCharacte
 import { EvaluateCondition, RotateVector } from './utility';
 import type { Immutable } from 'immer';
 
-export const FAKE_BONES: string[] = ['backView'];
-
 export class AppearanceConditionEvaluator {
 	public readonly pose: ReadonlyMap<BoneName, Readonly<BoneState>>;
 	public readonly view: CharacterView;
@@ -17,6 +15,7 @@ export class AppearanceConditionEvaluator {
 		for (const bone of pose) {
 			poseResult.set(bone.definition.name, bone);
 		}
+		poseResult.set('backView', { definition: character.assetManager.getBoneByName('backView'), rotation: view === 'back' ? 1 : 0 });
 		this.pose = poseResult;
 		this.view = view;
 		this.arms = arms;
@@ -129,7 +128,7 @@ export class AppearanceConditionEvaluator {
 	}
 	//#endregion
 
-	public getBone(bone: string): BoneState {
+	private getBone(bone: string): Readonly<BoneState> {
 		const state = this.pose.get(bone);
 		if (!state)
 			throw new Error(`Attempt to get pose for unknown bone: ${bone}`);
@@ -137,9 +136,6 @@ export class AppearanceConditionEvaluator {
 	}
 
 	public getBoneLikeValue(name: string): number {
-		if (name === 'backView') {
-			return this.view === 'back' ? 1 : 0;
-		}
 		return this.getBone(name).rotation;
 	}
 }

--- a/pandora-client-web/src/graphics/appearanceConditionEvaluator.ts
+++ b/pandora-client-web/src/graphics/appearanceConditionEvaluator.ts
@@ -63,6 +63,9 @@ export class AppearanceConditionEvaluator {
 			}
 		} else if ('legs' in condition) {
 			Assert(condition.legs != null);
+			if (condition.legs.startsWith('!')) {
+				return this.legs !== condition.legs.slice(1);
+			}
 			return this.legs === condition.legs;
 		} else {
 			AssertNever(condition);

--- a/pandora-client-web/src/graphics/appearanceConditionEvaluator.ts
+++ b/pandora-client-web/src/graphics/appearanceConditionEvaluator.ts
@@ -1,4 +1,4 @@
-import { AppearanceItemProperties, Assert, AssertNever, AssetFrameworkCharacterState, AssetManager, AtomicCondition, BoneName, BoneState, CharacterArmsPose, CharacterView, ConditionOperator, Item, TransformDefinition } from 'pandora-common';
+import { AppearanceItemProperties, AppearanceLegPose, Assert, AssertNever, AssetFrameworkCharacterState, AssetManager, AtomicCondition, BoneName, BoneState, CharacterArmsPose, CharacterView, ConditionOperator, Item, TransformDefinition } from 'pandora-common';
 import { useMemo } from 'react';
 import { EvaluateCondition, RotateVector } from './utility';
 import type { Immutable } from 'immer';
@@ -7,6 +7,7 @@ export class AppearanceConditionEvaluator {
 	public readonly pose: ReadonlyMap<BoneName, Readonly<BoneState>>;
 	public readonly view: CharacterView;
 	public readonly arms: CharacterArmsPose;
+	public readonly legs: AppearanceLegPose;
 	public readonly attributes: ReadonlySet<string>;
 
 	constructor(character: AssetFrameworkCharacterState) {
@@ -20,6 +21,7 @@ export class AppearanceConditionEvaluator {
 		this.pose = poseResult;
 		this.view = character.view;
 		this.arms = character.arms;
+		this.legs = character.legs;
 		this.attributes = AppearanceItemProperties(character.items).attributes;
 	}
 
@@ -59,6 +61,9 @@ export class AppearanceConditionEvaluator {
 			} else {
 				return this.attributes.has(condition.attribute);
 			}
+		} else if ('legs' in condition) {
+			Assert(condition.legs != null);
+			return this.legs === condition.legs;
 		} else {
 			AssertNever(condition);
 		}

--- a/pandora-client-web/src/graphics/appearanceConditionEvaluator.ts
+++ b/pandora-client-web/src/graphics/appearanceConditionEvaluator.ts
@@ -1,4 +1,4 @@
-import { AppearanceItemProperties, AppearanceLegPose, Assert, AssertNever, AssetFrameworkCharacterState, AssetManager, AtomicCondition, BoneName, BoneState, CharacterArmsPose, CharacterView, ConditionOperator, Item, TransformDefinition } from 'pandora-common';
+import { AppearanceItemProperties, LegsPose, Assert, AssertNever, AssetFrameworkCharacterState, AssetManager, AtomicCondition, BoneName, BoneState, CharacterArmsPose, CharacterView, ConditionOperator, Item, TransformDefinition } from 'pandora-common';
 import { useMemo } from 'react';
 import { EvaluateCondition, RotateVector } from './utility';
 import type { Immutable } from 'immer';
@@ -7,7 +7,7 @@ export class AppearanceConditionEvaluator {
 	public readonly pose: ReadonlyMap<BoneName, Readonly<BoneState>>;
 	public readonly view: CharacterView;
 	public readonly arms: CharacterArmsPose;
-	public readonly legs: AppearanceLegPose;
+	public readonly legs: LegsPose;
 	public readonly attributes: ReadonlySet<string>;
 
 	constructor(character: AssetFrameworkCharacterState) {
@@ -145,7 +145,7 @@ export class AppearanceConditionEvaluator {
 		return this.getBone(name).rotation;
 	}
 
-	public createLegsBoneState(assetManager: AssetManager, name: Omit<AppearanceLegPose, 'standing'> & string, legs: AppearanceLegPose): BoneState {
+	public createLegsBoneState(assetManager: AssetManager, name: Omit<LegsPose, 'standing'> & string, legs: LegsPose): BoneState {
 		return {
 			definition: assetManager.getBoneByName(name),
 			rotation: legs === name ? 180 : 0,

--- a/pandora-client-web/src/graphics/mirroring.ts
+++ b/pandora-client-web/src/graphics/mirroring.ts
@@ -43,6 +43,11 @@ export function MirrorCondition(condition: Immutable<Condition> | undefined): Co
 			return {
 				...c,
 			};
+		} else if ('view' in c) {
+			Assert(c.view != null);
+			return {
+				...c,
+			};
 		} else {
 			AssertNever(c);
 		}

--- a/pandora-client-web/src/graphics/mirroring.ts
+++ b/pandora-client-web/src/graphics/mirroring.ts
@@ -38,6 +38,11 @@ export function MirrorCondition(condition: Immutable<Condition> | undefined): Co
 			return {
 				...c,
 			};
+		} else if ('legs' in c) {
+			Assert(c.legs != null);
+			return {
+				...c,
+			};
 		} else {
 			AssertNever(c);
 		}

--- a/pandora-common/src/assets/appearance.ts
+++ b/pandora-common/src/assets/appearance.ts
@@ -7,9 +7,9 @@ import type { ItemPath, RoomActionTargetCharacter } from './appearanceTypes';
 import { AppearanceItems } from './appearanceValidation';
 import { AssetManager } from './assetManager';
 import { AssetId, WearableAssetType } from './definitions';
-import { BoneState } from './graphics';
+import type { BoneState, CharacterView } from './graphics';
 import { Item } from './item';
-import { AppearanceArmPose, AppearanceBundle, AppearancePose, AssetFrameworkCharacterState, CharacterView, SafemodeData } from './state/characterState';
+import { AppearanceArmPose, AppearanceBundle, AppearancePose, AssetFrameworkCharacterState, SafemodeData } from './state/characterState';
 
 export const BONE_MIN = -180;
 export const BONE_MAX = 180;

--- a/pandora-common/src/assets/appearance.ts
+++ b/pandora-common/src/assets/appearance.ts
@@ -31,6 +31,7 @@ export function GetDefaultAppearanceBundle(): AppearanceBundle {
 		bones: {},
 		leftArm: GetDefaultAppearanceArmPose(),
 		rightArm: GetDefaultAppearanceArmPose(),
+		legs: 'standing',
 		view: 'front',
 	};
 }

--- a/pandora-common/src/assets/appearanceActions.ts
+++ b/pandora-common/src/assets/appearanceActions.ts
@@ -19,6 +19,9 @@ import { AssetFrameworkGlobalStateContainer } from './state/globalState';
 import { AssetFrameworkGlobalStateManipulator } from './manipulators/globalStateManipulator';
 import { CharacterViewSchema, LegsPoseSchema } from './graphics/graphics';
 
+// Fix for pnpm resolution weirdness
+import type { } from "../validation";
+
 export const AppearanceActionCreateSchema = z.object({
 	type: z.literal('create'),
 	/** ID to give the new item */

--- a/pandora-common/src/assets/appearanceActions.ts
+++ b/pandora-common/src/assets/appearanceActions.ts
@@ -14,10 +14,10 @@ import { isEqual, sample } from 'lodash';
 import { nanoid } from 'nanoid';
 import { Asset, FilterAssetType } from './asset';
 import { CreateAssetPropertiesResult, MergeAssetProperties } from './properties';
-import { AppearanceArmPoseSchema, AppearancePoseSchema, CharacterViewSchema } from './state/characterState';
+import { AppearanceArmPoseSchema, AppearancePoseSchema } from './state/characterState';
 import { AssetFrameworkGlobalStateContainer } from './state/globalState';
 import { AssetFrameworkGlobalStateManipulator } from './manipulators/globalStateManipulator';
-import { LegsPoseSchema } from './graphics/graphics';
+import { CharacterViewSchema, LegsPoseSchema } from './graphics/graphics';
 
 export const AppearanceActionCreateSchema = z.object({
 	type: z.literal('create'),

--- a/pandora-common/src/assets/appearanceActions.ts
+++ b/pandora-common/src/assets/appearanceActions.ts
@@ -14,7 +14,7 @@ import { isEqual, sample } from 'lodash';
 import { nanoid } from 'nanoid';
 import { Asset, FilterAssetType } from './asset';
 import { CreateAssetPropertiesResult, MergeAssetProperties } from './properties';
-import { AppearanceArmPoseSchema, AppearancePoseSchema, CharacterViewSchema } from './state/characterState';
+import { AppearanceArmPoseSchema, AppearanceLegPoseSchema, AppearancePoseSchema, CharacterViewSchema } from './state/characterState';
 import { AssetFrameworkGlobalStateContainer } from './state/globalState';
 import { AssetFrameworkGlobalStateManipulator } from './manipulators/globalStateManipulator';
 
@@ -61,6 +61,7 @@ export const AppearanceActionPose = z.object({
 	bones: AppearancePoseSchema.shape.bones.optional(),
 	leftArm: AppearanceArmPoseSchema.partial().optional(),
 	rightArm: AppearanceArmPoseSchema.partial().optional(),
+	legs: AppearanceLegPoseSchema.optional(),
 });
 
 export const AppearanceActionBody = z.object({

--- a/pandora-common/src/assets/appearanceActions.ts
+++ b/pandora-common/src/assets/appearanceActions.ts
@@ -20,7 +20,7 @@ import { AssetFrameworkGlobalStateManipulator } from './manipulators/globalState
 import { CharacterViewSchema, LegsPoseSchema } from './graphics/graphics';
 
 // Fix for pnpm resolution weirdness
-import type { } from "../validation";
+import type { } from '../validation';
 
 export const AppearanceActionCreateSchema = z.object({
 	type: z.literal('create'),

--- a/pandora-common/src/assets/appearanceActions.ts
+++ b/pandora-common/src/assets/appearanceActions.ts
@@ -14,9 +14,10 @@ import { isEqual, sample } from 'lodash';
 import { nanoid } from 'nanoid';
 import { Asset, FilterAssetType } from './asset';
 import { CreateAssetPropertiesResult, MergeAssetProperties } from './properties';
-import { AppearanceArmPoseSchema, AppearanceLegPoseSchema, AppearancePoseSchema, CharacterViewSchema } from './state/characterState';
+import { AppearanceArmPoseSchema, AppearancePoseSchema, CharacterViewSchema } from './state/characterState';
 import { AssetFrameworkGlobalStateContainer } from './state/globalState';
 import { AssetFrameworkGlobalStateManipulator } from './manipulators/globalStateManipulator';
+import { LegsPoseSchema } from './graphics/graphics';
 
 export const AppearanceActionCreateSchema = z.object({
 	type: z.literal('create'),
@@ -61,7 +62,7 @@ export const AppearanceActionPose = z.object({
 	bones: AppearancePoseSchema.shape.bones.optional(),
 	leftArm: AppearanceArmPoseSchema.partial().optional(),
 	rightArm: AppearanceArmPoseSchema.partial().optional(),
-	legs: AppearanceLegPoseSchema.optional(),
+	legs: LegsPoseSchema.optional(),
 });
 
 export const AppearanceActionBody = z.object({

--- a/pandora-common/src/assets/appearanceLimit.ts
+++ b/pandora-common/src/assets/appearanceLimit.ts
@@ -4,8 +4,8 @@ import { ZodEnum } from 'zod';
 import { CloneDeepMutable, IntervalSetIntersection } from '../utility';
 import { GetDefaultAppearanceBundle } from './appearance';
 import type { AssetDefinitionPoseLimit, AssetDefinitionPoseLimits, PartialAppearancePose } from './definitions';
-import { ArmFingersSchema, ArmPoseSchema, ArmRotationSchema } from './graphics/graphics';
-import { AppearanceArmPose, AppearanceLegPoseSchema, AppearancePose, CharacterViewSchema } from './state/characterState';
+import { ArmFingersSchema, ArmPoseSchema, ArmRotationSchema, LegsPoseSchema } from './graphics/graphics';
+import { AppearanceArmPose, AppearancePose, CharacterViewSchema } from './state/characterState';
 
 class TreeLimit {
 	private readonly limit: ReadonlyMap<string, [number, number][]>;
@@ -283,7 +283,7 @@ function FromPose({ bones, leftArm, rightArm, arms, legs, view }: PartialAppeara
 	}
 	FromArmPose(data, 'leftArm', { ...arms, ...leftArm });
 	FromArmPose(data, 'rightArm', { ...arms, ...rightArm });
-	EnumToIndex(AppearanceLegPoseSchema, legs, (index) => data.set('legs', index));
+	EnumToIndex(LegsPoseSchema, legs, (index) => data.set('legs', index));
 	EnumToIndex(CharacterViewSchema, view, (index) => data.set('view', index));
 
 	return data;
@@ -313,10 +313,10 @@ function FromLimit({ bones, leftArm, rightArm, arms, legs, view }: Immutable<Ass
 	FromArmLimit(data, 'rightArm', { ...arms, ...rightArm });
 	EnumToIndex(CharacterViewSchema, view, (index) => data.set('view', [[index, index]]));
 	if (typeof legs === 'string') {
-		EnumToIndex(AppearanceLegPoseSchema, legs, (index) => data.set('legs', [[index, index]]));
+		EnumToIndex(LegsPoseSchema, legs, (index) => data.set('legs', [[index, index]]));
 	} else if (legs != null) {
 		data.set('legs', legs
-			.map((leg) => AppearanceLegPoseSchema.options.indexOf(leg))
+			.map((leg) => LegsPoseSchema.options.indexOf(leg))
 			.filter((index) => index !== -1)
 			.map((index) => [index, index]));
 	}
@@ -341,7 +341,7 @@ function ToPose(data: ReadonlyMap<string, number>): AppearancePose {
 	ToArmPose(data, 'leftArm', pose);
 	ToArmPose(data, 'rightArm', pose);
 
-	IndexToEnum(AppearanceLegPoseSchema, data.get('legs'), (value) => pose.legs = value);
+	IndexToEnum(LegsPoseSchema, data.get('legs'), (value) => pose.legs = value);
 	IndexToEnum(CharacterViewSchema, data.get('view'), (value) => pose.view = value);
 
 	for (const [key, value] of data) {

--- a/pandora-common/src/assets/appearanceLimit.ts
+++ b/pandora-common/src/assets/appearanceLimit.ts
@@ -4,8 +4,8 @@ import { ZodEnum } from 'zod';
 import { CloneDeepMutable, IntervalSetIntersection } from '../utility';
 import { GetDefaultAppearanceBundle } from './appearance';
 import type { AssetDefinitionPoseLimit, AssetDefinitionPoseLimits, PartialAppearancePose } from './definitions';
-import { ArmFingersSchema, ArmPoseSchema, ArmRotationSchema, LegsPoseSchema } from './graphics/graphics';
-import { AppearanceArmPose, AppearancePose, CharacterViewSchema } from './state/characterState';
+import { ArmFingersSchema, ArmPoseSchema, ArmRotationSchema, CharacterViewSchema, LegsPoseSchema } from './graphics/graphics';
+import type { AppearanceArmPose, AppearancePose } from './state/characterState';
 
 class TreeLimit {
 	private readonly limit: ReadonlyMap<string, [number, number][]>;

--- a/pandora-common/src/assets/appearanceLimit.ts
+++ b/pandora-common/src/assets/appearanceLimit.ts
@@ -5,7 +5,7 @@ import { CloneDeepMutable, IntervalSetIntersection } from '../utility';
 import { GetDefaultAppearanceBundle } from './appearance';
 import type { AssetDefinitionPoseLimit, AssetDefinitionPoseLimits, PartialAppearancePose } from './definitions';
 import { ArmFingersSchema, ArmPoseSchema, ArmRotationSchema } from './graphics/graphics';
-import { AppearanceArmPose, AppearancePose, CharacterViewSchema } from './state/characterState';
+import { AppearanceArmPose, AppearanceLegPoseSchema, AppearancePose, CharacterViewSchema } from './state/characterState';
 
 class TreeLimit {
 	private readonly limit: ReadonlyMap<string, [number, number][]>;
@@ -270,7 +270,7 @@ function CreateTreeNode(limits: Immutable<AssetDefinitionPoseLimits>): TreeNode 
 	return new TreeNode(FromLimit(limits), nodeChildren);
 }
 
-function FromPose({ bones, leftArm, rightArm, arms, view }: PartialAppearancePose): Map<string, number> {
+function FromPose({ bones, leftArm, rightArm, arms, legs, view }: PartialAppearancePose): Map<string, number> {
 	const data = new Map<string, number>();
 
 	if (bones) {
@@ -283,6 +283,7 @@ function FromPose({ bones, leftArm, rightArm, arms, view }: PartialAppearancePos
 	}
 	FromArmPose(data, 'leftArm', { ...arms, ...leftArm });
 	FromArmPose(data, 'rightArm', { ...arms, ...rightArm });
+	EnumToIndex(AppearanceLegPoseSchema, legs, (index) => data.set('legs', index));
 	EnumToIndex(CharacterViewSchema, view, (index) => data.set('view', index));
 
 	return data;
@@ -294,7 +295,7 @@ function FromArmPose(data: Map<string, number>, prefix: 'leftArm' | 'rightArm', 
 	EnumToIndex(ArmFingersSchema, fingers, (index) => data.set(`${prefix}.fingers`, index));
 }
 
-function FromLimit({ bones, leftArm, rightArm, arms, view }: Immutable<AssetDefinitionPoseLimit>): Map<string, [number, number][]> {
+function FromLimit({ bones, leftArm, rightArm, arms, legs, view }: Immutable<AssetDefinitionPoseLimit>): Map<string, [number, number][]> {
 	const data = new Map<string, [number, number][]>();
 
 	if (bones) {
@@ -311,7 +312,14 @@ function FromLimit({ bones, leftArm, rightArm, arms, view }: Immutable<AssetDefi
 	FromArmLimit(data, 'leftArm', { ...arms, ...leftArm });
 	FromArmLimit(data, 'rightArm', { ...arms, ...rightArm });
 	EnumToIndex(CharacterViewSchema, view, (index) => data.set('view', [[index, index]]));
-
+	if (typeof legs === 'string') {
+		EnumToIndex(AppearanceLegPoseSchema, legs, (index) => data.set('legs', [[index, index]]));
+	} else if (legs != null) {
+		data.set('legs', legs
+			.map((leg) => AppearanceLegPoseSchema.options.indexOf(leg))
+			.filter((index) => index !== -1)
+			.map((index) => [index, index]));
+	}
 	return data;
 }
 
@@ -333,6 +341,7 @@ function ToPose(data: ReadonlyMap<string, number>): AppearancePose {
 	ToArmPose(data, 'leftArm', pose);
 	ToArmPose(data, 'rightArm', pose);
 
+	IndexToEnum(AppearanceLegPoseSchema, data.get('legs'), (value) => pose.legs = value);
 	IndexToEnum(CharacterViewSchema, data.get('view'), (value) => pose.view = value);
 
 	for (const [key, value] of data) {

--- a/pandora-common/src/assets/assetManager.ts
+++ b/pandora-common/src/assets/assetManager.ts
@@ -7,7 +7,7 @@ import { AppearanceRandomizationData, AssetAttributeDefinition, AssetBodyPart, A
 import { BoneDefinition, BoneDefinitionCompressed, CharacterSize } from './graphics';
 import { CreateItem, Item, ItemBundle } from './item';
 
-export const FAKE_BONES: readonly string[] = ['backView'];
+export const FAKE_BONES: readonly string[] = ['backView', 'kneeling', 'sitting'];
 
 export class AssetManager {
 	protected readonly _assets: ReadonlyMap<AssetId, Asset>;

--- a/pandora-common/src/assets/assetManager.ts
+++ b/pandora-common/src/assets/assetManager.ts
@@ -7,6 +7,8 @@ import { AppearanceRandomizationData, AssetAttributeDefinition, AssetBodyPart, A
 import { BoneDefinition, BoneDefinitionCompressed, CharacterSize } from './graphics';
 import { CreateItem, Item, ItemBundle } from './item';
 
+export const FAKE_BONES: readonly string[] = ['backView'];
+
 export class AssetManager {
 	protected readonly _assets: ReadonlyMap<AssetId, Asset>;
 	protected readonly _bones: ReadonlyMap<string, BoneDefinition>;
@@ -131,6 +133,9 @@ export class AssetManager {
 			bones.set(bone.mirror, this.createBone(bone.mirror, {
 				...bone,
 			}, parent?.mirror ?? parent, newBone));
+		}
+		for (const bone of FAKE_BONES) {
+			bones.set(bone, this.createBone(bone, { type: 'fake' }));
 		}
 
 		this._bones = bones;

--- a/pandora-common/src/assets/assetManager.ts
+++ b/pandora-common/src/assets/assetManager.ts
@@ -7,8 +7,6 @@ import { AppearanceRandomizationData, AssetAttributeDefinition, AssetBodyPart, A
 import { BoneDefinition, BoneDefinitionCompressed, CharacterSize } from './graphics';
 import { CreateItem, Item, ItemBundle } from './item';
 
-export const FAKE_BONES: readonly string[] = ['backView', 'kneeling', 'sitting'];
-
 export class AssetManager {
 	protected readonly _assets: ReadonlyMap<AssetId, Asset>;
 	protected readonly _bones: ReadonlyMap<string, BoneDefinition>;
@@ -133,9 +131,6 @@ export class AssetManager {
 			bones.set(bone.mirror, this.createBone(bone.mirror, {
 				...bone,
 			}, parent?.mirror ?? parent, newBone));
-		}
-		for (const bone of FAKE_BONES) {
-			bones.set(bone, this.createBone(bone, { type: 'fake' }));
 		}
 
 		this._bones = bones;

--- a/pandora-common/src/assets/definitions.ts
+++ b/pandora-common/src/assets/definitions.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { IChatroomBackgroundData } from '../chatroom';
 import { HexRGBAColorString, ZodTemplateString } from '../validation';
-import type { AppearanceArmPose, CharacterView } from './state/characterState';
+import type { AppearanceArmPose, AppearanceLegPose, CharacterView } from './state/characterState';
 import type { BoneDefinitionCompressed, BoneName, Coordinates } from './graphics';
 import { AssetModuleDefinition } from './modules';
 import { AssetLockProperties, AssetProperties } from './properties';
@@ -38,6 +38,7 @@ export interface AssetDefinitionPoseLimit<A extends AssetDefinitionExtraArgs = A
 	arms?: Partial<AppearanceArmPose>;
 	leftArm?: Partial<AppearanceArmPose>;
 	rightArm?: Partial<AppearanceArmPose>;
+	legs?: AppearanceLegPose | AppearanceLegPose[];
 	view?: CharacterView;
 }
 
@@ -355,6 +356,7 @@ export type PartialAppearancePose<Bones extends BoneName = BoneName> = {
 	arms?: Partial<AppearanceArmPose>;
 	leftArm?: Partial<AppearanceArmPose>;
 	rightArm?: Partial<AppearanceArmPose>;
+	legs?: AppearanceLegPose;
 	view?: CharacterView;
 };
 

--- a/pandora-common/src/assets/definitions.ts
+++ b/pandora-common/src/assets/definitions.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import type { IChatroomBackgroundData } from '../chatroom';
 import { HexRGBAColorString, ZodTemplateString } from '../validation';
-import type { AppearanceArmPose, CharacterView } from './state/characterState';
-import type { BoneDefinitionCompressed, BoneName, Coordinates, LegsPose } from './graphics';
+import type { AppearanceArmPose } from './state/characterState';
+import type { BoneDefinitionCompressed, BoneName, CharacterView, Coordinates, LegsPose } from './graphics';
 import { AssetModuleDefinition } from './modules';
 import { AssetLockProperties, AssetProperties } from './properties';
 import { Satisfies } from '../utility';

--- a/pandora-common/src/assets/definitions.ts
+++ b/pandora-common/src/assets/definitions.ts
@@ -369,6 +369,7 @@ export function MergePartialAppearancePoses(base: Immutable<PartialAppearancePos
 		arms: { ...base.arms, ...extend.arms },
 		leftArm: { ...base.leftArm, ...extend.leftArm },
 		rightArm: { ...base.rightArm, ...extend.rightArm },
+		legs: base.legs ?? extend.legs,
 		view: base.view ?? extend.view,
 	};
 }

--- a/pandora-common/src/assets/definitions.ts
+++ b/pandora-common/src/assets/definitions.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import type { IChatroomBackgroundData } from '../chatroom';
 import { HexRGBAColorString, ZodTemplateString } from '../validation';
-import type { AppearanceArmPose, AppearanceLegPose, CharacterView } from './state/characterState';
-import type { BoneDefinitionCompressed, BoneName, Coordinates } from './graphics';
+import type { AppearanceArmPose, CharacterView } from './state/characterState';
+import type { BoneDefinitionCompressed, BoneName, Coordinates, LegsPose } from './graphics';
 import { AssetModuleDefinition } from './modules';
 import { AssetLockProperties, AssetProperties } from './properties';
 import { Satisfies } from '../utility';
@@ -38,7 +38,7 @@ export interface AssetDefinitionPoseLimit<A extends AssetDefinitionExtraArgs = A
 	arms?: Partial<AppearanceArmPose>;
 	leftArm?: Partial<AppearanceArmPose>;
 	rightArm?: Partial<AppearanceArmPose>;
-	legs?: AppearanceLegPose | AppearanceLegPose[];
+	legs?: LegsPose | LegsPose[];
 	view?: CharacterView;
 }
 
@@ -356,7 +356,7 @@ export type PartialAppearancePose<Bones extends BoneName = BoneName> = {
 	arms?: Partial<AppearanceArmPose>;
 	leftArm?: Partial<AppearanceArmPose>;
 	rightArm?: Partial<AppearanceArmPose>;
-	legs?: AppearanceLegPose;
+	legs?: LegsPose;
 	view?: CharacterView;
 };
 

--- a/pandora-common/src/assets/graphics/graphics.ts
+++ b/pandora-common/src/assets/graphics/graphics.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 import type { AssetId } from '../definitions';
-import { AppearanceLegPoseSchema } from '../state/characterState';
 
 export const CoordinatesSchema = z.object({ x: z.number(), y: z.number() });
 export type Coordinates = z.infer<typeof CoordinatesSchema>;
@@ -32,6 +31,9 @@ export type ArmRotation = z.infer<typeof ArmRotationSchema>;
 
 export const ArmFingersSchema = z.enum(['spread', 'fist']);
 export type ArmFingers = z.infer<typeof ArmFingersSchema>;
+
+export const LegsPoseSchema = z.enum(['standing', 'sitting', 'kneeling']);
+export type LegsPose = z.infer<typeof LegsPoseSchema>;
 
 export const RectangleSchema = CoordinatesSchema.merge(SizeSchema);
 export type Rectangle = z.infer<typeof RectangleSchema>;
@@ -71,7 +73,7 @@ export const AtomicConditionArmFingersSchema = z.object({
 	value: ArmFingersSchema,
 });
 export const AtomicConditionLegsSchema = z.object({
-	legs: AppearanceLegPoseSchema,
+	legs: LegsPoseSchema,
 });
 export const AtomicConditionSchema = z.union([
 	AtomicConditionBoneSchema,

--- a/pandora-common/src/assets/graphics/graphics.ts
+++ b/pandora-common/src/assets/graphics/graphics.ts
@@ -23,6 +23,9 @@ export const CharacterSize = {
 	HEIGHT: 1500,
 } as const;
 
+export const CharacterViewSchema = z.enum(['front', 'back']);
+export type CharacterView = z.infer<typeof CharacterViewSchema>;
+
 export const ArmPoseSchema = z.enum(['front', 'back']);
 export type ArmPose = z.infer<typeof ArmPoseSchema>;
 
@@ -100,6 +103,9 @@ function Negatable<T extends string[]>(arr: T): [...T, ...NegateArray<T>] {
 export const AtomicConditionLegsSchema = z.object({
 	legs: z.enum(Negatable(LegsPoseSchema.options)),
 });
+export const AtomicConditionViewSchema = z.object({
+	view: CharacterViewSchema,
+});
 export const AtomicConditionSchema = z.union([
 	AtomicConditionBoneSchema,
 	AtomicConditionModuleSchema,
@@ -107,6 +113,7 @@ export const AtomicConditionSchema = z.union([
 	AtomicConditionArmRotationSchema,
 	AtomicConditionArmFingersSchema,
 	AtomicConditionLegsSchema,
+	AtomicConditionViewSchema,
 ]);
 export type AtomicCondition = z.infer<typeof AtomicConditionSchema>;
 

--- a/pandora-common/src/assets/graphics/graphics.ts
+++ b/pandora-common/src/assets/graphics/graphics.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { AssetId } from '../definitions';
+import { AppearanceLegPoseSchema } from '../state/characterState';
 
 export const CoordinatesSchema = z.object({ x: z.number(), y: z.number() });
 export type Coordinates = z.infer<typeof CoordinatesSchema>;
@@ -69,13 +70,16 @@ export const AtomicConditionArmFingersSchema = z.object({
 	operator: ConditionOperatorSchema,
 	value: ArmFingersSchema,
 });
-
+export const AtomicConditionLegsSchema = z.object({
+	legs: AppearanceLegPoseSchema,
+});
 export const AtomicConditionSchema = z.union([
 	AtomicConditionBoneSchema,
 	AtomicConditionModuleSchema,
 	AtomicConditionAttributeSchema,
 	AtomicConditionArmRotationSchema,
 	AtomicConditionArmFingersSchema,
+	AtomicConditionLegsSchema,
 ]);
 export type AtomicCondition = z.infer<typeof AtomicConditionSchema>;
 

--- a/pandora-common/src/assets/graphics/graphics.ts
+++ b/pandora-common/src/assets/graphics/graphics.ts
@@ -10,7 +10,7 @@ export type CoordinatesCompressed = z.infer<typeof CoordinatesCompressedSchema>;
 export const BoneNameSchema = z.string();
 export type BoneName = z.infer<typeof BoneNameSchema>;
 
-export type BoneType = 'pose' | 'body';
+export type BoneType = 'pose' | 'body' | 'fake';
 
 export const SizeSchema = z.object({
 	width: z.number(),

--- a/pandora-common/src/assets/graphics/graphics.ts
+++ b/pandora-common/src/assets/graphics/graphics.ts
@@ -10,7 +10,7 @@ export type CoordinatesCompressed = z.infer<typeof CoordinatesCompressedSchema>;
 export const BoneNameSchema = z.string();
 export type BoneName = z.infer<typeof BoneNameSchema>;
 
-export type BoneType = 'pose' | 'body' | 'fake';
+export type BoneType = 'pose' | 'body';
 
 export const SizeSchema = z.object({
 	width: z.number(),

--- a/pandora-common/src/assets/graphics/graphics.ts
+++ b/pandora-common/src/assets/graphics/graphics.ts
@@ -1,5 +1,6 @@
-import { ZodEffects, ZodString, z } from 'zod';
+import { z } from 'zod';
 import type { AssetId } from '../definitions';
+import { ZodOverridable } from '../../validation';
 
 export const CoordinatesSchema = z.object({ x: z.number(), y: z.number() });
 export type Coordinates = z.infer<typeof CoordinatesSchema>;
@@ -7,7 +8,7 @@ export type Coordinates = z.infer<typeof CoordinatesSchema>;
 export const CoordinatesCompressedSchema = z.tuple([CoordinatesSchema.shape.x, CoordinatesSchema.shape.y]);
 export type CoordinatesCompressed = z.infer<typeof CoordinatesCompressedSchema>;
 
-export const BoneNameSchema = z.string();
+export const BoneNameSchema = ZodOverridable(z.string());
 export type BoneName = z.infer<typeof BoneNameSchema>;
 
 export type BoneType = 'pose' | 'body';
@@ -45,32 +46,17 @@ export const CONDITION_OPERATORS = ['=', '<', '<=', '>', '>=', '!='] as const;
 export const ConditionOperatorSchema = z.enum(CONDITION_OPERATORS);
 export type ConditionOperator = z.infer<typeof ConditionOperatorSchema>;
 
-type StringLikeSchema = ZodString | ZodEffects<ZodString, string, string>;
-
-let boneSchema: StringLikeSchema = z.string();
-let moduleSchema: StringLikeSchema = z.string();
-let attributeSchema: StringLikeSchema = z.string();
-
-export function SetBoneSchemaForAtomicCondition(schema: typeof boneSchema) {
-	boneSchema = schema;
-}
-
-export function SetModuleSchemaForAtomicCondition(schema: typeof moduleSchema) {
-	moduleSchema = schema;
-}
-
-export function SetAttributeSchemaForAtomicCondition(schema: typeof attributeSchema) {
-	attributeSchema = schema;
-}
+export const ModuleNameSchema = ZodOverridable(z.string());
+export const AttributeNameSchema = ZodOverridable(z.string());
 
 export const AtomicConditionBoneSchema = z.object({
-	bone: z.lazy(() => boneSchema),
+	bone: BoneNameSchema,
 	operator: ConditionOperatorSchema,
 	value: z.number(),
 });
 export type AtomicConditionBone = z.infer<typeof AtomicConditionBoneSchema>;
 export const AtomicConditionModuleSchema = z.object({
-	module: z.lazy(() => moduleSchema),
+	module: ModuleNameSchema,
 	operator: ConditionOperatorSchema,
 	value: z.string(),
 });
@@ -79,7 +65,7 @@ export const AtomicConditionAttributeSchema = z.object({
 	 * Attribute that which required for this condition to be true
 	 *  - attribute can be prefixed with `!` to negate the condition
 	 */
-	attribute: z.lazy(() => attributeSchema),
+	attribute: AttributeNameSchema,
 });
 export const AtomicConditionArmRotationSchema = z.object({
 	armType: z.literal('rotation'),
@@ -120,14 +106,8 @@ export type AtomicCondition = z.infer<typeof AtomicConditionSchema>;
 export const ConditionSchema = z.array(z.array(AtomicConditionSchema));
 export type Condition = z.infer<typeof ConditionSchema>;
 
-let transformDefinitionBoneSchema: StringLikeSchema = z.string();
-
-export function SetTransformDefinitionBoneSchema(schema: typeof transformDefinitionBoneSchema) {
-	transformDefinitionBoneSchema = schema;
-}
-
 const TransformDefinitionBaseSchema = z.object({
-	bone: z.lazy(() => transformDefinitionBoneSchema),
+	bone: BoneNameSchema,
 	condition: ConditionSchema.optional(),
 });
 

--- a/pandora-common/src/assets/graphics/graphics.ts
+++ b/pandora-common/src/assets/graphics/graphics.ts
@@ -48,7 +48,6 @@ let boneSchema: StringLikeSchema = z.string();
 let moduleSchema: StringLikeSchema = z.string();
 let attributeSchema: StringLikeSchema = z.string();
 
-
 export function SetBoneSchemaForAtomicCondition(schema: typeof boneSchema) {
 	boneSchema = schema;
 }
@@ -91,8 +90,15 @@ export const AtomicConditionArmFingersSchema = z.object({
 	operator: ConditionOperatorSchema,
 	value: ArmFingersSchema,
 });
+
+type Negate<T extends string> = `!${T}`;
+type NegateArray<T extends string[]> = T extends [infer F extends string, ...infer R extends string[]] ? [Negate<F>, ...NegateArray<R>] : [];
+function Negatable<T extends string[]>(arr: T): [...T, ...NegateArray<T>] {
+	return [...arr, ...arr.map((x) => `!${x}`) as NegateArray<T>];
+}
+
 export const AtomicConditionLegsSchema = z.object({
-	legs: LegsPoseSchema,
+	legs: z.enum(Negatable(LegsPoseSchema.options)),
 });
 export const AtomicConditionSchema = z.union([
 	AtomicConditionBoneSchema,

--- a/pandora-common/src/assets/graphics/graphics.ts
+++ b/pandora-common/src/assets/graphics/graphics.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { ZodEffects, ZodString, z } from 'zod';
 import type { AssetId } from '../definitions';
 
 export const CoordinatesSchema = z.object({ x: z.number(), y: z.number() });
@@ -42,14 +42,33 @@ export const CONDITION_OPERATORS = ['=', '<', '<=', '>', '>=', '!='] as const;
 export const ConditionOperatorSchema = z.enum(CONDITION_OPERATORS);
 export type ConditionOperator = z.infer<typeof ConditionOperatorSchema>;
 
+type StringLikeSchema = ZodString | ZodEffects<ZodString, string, string>;
+
+let boneSchema: StringLikeSchema = z.string();
+let moduleSchema: StringLikeSchema = z.string();
+let attributeSchema: StringLikeSchema = z.string();
+
+
+export function SetBoneSchemaForAtomicCondition(schema: typeof boneSchema) {
+	boneSchema = schema;
+}
+
+export function SetModuleSchemaForAtomicCondition(schema: typeof moduleSchema) {
+	moduleSchema = schema;
+}
+
+export function SetAttributeSchemaForAtomicCondition(schema: typeof attributeSchema) {
+	attributeSchema = schema;
+}
+
 export const AtomicConditionBoneSchema = z.object({
-	bone: z.string(),
+	bone: z.lazy(() => boneSchema),
 	operator: ConditionOperatorSchema,
 	value: z.number(),
 });
 export type AtomicConditionBone = z.infer<typeof AtomicConditionBoneSchema>;
 export const AtomicConditionModuleSchema = z.object({
-	module: z.string(),
+	module: z.lazy(() => moduleSchema),
 	operator: ConditionOperatorSchema,
 	value: z.string(),
 });
@@ -58,7 +77,7 @@ export const AtomicConditionAttributeSchema = z.object({
 	 * Attribute that which required for this condition to be true
 	 *  - attribute can be prefixed with `!` to negate the condition
 	 */
-	attribute: z.string(),
+	attribute: z.lazy(() => attributeSchema),
 });
 export const AtomicConditionArmRotationSchema = z.object({
 	armType: z.literal('rotation'),
@@ -88,8 +107,14 @@ export type AtomicCondition = z.infer<typeof AtomicConditionSchema>;
 export const ConditionSchema = z.array(z.array(AtomicConditionSchema));
 export type Condition = z.infer<typeof ConditionSchema>;
 
+let transformDefinitionBoneSchema: StringLikeSchema = z.string();
+
+export function SetTransformDefinitionBoneSchema(schema: typeof transformDefinitionBoneSchema) {
+	transformDefinitionBoneSchema = schema;
+}
+
 const TransformDefinitionBaseSchema = z.object({
-	bone: z.string(),
+	bone: z.lazy(() => transformDefinitionBoneSchema),
 	condition: ConditionSchema.optional(),
 });
 

--- a/pandora-common/src/assets/state/characterState.ts
+++ b/pandora-common/src/assets/state/characterState.ts
@@ -1,6 +1,6 @@
 import { AppearanceItemProperties, AppearanceItems, AppearanceValidationResult, CharacterAppearanceLoadAndValidate, ValidateAppearanceItems } from '../appearanceValidation';
 import { AssetsPosePreset, MergePartialAppearancePoses, PartialAppearancePose, WearableAssetType } from '../definitions';
-import { Assert, AssertNotNullable, MemoizeNoArg } from '../../utility';
+import { Assert, MemoizeNoArg } from '../../utility';
 import { ZodArrayWithInvalidDrop } from '../../validation';
 import { freeze } from 'immer';
 import { z } from 'zod';

--- a/pandora-common/src/assets/state/characterState.ts
+++ b/pandora-common/src/assets/state/characterState.ts
@@ -45,21 +45,21 @@ export type AppearanceClientBundle = AppearanceBundle & { clientOnly: true; };
 
 export type AppearanceCharacterPose = ReadonlyMap<BoneName, BoneState>;
 
-type Props = {
-	assetManager: AssetManager;
-	id: CharacterId;
-	items: AppearanceItems<WearableAssetType>;
-	pose: AppearanceCharacterPose;
-	arms: CharacterArmsPose;
-	legs: LegsPose;
-	view: CharacterView;
-	safemode: SafemodeData | undefined;
+type AssetFrameworkCharacterStateProps = {
+	readonly assetManager: AssetManager;
+	readonly id: CharacterId;
+	readonly items: AppearanceItems<WearableAssetType>;
+	readonly pose: AppearanceCharacterPose;
+	readonly arms: CharacterArmsPose;
+	readonly legs: LegsPose;
+	readonly view: CharacterView;
+	readonly safemode: SafemodeData | undefined;
 };
 
 /**
  * State of an character. Immutable.
  */
-export class AssetFrameworkCharacterState {
+export class AssetFrameworkCharacterState implements AssetFrameworkCharacterStateProps {
 	public readonly type = 'character';
 	public readonly assetManager: AssetManager;
 
@@ -71,29 +71,18 @@ export class AssetFrameworkCharacterState {
 	public readonly view: CharacterView;
 	public readonly safemode: SafemodeData | undefined;
 
-	private constructor(props: Props);
-	private constructor(old: AssetFrameworkCharacterState, override: Partial<Props>);
-	private constructor(props: Props | AssetFrameworkCharacterState, override?: Partial<Props>) {
-		if (props instanceof AssetFrameworkCharacterState) {
-			AssertNotNullable(override);
-			this.assetManager = override.assetManager ?? props.assetManager;
-			this.id = override.id ?? props.id;
-			this.items = override.items ?? props.items;
-			this.pose = override.pose ?? props.pose;
-			this.arms = override.arms ?? props.arms;
-			this.legs = override.legs ?? props.legs;
-			this.view = override.view ?? props.view;
-			this.safemode = 'safemode' in override ? override.safemode : props.safemode;
-		} else {
-			this.assetManager = props.assetManager;
-			this.id = props.id;
-			this.items = props.items;
-			this.pose = props.pose;
-			this.arms = props.arms;
-			this.legs = props.legs;
-			this.view = props.view;
-			this.safemode = props.safemode;
-		}
+	private constructor(props: AssetFrameworkCharacterStateProps);
+	private constructor(old: AssetFrameworkCharacterState, override: Partial<AssetFrameworkCharacterStateProps>);
+	private constructor(props: AssetFrameworkCharacterStateProps, override: Partial<AssetFrameworkCharacterStateProps> = {}) {
+		this.assetManager = override.assetManager ?? props.assetManager;
+		this.id = override.id ?? props.id;
+		this.items = override.items ?? props.items;
+		this.pose = override.pose ?? props.pose;
+		this.arms = override.arms ?? props.arms;
+		this.legs = override.legs ?? props.legs;
+		this.view = override.view ?? props.view;
+		// allow override safemode with undefined (override: { safemode: undefined })
+		this.safemode = 'safemode' in override ? override.safemode : props.safemode;
 	}
 
 	public isValid(): boolean {

--- a/pandora-common/src/assets/state/characterState.ts
+++ b/pandora-common/src/assets/state/characterState.ts
@@ -29,10 +29,14 @@ export const AppearanceArmPoseSchema = z.object({
 });
 export type AppearanceArmPose = z.infer<typeof AppearanceArmPoseSchema>;
 
+export const AppearanceLegPoseSchema = z.enum(['standing', 'sitting', 'kneeling']);
+export type AppearanceLegPose = z.infer<typeof AppearanceLegPoseSchema>;
+
 export const AppearancePoseSchema = z.object({
 	bones: z.record(BoneNameSchema, z.number().optional()).default({}),
 	leftArm: AppearanceArmPoseSchema.default({}),
 	rightArm: AppearanceArmPoseSchema.default({}),
+	legs: AppearanceLegPoseSchema.default('standing'),
 	view: CharacterViewSchema.catch('front'),
 });
 export type AppearancePose = z.infer<typeof AppearancePoseSchema>;
@@ -53,6 +57,7 @@ type Props = {
 	items: AppearanceItems<WearableAssetType>;
 	pose: AppearanceCharacterPose;
 	arms: CharacterArmsPose;
+	legs: AppearanceLegPose;
 	view: CharacterView;
 	safemode: SafemodeData | undefined;
 };
@@ -68,6 +73,7 @@ export class AssetFrameworkCharacterState {
 	public readonly items: AppearanceItems<WearableAssetType>;
 	public readonly pose: AppearanceCharacterPose;
 	public readonly arms: CharacterArmsPose;
+	public readonly legs: AppearanceLegPose;
 	public readonly view: CharacterView;
 	public readonly safemode: SafemodeData | undefined;
 
@@ -81,6 +87,7 @@ export class AssetFrameworkCharacterState {
 			this.items = override.items ?? props.items;
 			this.pose = override.pose ?? props.pose;
 			this.arms = override.arms ?? props.arms;
+			this.legs = override.legs ?? props.legs;
 			this.view = override.view ?? props.view;
 			this.safemode = 'safemode' in override ? override.safemode : props.safemode;
 		} else {
@@ -89,6 +96,7 @@ export class AssetFrameworkCharacterState {
 			this.items = props.items;
 			this.pose = props.pose;
 			this.arms = props.arms;
+			this.legs = props.legs;
 			this.view = props.view;
 			this.safemode = props.safemode;
 		}
@@ -125,6 +133,7 @@ export class AssetFrameworkCharacterState {
 			bones: Object.fromEntries([...this.pose.entries()].map(([bone, state]) => [bone, state.rotation])),
 			leftArm: this.arms.leftArm,
 			rightArm: this.arms.rightArm,
+			legs: this.legs,
 			view: this.view,
 		};
 	}
@@ -135,6 +144,7 @@ export class AssetFrameworkCharacterState {
 			bones: this.exportBones(),
 			leftArm: _.cloneDeep(this.arms.leftArm),
 			rightArm: _.cloneDeep(this.arms.rightArm),
+			legs: this.legs,
 			view: this.view,
 			safemode: this.safemode,
 		};
@@ -147,6 +157,7 @@ export class AssetFrameworkCharacterState {
 			bones: this.exportBones(),
 			leftArm: _.cloneDeep(this.arms.leftArm),
 			rightArm: _.cloneDeep(this.arms.rightArm),
+			legs: this.legs,
 			view: this.view,
 			safemode: this.safemode,
 			clientOnly: true,
@@ -184,7 +195,7 @@ export class AssetFrameworkCharacterState {
 		if (!changed)
 			return this;
 
-		const { bones, leftArm, rightArm, view } = pose;
+		const { bones, leftArm, rightArm, legs, view } = pose;
 
 		const newPose = new Map(this.pose);
 		for (const [bone, state] of newPose.entries()) {
@@ -203,6 +214,7 @@ export class AssetFrameworkCharacterState {
 				leftArm,
 				rightArm,
 			},
+			legs,
 			view,
 		});
 	}
@@ -383,6 +395,7 @@ export class AssetFrameworkCharacterState {
 				leftArm: _.cloneDeep(bundle.leftArm),
 				rightArm: _.cloneDeep(bundle.rightArm),
 			},
+			legs: bundle.legs,
 			view: bundle.view,
 			safemode: bundle.safemode,
 		}), true);

--- a/pandora-common/src/assets/state/characterState.ts
+++ b/pandora-common/src/assets/state/characterState.ts
@@ -4,7 +4,7 @@ import { Assert, AssertNotNullable, MemoizeNoArg } from '../../utility';
 import { ZodArrayWithInvalidDrop } from '../../validation';
 import { freeze } from 'immer';
 import { z } from 'zod';
-import { ArmFingersSchema, ArmPoseSchema, ArmRotationSchema, BoneName, BoneNameSchema, BoneState, BoneType, LegsPose, LegsPoseSchema } from '../graphics';
+import { ArmFingersSchema, ArmPoseSchema, ArmRotationSchema, BoneName, BoneNameSchema, BoneState, BoneType, CharacterView, CharacterViewSchema, LegsPose, LegsPoseSchema } from '../graphics';
 import { Item, ItemBundleSchema } from '../item';
 import { AssetManager } from '../assetManager';
 import { BONE_MAX, BONE_MIN, CharacterArmsPose, GetDefaultAppearanceBundle } from '../appearance';
@@ -13,9 +13,6 @@ import _, { isEqual } from 'lodash';
 import { AssetFrameworkRoomState } from './roomState';
 import { CharacterId } from '../../character';
 import type { IExportOptions } from '../modules/common';
-
-export const CharacterViewSchema = z.enum(['front', 'back']);
-export type CharacterView = z.infer<typeof CharacterViewSchema>;
 
 export const SafemodeDataSchema = z.object({
 	allowLeaveAt: z.number(),

--- a/pandora-common/src/assets/state/characterState.ts
+++ b/pandora-common/src/assets/state/characterState.ts
@@ -362,9 +362,6 @@ export class AssetFrameworkCharacterState {
 
 		const pose = new Map<BoneName, BoneState>();
 		for (const bone of assetManager.getAllBones()) {
-			if (bone.type === 'fake')
-				continue;
-
 			const value = bundle.bones[bone.name];
 			pose.set(bone.name, {
 				definition: bone,

--- a/pandora-common/src/assets/state/characterState.ts
+++ b/pandora-common/src/assets/state/characterState.ts
@@ -231,7 +231,7 @@ export class AssetFrameworkCharacterState {
 		if (changed) {
 			resultArms = arms;
 		}
-		const { bones } = pose;
+		const { bones, legs } = pose;
 		if (bones) {
 			const newPose = new Map(resultPose);
 			for (const [bone, state] of newPose.entries()) {
@@ -246,11 +246,11 @@ export class AssetFrameworkCharacterState {
 				});
 			}
 			resultPose = newPose;
-		} else if (!changed) {
+		} else if (!changed && (legs == null || this.legs === legs)) {
 			return [false, this];
 		}
 
-		return [true, new AssetFrameworkCharacterState(this, { pose: resultPose, arms: resultArms })];
+		return [true, new AssetFrameworkCharacterState(this, { pose: resultPose, arms: resultArms, legs })];
 	}
 
 	public produceWithPose(pose: PartialAppearancePose, type: BoneType | true, missingAsZero: boolean): AssetFrameworkCharacterState {

--- a/pandora-common/src/assets/state/characterState.ts
+++ b/pandora-common/src/assets/state/characterState.ts
@@ -356,6 +356,9 @@ export class AssetFrameworkCharacterState {
 
 		const pose = new Map<BoneName, BoneState>();
 		for (const bone of assetManager.getAllBones()) {
+			if (bone.type === 'fake')
+				continue;
+
 			const value = bundle.bones[bone.name];
 			pose.set(bone.name, {
 				definition: bone,

--- a/pandora-common/src/assets/state/characterState.ts
+++ b/pandora-common/src/assets/state/characterState.ts
@@ -4,7 +4,7 @@ import { Assert, AssertNotNullable, MemoizeNoArg } from '../../utility';
 import { ZodArrayWithInvalidDrop } from '../../validation';
 import { freeze } from 'immer';
 import { z } from 'zod';
-import { ArmFingersSchema, ArmPoseSchema, ArmRotationSchema, BoneName, BoneNameSchema, BoneState, BoneType } from '../graphics';
+import { ArmFingersSchema, ArmPoseSchema, ArmRotationSchema, BoneName, BoneNameSchema, BoneState, BoneType, LegsPose, LegsPoseSchema } from '../graphics';
 import { Item, ItemBundleSchema } from '../item';
 import { AssetManager } from '../assetManager';
 import { BONE_MAX, BONE_MIN, CharacterArmsPose, GetDefaultAppearanceBundle } from '../appearance';
@@ -29,14 +29,11 @@ export const AppearanceArmPoseSchema = z.object({
 });
 export type AppearanceArmPose = z.infer<typeof AppearanceArmPoseSchema>;
 
-export const AppearanceLegPoseSchema = z.enum(['standing', 'sitting', 'kneeling']);
-export type AppearanceLegPose = z.infer<typeof AppearanceLegPoseSchema>;
-
 export const AppearancePoseSchema = z.object({
 	bones: z.record(BoneNameSchema, z.number().optional()).default({}),
 	leftArm: AppearanceArmPoseSchema.default({}),
 	rightArm: AppearanceArmPoseSchema.default({}),
-	legs: AppearanceLegPoseSchema.default('standing'),
+	legs: LegsPoseSchema.default('standing'),
 	view: CharacterViewSchema.catch('front'),
 });
 export type AppearancePose = z.infer<typeof AppearancePoseSchema>;
@@ -57,7 +54,7 @@ type Props = {
 	items: AppearanceItems<WearableAssetType>;
 	pose: AppearanceCharacterPose;
 	arms: CharacterArmsPose;
-	legs: AppearanceLegPose;
+	legs: LegsPose;
 	view: CharacterView;
 	safemode: SafemodeData | undefined;
 };
@@ -73,7 +70,7 @@ export class AssetFrameworkCharacterState {
 	public readonly items: AppearanceItems<WearableAssetType>;
 	public readonly pose: AppearanceCharacterPose;
 	public readonly arms: CharacterArmsPose;
-	public readonly legs: AppearanceLegPose;
+	public readonly legs: LegsPose;
 	public readonly view: CharacterView;
 	public readonly safemode: SafemodeData | undefined;
 

--- a/pandora-common/src/assets/state/globalState.ts
+++ b/pandora-common/src/assets/state/globalState.ts
@@ -11,6 +11,9 @@ import { ActionProcessingContext, RoomTargetSelector } from '../appearanceTypes'
 import { AssetFrameworkRoomState, RoomInventoryBundleSchema, RoomInventoryClientBundle } from './roomState';
 import { IExportOptions } from '../modules/common';
 
+// Fix for pnpm resolution weirdness
+import type { } from "../../validation";
+
 export const AssetFrameworkGlobalStateBundleSchema = z.object({
 	characters: z.record(CharacterIdSchema, AppearanceBundleSchema),
 	room: RoomInventoryBundleSchema.nullable(),

--- a/pandora-common/src/assets/state/globalState.ts
+++ b/pandora-common/src/assets/state/globalState.ts
@@ -12,7 +12,7 @@ import { AssetFrameworkRoomState, RoomInventoryBundleSchema, RoomInventoryClient
 import { IExportOptions } from '../modules/common';
 
 // Fix for pnpm resolution weirdness
-import type { } from "../../validation";
+import type { } from '../../validation';
 
 export const AssetFrameworkGlobalStateBundleSchema = z.object({
 	characters: z.record(CharacterIdSchema, AppearanceBundleSchema),

--- a/pandora-common/src/networking/shard_directory.ts
+++ b/pandora-common/src/networking/shard_directory.ts
@@ -12,6 +12,7 @@ export type IChatRoomDataAccess = z.infer<typeof ChatRoomDataAccessSchema>;
 import type { } from '../assets/appearance';
 import type { } from '../character/pronouns';
 import type { } from '../chatroom/chat';
+import type { } from "../validation";
 
 export const ShardDirectorySchema = {
 	shardRegister: {

--- a/pandora-common/src/networking/shard_directory.ts
+++ b/pandora-common/src/networking/shard_directory.ts
@@ -12,7 +12,7 @@ export type IChatRoomDataAccess = z.infer<typeof ChatRoomDataAccessSchema>;
 import type { } from '../assets/appearance';
 import type { } from '../character/pronouns';
 import type { } from '../chatroom/chat';
-import type { } from "../validation";
+import type { } from '../validation';
 
 export const ShardDirectorySchema = {
 	shardRegister: {

--- a/pandora-common/src/validation.ts
+++ b/pandora-common/src/validation.ts
@@ -37,16 +37,16 @@ export function ZodArrayWithInvalidDrop<ZodShape extends ZodTypeAny, ZodPreCheck
 	});
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface ZodOverridableType<Output = any, Def extends ZodTypeDef = ZodTypeDef, Input = Output> extends ZodEffects<ZodType<Output, Def, Input>, Output, Input> {
-	override: ((attachedValidation: ((arg: Output, ctx: RefinementCtx) => void)) => void);
+export const SCHEME_OVERRIDE = Symbol('SCHEME_OVERRIDE');
+
+export interface ZodOverridableType<Output = undefined, Def extends ZodTypeDef = ZodTypeDef, Input = Output> extends ZodEffects<ZodType<Output, Def, Input>, Output, Input> {
+	[SCHEME_OVERRIDE]: ((attachedValidation: ((arg: Output, ctx: RefinementCtx) => void)) => void);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function ZodOverridable<Output = any, Def extends ZodTypeDef = ZodTypeDef, Input = Output>(schema: ZodType<Output, Def, Input>): ZodOverridableType<Output, Def, Input> {
+export function ZodOverridable<Output = undefined, Def extends ZodTypeDef = ZodTypeDef, Input = Output>(schema: ZodType<Output, Def, Input>): ZodOverridableType<Output, Def, Input> {
 	let attachedValidation: ((arg: Output, ctx: RefinementCtx) => void) | undefined;
 	const refined = schema.superRefine((arg, ctx) => attachedValidation?.(arg, ctx)) as ZodOverridableType<Output, Def, Input>;
-	refined.override = (fn) => attachedValidation = fn;
+	refined[SCHEME_OVERRIDE] = (fn) => attachedValidation = fn;
 	return refined;
 }
 

--- a/pandora-common/src/validation.ts
+++ b/pandora-common/src/validation.ts
@@ -39,11 +39,11 @@ export function ZodArrayWithInvalidDrop<ZodShape extends ZodTypeAny, ZodPreCheck
 
 export const SCHEME_OVERRIDE = Symbol('SCHEME_OVERRIDE');
 
-export interface ZodOverridableType<Output = undefined, Def extends ZodTypeDef = ZodTypeDef, Input = Output> extends ZodEffects<ZodType<Output, Def, Input>, Output, Input> {
+export interface ZodOverridableType<Output, Def extends ZodTypeDef = ZodTypeDef, Input = Output> extends ZodEffects<ZodType<Output, Def, Input>, Output, Input> {
 	[SCHEME_OVERRIDE]: ((attachedValidation: ((arg: Output, ctx: RefinementCtx) => void)) => void);
 }
 
-export function ZodOverridable<Output = undefined, Def extends ZodTypeDef = ZodTypeDef, Input = Output>(schema: ZodType<Output, Def, Input>): ZodOverridableType<Output, Def, Input> {
+export function ZodOverridable<Output, Def extends ZodTypeDef = ZodTypeDef, Input = Output>(schema: ZodType<Output, Def, Input>): ZodOverridableType<Output, Def, Input> {
 	let attachedValidation: ((arg: Output, ctx: RefinementCtx) => void) | undefined;
 	const refined = schema.superRefine((arg, ctx) => attachedValidation?.(arg, ctx)) as ZodOverridableType<Output, Def, Input>;
 	refined[SCHEME_OVERRIDE] = (fn) => attachedValidation = fn;


### PR DESCRIPTION
Adds new legs state enum:
```ts
export const LegsPoseSchema = z.enum(['standing', 'sitting', 'kneeling']);
export type LegsPose = z.infer<typeof LegsPoseSchema>;
```

add new atomic conditions for legs and view

fake bones are removed at the end, they are required to make it easier to create atomic commits and reduce the size of them

Draft until:
 - ~~#325 is merged (since this will have some conflicts and I didn't include some changes due to that)~~
 - ~~the respective assets repo PR is made~~
