### PR TITLE
[DEV] Fix: Use PR author for checking

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,13 +41,13 @@ jobs:
 
     steps:
       - name: Auto-approve (Lead Developer)
-        if: contains(fromJSON('["ace-1331", "ClaudiaMia", "elliesec", "Jomshir98", "Sekkmer"]'), github.actor)
+        if: contains(fromJSON('["ace-1331", "ClaudiaMia", "elliesec", "Jomshir98", "Sekkmer"]'), github.event.pull_request.user.login)
         uses: hmarr/auto-approve-action@v3
         with:
           review-message: "PR is from a Lead Developer."
 
       - name: Auto-approve (Renovate)
-        if: github.actor == 'renovate[bot]'
+        if: github.event.pull_request.user.login == 'renovate[bot]'
         uses: hmarr/auto-approve-action@v3
         with:
-          review-message: "Automated dependency updates only need a single review."
+          review-message: "Automated dependency update."

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,4 @@
 name: PR
-concurrency: automation
 
 on:
   # Triggers the workflow on any pull request (but runs in context of target branch, having a bit higher rights)
@@ -36,6 +35,7 @@ jobs:
   automation:
     name: Automation tasks
     runs-on: ubuntu-latest
+    concurrency: automation
     permissions:
       pull-requests: write
 


### PR DESCRIPTION
This fixies issue with auto-approves that appeared in #196.
Before this fix the login of person triggering the event was used to check - this meant that if, for example, lead dev added a label or changed PR name, then the approve would trigger.
This PR changes this to use login of person that authored the PR (hopefully, the docs aren't the best, but testing on personal repo makes it seem like that is the case)
Also fixes problem where concurrency could cause PR title check to fail.