### PR TITLE
[DEV] Improve webpack watch detection, show progress

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -92,7 +92,7 @@
 		{
 			"label": "pandora-client-web: dev",
 			"type": "npm",
-			"script": "dev",
+			"script": "dev:progress",
 			"path": "pandora-client-web",
 			"dependsOn": [
 				"pandora-common: dev"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -129,8 +129,8 @@
 				],
 				"background": {
 					"activeOnStart": true,
-					"beginsPattern": "^assets by ",
-					"endsPattern": "webpack [\\d.]+ compiled .+ in \\d+ ms"
+					"beginsPattern": "Compiler starting\\.\\.\\.",
+					"endsPattern": "(webpack [\\d.]+ compiled .+ in \\d+ ms)|(Compiler is watching files for update\\.\\.\\.)"
 				}
 			}
 		},

--- a/pandora-client-web/package.json
+++ b/pandora-client-web/package.json
@@ -7,7 +7,7 @@
 	"scripts": {
 		"clean": "rimraf dist",
 		"build": "pnpm run --silent clean && cross-env TS_NODE_PROJECT=\"tsconfig.webpack.json\" webpack --env prod --fail-on-warnings",
-		"dev": "pnpm run --silent clean && cross-env TS_NODE_PROJECT=\"tsconfig.webpack.json\" webpack serve",
+		"dev": "pnpm run --silent clean && cross-env TS_NODE_PROJECT=\"tsconfig.webpack.json\" webpack serve --progress",
 		"lint": "eslint --max-warnings 0 --report-unused-disable-directives .",
 		"lint:fix": "eslint --fix .",
 		"type-check": "pnpm run '/type-check:.*/'",

--- a/pandora-client-web/package.json
+++ b/pandora-client-web/package.json
@@ -7,7 +7,8 @@
 	"scripts": {
 		"clean": "rimraf dist",
 		"build": "pnpm run --silent clean && cross-env TS_NODE_PROJECT=\"tsconfig.webpack.json\" webpack --env prod --fail-on-warnings",
-		"dev": "pnpm run --silent clean && cross-env TS_NODE_PROJECT=\"tsconfig.webpack.json\" webpack serve --progress",
+		"dev": "pnpm run --silent clean && cross-env TS_NODE_PROJECT=\"tsconfig.webpack.json\" webpack serve",
+		"dev:progress": "pnpm run --silent dev --progress",
 		"lint": "eslint --max-warnings 0 --report-unused-disable-directives .",
 		"lint:fix": "eslint --fix .",
 		"type-check": "pnpm run '/type-check:.*/'",

--- a/pandora-client-web/webpack.config.ts
+++ b/pandora-client-web/webpack.config.ts
@@ -90,6 +90,9 @@ export default function (env: WebpackEnv): Configuration {
 			maxAssetSize: 2 * 1024 * 1024,
 			maxEntrypointSize: 2 * 1024 * 1024,
 		},
+		infrastructureLogging: {
+			level: 'log',
+		},
 	};
 }
 


### PR DESCRIPTION
This PR configures webpack to show messages about compilation starting and finishing to let VSCode properly detect state of compilation in the background task. This is necessary to avoid showing stale errors from previous compilation when they were fixed.
Also makes Webpack show progress in VSCode to be more interactive.