### PR TITLE
[FEATURE] links in chat messages

### DIFF
--- a/pandora-client-web/src/components/chatroom/chat.tsx
+++ b/pandora-client-web/src/components/chatroom/chat.tsx
@@ -89,7 +89,7 @@ function DisplayUserMessage({ message, playerId }: { message: IChatRoomMessageCh
 				<DisplayInfo message={ message } />
 				{ before }
 				<DisplayName message={ message } color={ message.from.labelColor } />
-				{...message.parts.map((c, i) => RenderChatPart(c, i))}
+				{...message.parts.map((c, i) => RenderChatPart(c, i, message.type === 'ooc'))}
 				{ after }
 			</div>
 			{ self ? (
@@ -249,13 +249,13 @@ function ActionMessage({ message }: { message: IChatroomMessageProcessed<IChatRo
 		<div className={ classNames('message', message.type, extraContent !== null ? 'foldable' : null) } style={ style } onClick={ () => setFolded(!folded) }>
 			<DisplayInfo message={ message } />
 			{ extraContent != null ? (folded ? '\u25ba ' : '\u25bc ') : null }
-			{ content.map((c, i) => RenderChatPart(c, i)) }
+			{ content.map((c, i) => RenderChatPart(c, i, false)) }
 			{ extraContent != null && folded ? ' ( ... )' : null }
 			{
 				!folded && extraContent != null && (
 					<>
 						<br />
-						{ extraContent.map((c, i) => RenderChatPart(c, i)) }
+						{ extraContent.map((c, i) => RenderChatPart(c, i, false)) }
 					</>
 				)
 			}

--- a/pandora-client-web/src/components/chatroom/chatParser.ts
+++ b/pandora-client-web/src/components/chatroom/chatParser.ts
@@ -35,7 +35,7 @@ export class LineParser {
 		while (text) {
 			const [type, inner, next] = this._parseOne(text, allowNonTargeted);
 			if (type)
-				result.push([type, inner ?? '']);
+				result.push([type, inner?.trim() ?? '']);
 
 			text = next ?? '';
 		}
@@ -91,7 +91,7 @@ export class SegmentParser {
 	];
 
 	public parse(text: string): IChatSegment[] {
-
+		text = text.trim();
 		const result: IChatSegment[] = [];
 		while (text) {
 			const [modifier, inner, next] = this._parseOne(text);

--- a/pandora-client-web/src/components/chatroom/chatParser.ts
+++ b/pandora-client-web/src/components/chatroom/chatParser.ts
@@ -56,10 +56,11 @@ export class LineParser {
 
 			if (text.startsWith(start)) {
 				const [index, inner] = IndexOf(text, lineEnd);
+				const idx = type === 'link' ? 0 : start.length;
 				if (index === -1)
-					return [type, inner.substring(start.length).replace(replace, '')];
+					return [type, inner.substring(idx).replace(replace, '')];
 
-				return [type, inner.substring(start.length, index).replace(replace, ''), inner.substring(index + lineEnd.length)];
+				return [type, inner.substring(idx, index).replace(replace, ''), inner.substring(index + lineEnd.length)];
 			}
 
 			if (text.startsWith(ESCAPE + start)) {

--- a/pandora-client-web/src/components/chatroom/chatroom.scss
+++ b/pandora-client-web/src/components/chatroom/chatroom.scss
@@ -127,6 +127,15 @@
 			font-size: 0.6em;
 			margin-right: 0.2em;
 		}
+
+		a {
+			color: $white;
+			text-decoration: underline;
+
+			&:hover {
+				color: $grey-mid;
+			}
+		}
 	}
 
 	textarea {

--- a/pandora-client-web/src/components/chatroom/chatroomMessages.tsx
+++ b/pandora-client-web/src/components/chatroom/chatroomMessages.tsx
@@ -124,7 +124,14 @@ export function DescribeAssetSlot(assetManager: AssetManagerClient, slot: string
 	return slotDefinition?.description ?? `[UNKNOWN SLOT '${slot}']`;
 }
 
-export function RenderChatPart([type, contents]: IChatSegment, index: number): ReactElement {
+export function RenderChatPart([type, contents]: IChatSegment, index: number, allowLinkInNormal: boolean): ReactElement {
+	if (type === 'normal' && allowLinkInNormal && contents.match(/^https?:\/\//)) {
+		return (
+			<a key={ index } href={ contents } target='_blank' referrerPolicy='no-referrer' rel='noopener noreferrer'>
+				{ contents }
+			</a>
+		)
+	}
 	switch (type) {
 		case 'normal':
 			return <span key={ index }>{ contents }</span>;

--- a/pandora-client-web/src/components/directMessage/directMessage.tsx
+++ b/pandora-client-web/src/components/directMessage/directMessage.tsx
@@ -72,7 +72,7 @@ function DirectMessageElement({ message, channel, account }: { message: DirectMe
 			</span>
 			{ ': ' }
 			<span className='direct-message-entry__content'>
-				{...message.message.map((c, i) => RenderChatPart(c, i))}
+				{...message.message.map((c, i) => RenderChatPart(c, i, true))}
 			</span>
 		</div>
 	);

--- a/pandora-client-web/src/components/gameContext/chatRoomContextProvider.tsx
+++ b/pandora-client-web/src/components/gameContext/chatRoomContextProvider.tsx
@@ -364,7 +364,7 @@ export class ChatRoom extends TypedEventEmitter<RoomInventoryEvents & {
 		}
 		let messages: IClientMessage[] = [];
 		if (type !== undefined) {
-			messages = [{ type, parts: raw ? [['normal', message]] : ChatParser.parseStyle(message), to: target }];
+			messages = [{ type, parts: raw ? [['normal', message]] : ChatParser.parseStyle(message, type === 'ooc'), to: target }];
 		} else if (raw) {
 			throw new Error('Raw is not implemented for multi-part messages');
 		} else {

--- a/pandora-client-web/src/networking/directMessageManager.ts
+++ b/pandora-client-web/src/networking/directMessageManager.ts
@@ -273,7 +273,7 @@ export class DirectMessageChannel {
 		}
 		return {
 			time,
-			message: ChatParser.parseStyle(await this.#encryption.decrypt(content)),
+			message: ChatParser.parseStyle(await this.#encryption.decrypt(content), true),
 			sent: source !== this._id,
 			edited,
 		};
@@ -295,7 +295,7 @@ export class DirectMessageChannel {
 				...begin,
 				{
 					time,
-					message: ChatParser.parseStyle(message),
+					message: ChatParser.parseStyle(message, true),
 					sent,
 					edited,
 				},
@@ -305,7 +305,7 @@ export class DirectMessageChannel {
 		}
 		this._messages.value = [...this.messages.value, {
 			time,
-			message: ChatParser.parseStyle(message),
+			message: ChatParser.parseStyle(message, true),
 			sent,
 			edited,
 		}];


### PR DESCRIPTION
parse `http://` and `https://` as raw occ messages, automatically parse as raw when inside ooc
parse links inside raw ooc messages and display them in an anchor element