### PR TITLE
[CHANGE] Cleanup contacts list, add online indicator

### DIFF
--- a/pandora-client-web/src/components/chatroom/contextMenus/characterContextMenu.tsx
+++ b/pandora-client-web/src/components/chatroom/contextMenus/characterContextMenu.tsx
@@ -10,7 +10,7 @@ import { usePlayerId } from '../../gameContext/playerContextProvider';
 import { useChatInput } from '../chatInput';
 import { toast } from 'react-toastify';
 import { TOAST_OPTIONS_ERROR } from '../../../persistentToast';
-import { HandleResult, useRelationship } from '../../releationships/relationships';
+import { RelationshipChangeHandleResult, useRelationship } from '../../releationships/relationshipsContext';
 
 type MenuType = 'main' | 'admin' | 'relationship';
 
@@ -122,7 +122,7 @@ function FriendRequestMenu({ action, text }: { action: 'initiate' | 'accept' | '
 	const request = useCallback(() => {
 		if (confirm(`Are you sure you want to ${action} adding the account behind ${character.data.name} to your contacts list?`)) {
 			directory.awaitResponse('friendRequest', { action, id: character.data.accountId })
-				.then(({ result }) => HandleResult(result))
+				.then(({ result }) => RelationshipChangeHandleResult(result))
 				.catch((err) => toast(err instanceof Error ? err.message : 'An unknown error occurred', TOAST_OPTIONS_ERROR));
 		}
 	}, [action, character, directory]);
@@ -141,7 +141,7 @@ function UnfriendRequestMenu(): ReactElement {
 	const request = useCallback(() => {
 		if (confirm(`Are you sure you want to remove the account behind ${character.data.name} from your contacts list?`)) {
 			directory.awaitResponse('unfriend', { id: character.data.accountId })
-				.then(({ result }) => HandleResult(result))
+				.then(({ result }) => RelationshipChangeHandleResult(result))
 				.catch((err) => toast(err instanceof Error ? err.message : 'An unknown error occurred', TOAST_OPTIONS_ERROR));
 		}
 	}, [character, directory]);

--- a/pandora-client-web/src/components/chatroomAdmin/chatroomAdmin.tsx
+++ b/pandora-client-web/src/components/chatroomAdmin/chatroomAdmin.tsx
@@ -366,7 +366,7 @@ export function ChatroomAdmin({ creation = false }: { creation?: boolean; } = {}
 	return (
 		<div className='roomAdminScreen configuration'>
 			<Link to='/chatroom'>◄ Back</Link>
-			<p>Current room ID: <span className='selectable'>{ roomInfo.id }</span></p>
+			<p>Current room ID: <span className='selectable-all'>{ roomInfo.id }</span></p>
 			{ configurableElements }
 			<div className='input-container'>
 				<label>Features (cannot be changed after creation)</label>

--- a/pandora-client-web/src/components/header/Header.tsx
+++ b/pandora-client-web/src/components/header/Header.tsx
@@ -18,7 +18,7 @@ import { TOAST_OPTIONS_ERROR } from '../../persistentToast';
 import { DirectMessageChannel } from '../../networking/directMessageManager';
 import { useCharacterSafemode } from '../../character/character';
 import { useSafemodeDialogContext } from '../characterSafemode/characterSafemode';
-import { RelationshipContext, useRelationships } from '../releationships/relationships';
+import { RelationshipContext, useRelationships } from '../releationships/relationshipsContext';
 import { useObservable } from '../../observable';
 import { LeaveButton } from './leaveButton';
 

--- a/pandora-client-web/src/components/releationships/relationships.scss
+++ b/pandora-client-web/src/components/releationships/relationships.scss
@@ -18,7 +18,7 @@
 
 	td,
 	th {
-		padding: 0.2em;
+		padding: 0.2em 0.5em;
 		text-align: center;
 		border: 1px solid $grey-darker;
 	}
@@ -33,5 +33,29 @@
 
 	tr:nth-child(2n) {
 		background-color: $grey-lighter;
+	}
+
+	.friend {
+		.status .indicator {
+			font-size: x-large;
+		}
+
+		&.online {
+			.status .indicator {
+				color: #080;
+			}
+		}
+
+		&.offline {
+			.status {
+				font-style: italic;
+
+				.indicator {
+					color: #444;
+					font-style: normal;
+				}
+			}
+
+		}
 	}
 }

--- a/pandora-client-web/src/components/releationships/relationshipsContext.ts
+++ b/pandora-client-web/src/components/releationships/relationshipsContext.ts
@@ -4,7 +4,6 @@ import { Observable, useObservable } from '../../observable';
 import './relationships.scss';
 import { toast } from 'react-toastify';
 import { TOAST_OPTIONS_ERROR } from '../../persistentToast';
-import _ from 'lodash';
 
 const RELATIONSHIPS = new Observable<readonly IAccountRelationship[]>([]);
 const FRIEND_STATUS = new Observable<readonly IAccountFriendStatus[]>([]);

--- a/pandora-client-web/src/components/releationships/relationshipsContext.ts
+++ b/pandora-client-web/src/components/releationships/relationshipsContext.ts
@@ -1,0 +1,115 @@
+import { useMemo } from 'react';
+import { AccountId, AsyncSynchronized, IAccountFriendStatus, IAccountRelationship, IClientDirectory, IConnectionBase, IDirectoryClientArgument, TypedEventEmitter } from 'pandora-common';
+import { Observable, useObservable } from '../../observable';
+import './relationships.scss';
+import { toast } from 'react-toastify';
+import { TOAST_OPTIONS_ERROR } from '../../persistentToast';
+import _ from 'lodash';
+
+const RELATIONSHIPS = new Observable<readonly IAccountRelationship[]>([]);
+const FRIEND_STATUS = new Observable<readonly IAccountFriendStatus[]>([]);
+
+export function useRelationships(type: IAccountRelationship['type']) {
+	const rel = useObservable(RELATIONSHIPS);
+	return useMemo(() => rel.filter((r) => r.type === type), [rel, type]);
+}
+
+export function useRelationship(id: AccountId): IAccountRelationship | undefined {
+	const rel = useObservable(RELATIONSHIPS);
+	return useMemo(() => rel.find((r) => r.id === id), [rel, id]);
+}
+
+export function useFriendStatus() {
+	return useObservable(FRIEND_STATUS);
+}
+
+export const RelationshipContext = new class RelationshipContext extends TypedEventEmitter<{
+	incoming: IAccountRelationship & { type: 'incoming'; };
+}> {
+	private _queue: (() => void)[] = [];
+	private _useQueue = true;
+
+	@AsyncSynchronized()
+	public async initStatus(connection: IConnectionBase<IClientDirectory>): Promise<void> {
+		if (!this._useQueue) {
+			return;
+		}
+		const { friends, relationships } = await connection.awaitResponse('getRelationships', {});
+		RELATIONSHIPS.value = relationships;
+		FRIEND_STATUS.value = friends;
+		this._dequeue();
+	}
+
+	public handleFriendStatus(data: IDirectoryClientArgument['friendStatus']) {
+		if (this._useQueue) {
+			this._queue.push(() => this.handleFriendStatus(data));
+			return;
+		}
+		const filtered = FRIEND_STATUS.value.filter((status) => status.id !== data.id);
+		if (data.online !== 'delete') {
+			filtered.push(data);
+		}
+		FRIEND_STATUS.value = filtered;
+	}
+
+	public handleRelationshipsUpdate({ relationship, friendStatus }: IDirectoryClientArgument['relationshipsUpdate']) {
+		if (this._useQueue) {
+			this._queue.push(() => this.handleRelationshipsUpdate({ relationship, friendStatus }));
+			return;
+		}
+		// Update relationship side
+		{
+			const filtered = RELATIONSHIPS.value.filter((currentRelationship) => currentRelationship.id !== relationship.id);
+			if (relationship.type !== 'none') {
+				filtered.push(relationship);
+				if (filtered.length > RELATIONSHIPS.value.length && relationship.type === 'incoming') {
+					this.emit('incoming', { ...relationship, type: 'incoming' });
+				}
+			}
+			RELATIONSHIPS.value = filtered;
+		}
+		// Update friend side
+		{
+			const filtered = FRIEND_STATUS.value.filter((status) => status.id !== friendStatus.id);
+			if (friendStatus.online !== 'delete') {
+				filtered.push(friendStatus);
+			}
+			FRIEND_STATUS.value = filtered;
+		}
+	}
+
+	public handleLogout() {
+		this._useQueue = true;
+		FRIEND_STATUS.value = [];
+		RELATIONSHIPS.value = [];
+	}
+
+	private _dequeue() {
+		this._useQueue = false;
+		this._queue.forEach((fn) => fn());
+		this._queue = [];
+	}
+};
+
+export function RelationshipChangeHandleResult(result: 'ok' | 'accountNotFound' | 'requestNotFound' | 'blocked' | 'requestAlreadyExists' | undefined) {
+	switch (result) {
+		case undefined:
+		case 'ok':
+			return;
+		case 'accountNotFound':
+			toast('Account not found', TOAST_OPTIONS_ERROR);
+			return;
+		case 'requestNotFound':
+			toast('Request not found', TOAST_OPTIONS_ERROR);
+			return;
+		case 'blocked':
+			toast('Account is blocked', TOAST_OPTIONS_ERROR);
+			return;
+		case 'requestAlreadyExists':
+			toast('Request already exists', TOAST_OPTIONS_ERROR);
+			return;
+		default:
+			toast('Unknown error', TOAST_OPTIONS_ERROR);
+			return;
+	}
+}

--- a/pandora-client-web/src/index.scss
+++ b/pandora-client-web/src/index.scss
@@ -20,10 +20,6 @@ html, body {
 	user-select: none;
 }
 
-.selectable {
-	user-select: all;
-}
-
 div.main {
 	@include flex(column);
 	background-color: $grey-light;

--- a/pandora-client-web/src/networking/socketio_directory_connector.ts
+++ b/pandora-client-web/src/networking/socketio_directory_connector.ts
@@ -21,7 +21,7 @@ import {
 import { SocketInterfaceRequest, SocketInterfaceResponse } from 'pandora-common/dist/networking/helpers';
 import { connect, Socket } from 'socket.io-client';
 import { BrowserStorage } from '../browserStorage';
-import { RelationshipContext } from '../components/releationships/relationships';
+import { RelationshipContext } from '../components/releationships/relationshipsContext';
 import { PrehashPassword } from '../crypto/helpers';
 import { Observable, ReadonlyObservable } from '../observable';
 import { PersistentToast } from '../persistentToast';

--- a/pandora-client-web/src/styles/globalUtils.scss
+++ b/pandora-client-web/src/styles/globalUtils.scss
@@ -103,3 +103,15 @@
 }
 
 //#endregion
+
+//#region Misc
+
+.selectable {
+	user-select: text;
+}
+
+.selectable-all {
+	user-select: all;
+}
+
+//#endregion


### PR DESCRIPTION
This PR does following changes:
- Splits `relationships.tsx` file into this and context file, so UI can be changed without whole page reloading (no changes to the context code, except rename of one function)
- Cleanups style of contacts list by sorting columns differently and making some smaller
- Renames column "Created" to "Since" and only shows date instead of date and time
- Adds a green or empty dot next to "Online" or "Offline", respectively, for quicker orientation; also makes the Offline text into italics 