### PR TITLE
[CHORE] Remove unused `engine.io-client` dependency

### DIFF
--- a/pandora-client-web/package.json
+++ b/pandora-client-web/package.json
@@ -26,7 +26,6 @@
 		"classnames": "2.3.2",
 		"client-zip": "2.4.3",
 		"delaunator": "5.0.0",
-		"engine.io-client": "6.4.0",
 		"history": "5.3.0",
 		"immer": "10.0.2",
 		"lodash": "4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,9 +40,6 @@ importers:
       delaunator:
         specifier: 5.0.0
         version: 5.0.0
-      engine.io-client:
-        specifier: 6.4.0
-        version: 6.4.0
       history:
         specifier: 5.3.0
         version: 5.3.0
@@ -6772,6 +6769,16 @@ packages:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
     dev: true
 
+  /follow-redirects@1.15.2:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: true
+
   /follow-redirects@1.15.2(debug@4.3.4):
     resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
     engines: {node: '>=4.0'}
@@ -6782,6 +6789,7 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.4
+    dev: false
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -7202,7 +7210,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.2(debug@4.3.4)
+      follow-redirects: 1.15.2
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
This dependency seems to have been added during pnpm migration (#88), because tests were failing without it.
When I tested this after removing the dependency, it doesn't seem to be the case anymore. I'm not sure what exactly changed, as socket.io doesn't seem to have changed how it depends on engine.io, however we did have a major update of pnpm and some configuration changes for it, so that is most likely cause in my opinion.