### PR TITLE
[CHANGE] Rework pose enforcement into requested and actual poses

### DIFF
--- a/pandora-client-web/src/assets/appearanceValidation.ts
+++ b/pandora-client-web/src/assets/appearanceValidation.ts
@@ -111,8 +111,6 @@ export function RenderAppearanceActionResult(assetManager: AssetManagerClient, r
 			}
 			case 'poseConflict':
 				return `This item requires a pose conflicting with the added items.`;
-			case 'invalidPose':
-				return `This action results in an invalid pose.`;
 			case 'tooManyItems':
 				return e.asset ?
 					`At most ${e.limit} "${DescribeAsset(assetManager, e.asset)}" can be equipped.` :

--- a/pandora-client-web/src/assets/appearanceValidation.ts
+++ b/pandora-client-web/src/assets/appearanceValidation.ts
@@ -79,8 +79,6 @@ export function RenderAppearanceActionResult(assetManager: AssetManagerClient, r
 				return `The ${DescribeAsset(assetManager, e.asset)} cannot be added, removed, or modified, because ${DescribeAssetSlot(assetManager, e.slot)} is covered by another item.`;
 			case 'blockedHands':
 				return `You need to be able to use hands to do this.`;
-			case 'exitPose':
-				return `You cannot assume the pose required to exit the ${DescribeAsset(assetManager, e.asset)}.`;
 			case 'invalid':
 				return '';
 		}

--- a/pandora-client-web/src/character/character.ts
+++ b/pandora-client-web/src/character/character.ts
@@ -1,8 +1,6 @@
 import {
 	TypedEventEmitter,
 	CharacterAppearance,
-	BoneState,
-	CharacterView,
 	GetLogger,
 	ICharacterPublicData,
 	Item,
@@ -12,7 +10,6 @@ import {
 	ItemPath,
 	SafemodeData,
 	CharacterId,
-	CharacterArmsPose,
 	AppearanceItems,
 	WearableAssetType,
 	AssetFrameworkCharacterState,
@@ -101,18 +98,6 @@ export function useCharacterAppearanceItem(characterState: AssetFrameworkCharact
 	const items = useCharacterAppearanceItems(characterState);
 
 	return useMemo(() => (items && path) ? EvalItemPath(items, path) : undefined, [items, path]);
-}
-
-export function useCharacterAppearancePose(characterState: AssetFrameworkCharacterState): readonly BoneState[] {
-	return useMemo(() => Array.from(characterState.pose.values()), [characterState.pose]);
-}
-
-export function useCharacterAppearanceArmsPose(characterState: AssetFrameworkCharacterState): CharacterArmsPose {
-	return characterState.arms;
-}
-
-export function useCharacterAppearanceView(characterState: AssetFrameworkCharacterState): CharacterView {
-	return characterState.view;
 }
 
 export function useCharacterSafemode(characterState: AssetFrameworkCharacterState): Readonly<SafemodeData> | null {

--- a/pandora-client-web/src/common/useDebounceValue.ts
+++ b/pandora-client-web/src/common/useDebounceValue.ts
@@ -1,0 +1,14 @@
+import _ from 'lodash';
+import { useEffect, useMemo, useState } from 'react';
+
+export function useDebouncedValue<T>(value: T, wait: number): T {
+	const [debouncedValue, setDebouncedValue] = useState(value);
+
+	const update = useMemo(() => _.debounce(setDebouncedValue, wait), [wait]);
+
+	useEffect(() => {
+		update(value);
+	}, [update, value]);
+
+	return debouncedValue;
+}

--- a/pandora-client-web/src/common/useRemotelyUpdatedUserInput.ts
+++ b/pandora-client-web/src/common/useRemotelyUpdatedUserInput.ts
@@ -1,0 +1,64 @@
+import { DependencyList, useEffect, useRef, useState } from 'react';
+import { useEvent } from './useEvent';
+
+export interface RemotelyUpdatedUserInputOptions<T extends string | number | boolean | undefined | null> {
+	/**
+	 * Time without input after which the input resets to the remote value.
+	 * @default 1000
+	 */
+	resetTimer?: number;
+	updateCallback?: (newValue: T) => void;
+}
+
+export function useRemotelyUpdatedUserInput<T extends string | number | boolean | undefined | null>(
+	originalValue: T,
+	deps: DependencyList = [],
+	{
+		resetTimer = 1000,
+		updateCallback,
+	}: RemotelyUpdatedUserInputOptions<T> = {},
+): [T, (newValue: T) => void] {
+	const [value, setValue] = useState(originalValue);
+	const lastSetValue = useRef(originalValue);
+	const shouldUpdate = useRef(true);
+	const resetTimeout = useRef<null | number>(null);
+
+	const resetValue = useEvent(() => {
+		if (resetTimeout.current != null) {
+			clearTimeout(resetTimeout.current);
+			resetTimeout.current = null;
+		}
+		shouldUpdate.current = true;
+		setValue(originalValue);
+	});
+
+	useEffect(() => {
+		resetValue();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, deps);
+
+	useEffect(() => {
+		if (originalValue === lastSetValue.current) {
+			shouldUpdate.current = true;
+		} else if (shouldUpdate.current) {
+			lastSetValue.current = originalValue;
+			setValue(originalValue);
+		}
+	}, [originalValue]);
+
+	const updateValue = useEvent((newValue: T) => {
+		shouldUpdate.current = originalValue === newValue;
+		lastSetValue.current = newValue;
+		if (resetTimeout.current != null) {
+			clearTimeout(resetTimeout.current);
+			resetTimeout.current = null;
+		}
+		if (!shouldUpdate.current) {
+			resetTimeout.current = setTimeout(resetValue, resetTimer);
+		}
+		setValue(newValue);
+		updateCallback?.(newValue);
+	});
+
+	return [value, updateValue];
+}

--- a/pandora-client-web/src/components/chatroom/chatRoomCharacter.tsx
+++ b/pandora-client-web/src/components/chatroom/chatRoomCharacter.tsx
@@ -1,7 +1,7 @@
 import { AssetFrameworkCharacterState, CalculateCharacterMaxYForBackground, CharacterRoomPosition, CharacterSize, ICharacterRoomData, IChatroomBackgroundData, IChatRoomFullInfo, LegsPose } from 'pandora-common';
 import PIXI, { DEG_TO_RAD, FederatedPointerEvent, Point, Rectangle, TextStyle } from 'pixi.js';
 import React, { ReactElement, useCallback, useEffect, useMemo, useRef } from 'react';
-import { Character, useCharacterAppearanceView, useCharacterData } from '../../character/character';
+import { Character, useCharacterData } from '../../character/character';
 import { ShardConnector } from '../../networking/shardConnector';
 import _ from 'lodash';
 import { ChatroomDebugConfig } from './chatroomDebug';
@@ -55,7 +55,7 @@ export function useChatRoomCharacterOffsets(characterState: AssetFrameworkCharac
 	const evaluator = useAppearanceConditionEvaluator(characterState);
 
 	let baseScale = 1;
-	if (evaluator.legs === 'sitting') {
+	if (evaluator.pose.legs === 'sitting') {
 		baseScale *= 0.9;
 	}
 
@@ -64,9 +64,9 @@ export function useChatRoomCharacterOffsets(characterState: AssetFrameworkCharac
 		sitting: 0,
 		kneeling: 300,
 	};
-	const legEffectCharacterOffsetBase = evaluator.legs === 'sitting' ? 135 : legEffectMap.standing;
-	const legEffect = legEffectMap[evaluator.legs]
-		+ (evaluator.legs !== 'kneeling' ? 0.2 : 0) * evaluator.getBoneLikeValue('tiptoeing');
+	const legEffectCharacterOffsetBase = evaluator.pose.legs === 'sitting' ? 135 : legEffectMap.standing;
+	const legEffect = legEffectMap[evaluator.pose.legs]
+		+ (evaluator.pose.legs !== 'kneeling' ? 0.2 : 0) * evaluator.getBoneLikeValue('tiptoeing');
 
 	const effectiveLegAngle = Math.min(Math.abs(evaluator.getBoneLikeValue('leg_l')), Math.abs(evaluator.getBoneLikeValue('leg_r')), 90);
 
@@ -192,7 +192,7 @@ function ChatRoomCharacterDisplay({
 
 	const setPositionThrottled = useMemo(() => _.throttle(setPositionRaw, 100), [setPositionRaw]);
 
-	const backView = useCharacterAppearanceView(characterState) === 'back';
+	const backView = characterState.actualPose.view === 'back';
 
 	const scaleX = backView ? -1 : 1;
 

--- a/pandora-client-web/src/components/chatroom/chatRoomDevice.tsx
+++ b/pandora-client-web/src/components/chatroom/chatRoomDevice.tsx
@@ -13,7 +13,7 @@ import { Immutable } from 'immer';
 import { useAsyncEvent, useEvent } from '../../common/useEvent';
 import _ from 'lodash';
 import { ShardConnector } from '../../networking/shardConnector';
-import { Character, useCharacterAppearanceView } from '../../character/character';
+import { Character } from '../../character/character';
 import { useCharacterRestrictionsManager, useCharacterState, useChatRoomCharacters, useChatroomRequired } from '../gameContext/chatRoomContextProvider';
 import type { FederatedPointerEvent } from 'pixi.js';
 import { z } from 'zod';
@@ -391,7 +391,7 @@ function RoomDeviceGraphicsLayerSlotCharacter({ item, layer, character, characte
 
 	const scale = baseScale * (layer.characterPosition.relativeScale ?? 1);
 
-	const backView = useCharacterAppearanceView(characterState) === 'back';
+	const backView = characterState.actualPose.view === 'back';
 
 	const scaleX = backView ? -1 : 1;
 

--- a/pandora-client-web/src/components/chatroom/commands.ts
+++ b/pandora-client-web/src/components/chatroom/commands.ts
@@ -209,7 +209,7 @@ export const COMMANDS: readonly IClientCommand[] = [
 				shardConnector.awaitResponse('appearanceAction', {
 					type: 'setView',
 					target: player.data.id,
-					view: playerState.view === 'front' ? 'back' : 'front',
+					view: playerState.requestedPose.view === 'front' ? 'back' : 'front',
 				}).catch(() => { /** TODO */ });
 				return true;
 			}),

--- a/pandora-client-web/src/components/chatroomAdmin/chatroomAdmin.scss
+++ b/pandora-client-web/src/components/chatroomAdmin/chatroomAdmin.scss
@@ -126,23 +126,7 @@
 		background-color: $grey-lighter;
 
 		.details {
-			display: flex;
-			flex-flow: column;
-			align-items: center;
-			justify-content: center;
-			padding: 0.3em;
-			border: 2px solid transparent;
-			transition: border-color 150ms linear;
-			border-radius: 0.5em;
 			height: 10em;
-
-			&.selected {
-				border-color: black;
-			}
-
-			&.current:not(.selected) {
-				border-color: #888888aa;
-			}
 
 			.preview {
 				@include center-flex;

--- a/pandora-client-web/src/components/chatroomAdmin/chatroomAdmin.tsx
+++ b/pandora-client-web/src/components/chatroomAdmin/chatroomAdmin.tsx
@@ -35,6 +35,7 @@ import { FieldsetToggle } from '../common/fieldsetToggle';
 import './chatroomAdmin.scss';
 import classNames from 'classnames';
 import { ColorInput } from '../common/colorInput/colorInput';
+import { SelectionIndicator } from '../common/selectionIndicator/selectionIndicator';
 
 const IsChatroomName = ZodMatcher(ChatRoomBaseInfoSchema.shape.name);
 
@@ -579,14 +580,20 @@ function BackgroundSelectDialog({ hide, current, select }: {
 									setSelectedBackground(b.id);
 								} }
 							>
-								<div
-									className={ classNames('details', b.id === selectedBackground && 'selected', b.id === current && 'current') }
+								<SelectionIndicator
+									direction='column'
+									align='center'
+									justify='center'
+									padding='small'
+									selected={ b.id === selectedBackground }
+									active={ b.id === current }
+									className='details'
 								>
 									<div className='preview'>
 										<img src={ GetAssetsSourceUrl() + b.preview } />
 									</div>
 									<div className='name'>{ b.name }</div>
-								</div>
+								</SelectionIndicator>
 							</a>
 						)) }
 				</div>

--- a/pandora-client-web/src/components/common/selectionIndicator/selectionIndicator.scss
+++ b/pandora-client-web/src/components/common/selectionIndicator/selectionIndicator.scss
@@ -1,0 +1,25 @@
+.selectionIndicator {
+	position: relative;
+	margin: 2px;
+	border-radius: 0.5em;
+	outline: solid 2px transparent;
+	transition: outline-color 150ms linear;
+
+	&.selected {
+		outline-color: black;
+	}
+
+	&::before {
+		content: " ";
+		position: absolute;
+		inset: 0px;
+		outline: dashed 2px transparent;
+		border-radius: 0.5em;
+		transition: outline-color 150ms linear;
+		pointer-events: none;
+	}
+
+	&.active:not(.selected)::before {
+		outline-color: black;
+	}
+}

--- a/pandora-client-web/src/components/common/selectionIndicator/selectionIndicator.tsx
+++ b/pandora-client-web/src/components/common/selectionIndicator/selectionIndicator.tsx
@@ -1,0 +1,34 @@
+import React, { ReactElement } from 'react';
+import './selectionIndicator.scss';
+import { DivContainer, DivContainerProps } from '../container/container';
+import classNames from 'classnames';
+
+export interface SelectionIndicatorProps extends DivContainerProps {
+	/** @default false */
+	selected?: boolean;
+	/** @default false */
+	active?: boolean;
+}
+
+export function SelectionIndicator({
+	selected = false,
+	active = false,
+	children,
+	className,
+	...divContainerProps
+}: SelectionIndicatorProps): ReactElement {
+	return (
+		<DivContainer
+			padding='tiny'
+			{ ...divContainerProps }
+			className={ classNames(
+				'selectionIndicator',
+				selected ? 'selected' : null,
+				active ? 'active' : null,
+				className,
+			) }
+		>
+			{ children }
+		</DivContainer>
+	);
+}

--- a/pandora-client-web/src/components/wardrobe/views/wardrobeBodySizeView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobeBodySizeView.tsx
@@ -3,7 +3,7 @@ import {
 	BoneName,
 } from 'pandora-common';
 import React, { ReactElement, useCallback, useMemo } from 'react';
-import { ICharacter, useCharacterAppearancePose } from '../../../character/character';
+import { ICharacter } from '../../../character/character';
 import _ from 'lodash';
 import { useWardrobeExecuteCallback } from '../wardrobeContext';
 import { BoneRowElement } from './wardrobePoseView';
@@ -13,7 +13,8 @@ export function WardrobeBodySizeEditor({ character, characterState }: {
 	characterState: AssetFrameworkCharacterState;
 }): ReactElement {
 	const [execute] = useWardrobeExecuteCallback();
-	const currentBones = useCharacterAppearancePose(characterState);
+	const assetManager = characterState.assetManager;
+	const allBones = useMemo(() => assetManager.getAllBones(), [assetManager]);
 
 	const setBodyDirect = useCallback(({ bones }: { bones: Record<BoneName, number>; }) => {
 		execute({
@@ -29,13 +30,13 @@ export function WardrobeBodySizeEditor({ character, characterState }: {
 		<div className='inventoryView'>
 			<div className='bone-ui'>
 				{
-					currentBones
-						.filter((bone) => bone.definition.type === 'body')
+					allBones
+						.filter((bone) => bone.type === 'body')
 						.map((bone) => (
-							<BoneRowElement key={ bone.definition.name } bone={ bone } onChange={ (value) => {
+							<BoneRowElement key={ bone.name } definition={ bone } rotation={ characterState.requestedPose.bones[bone.name] || 0 } onChange={ (value) => {
 								setBody({
 									bones: {
-										[bone.definition.name]: value,
+										[bone.name]: value,
 									},
 								});
 							} } />

--- a/pandora-client-web/src/components/wardrobe/views/wardrobeBodySizeView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobeBodySizeView.tsx
@@ -33,7 +33,7 @@ export function WardrobeBodySizeEditor({ character, characterState }: {
 					allBones
 						.filter((bone) => bone.type === 'body')
 						.map((bone) => (
-							<BoneRowElement key={ bone.name } definition={ bone } rotation={ characterState.requestedPose.bones[bone.name] || 0 } onChange={ (value) => {
+							<BoneRowElement key={ bone.name } definition={ bone } characterState={ characterState } onChange={ (value) => {
 								setBody({
 									bones: {
 										[bone.name]: value,

--- a/pandora-client-web/src/components/wardrobe/views/wardrobePoseView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobePoseView.tsx
@@ -287,7 +287,7 @@ export function WardrobePoseGui({ character, characterState }: {
 	const assetManager = characterState.assetManager;
 	const allBones = useMemo(() => assetManager.getAllBones(), [assetManager]);
 
-	const setPoseDirect = useEvent(({ bones, arms, leftArm, rightArm, legs }: PartialAppearancePose) => {
+	const setPoseDirect = useEvent(({ bones, arms, leftArm, rightArm, legs, view }: PartialAppearancePose) => {
 		execute({
 			type: 'pose',
 			target: character.id,
@@ -295,6 +295,7 @@ export function WardrobePoseGui({ character, characterState }: {
 			leftArm: { ...arms, ...leftArm },
 			rightArm: { ...arms, ...rightArm },
 			legs,
+			view,
 		});
 	});
 

--- a/pandora-client-web/src/components/wardrobe/views/wardrobePoseView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobePoseView.tsx
@@ -29,6 +29,7 @@ import { useCharacterIsInChatroom } from '../../gameContext/chatRoomContextProvi
 import { Row } from '../../common/container/container';
 import { useShardConnector } from '../../gameContext/shardConnectorContextProvider';
 import { useUpdatedUserInput } from '../../../common/useSyncUserInput';
+import { SelectionIndicator } from '../../common/selectionIndicator/selectionIndicator';
 
 type CheckedPosePreset = {
 	active: boolean;
@@ -348,13 +349,13 @@ export function WardrobePoseGui({ character, characterState }: {
 function PoseButton({ preset, setPose }: { preset: CheckedPosePreset; setPose: (pose: PartialAppearancePose) => void; }): ReactElement {
 	const { name, available, requested, active, pose } = preset;
 	return (
-		<Row
+		<SelectionIndicator
+			selected={ requested }
+			active={ active }
 			className={ classNames(
 				'pose',
 				{
 					['pose-unavailable']: !available,
-					['pose-requested']: requested,
-					['pose-active']: active,
 				},
 			) }
 		>
@@ -364,7 +365,7 @@ function PoseButton({ preset, setPose }: { preset: CheckedPosePreset; setPose: (
 			>
 				{ name }
 			</Button>
-		</Row>
+		</SelectionIndicator>
 	);
 }
 

--- a/pandora-client-web/src/components/wardrobe/views/wardrobePoseView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobePoseView.tsx
@@ -282,7 +282,7 @@ export function WardrobePoseGui({ character, characterState }: {
 	character: IChatroomCharacter;
 	characterState: AssetFrameworkCharacterState;
 }): ReactElement {
-	const [execute, processing] = useWardrobeExecuteCallback();
+	const [execute] = useWardrobeExecuteCallback();
 	const roomItems = useWardrobeContext().globalState.getItems({ type: 'roomInventory' });
 	const assetManager = characterState.assetManager;
 	const allBones = useMemo(() => assetManager.getAllBones(), [assetManager]);
@@ -306,22 +306,6 @@ export function WardrobePoseGui({ character, characterState }: {
 	return (
 		<div className='inventoryView'>
 			<div className='bone-ui'>
-				<div>
-					<label htmlFor='back-view-toggle'>Show back view</label>
-					<input
-						id='back-view-toggle'
-						type='checkbox'
-						checked={ characterState.requestedPose.view === 'back' }
-						onChange={ (e) => {
-							execute({
-								type: 'setView',
-								target: character.id,
-								view: e.target.checked ? 'back' : 'front',
-							});
-						} }
-						disabled={ processing }
-					/>
-				</div>
 				<WardrobePoseCategoriesInternal poses={ poses } setPose={ setPose } />
 				<ChatroomManualYOffsetControl character={ character } />
 				<FieldsetToggle legend='Manual pose' persistent='bone-ui-dev-pose'>

--- a/pandora-client-web/src/components/wardrobe/views/wardrobePoseView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobePoseView.tsx
@@ -11,6 +11,7 @@ import {
 	BONE_MIN,
 	BoneDefinition,
 	CharacterArmsPose,
+	CloneDeepMutable,
 	LegsPose,
 	LegsPoseSchema,
 	MergePartialAppearancePoses,
@@ -303,9 +304,33 @@ export function WardrobePoseGui({ character, characterState }: {
 
 	const setPose = useMemo(() => _.throttle(setPoseDirect, 100), [setPoseDirect]);
 
+	const actualPoseDiffers = !_.isEqual(characterState.requestedPose, characterState.actualPose);
+
 	return (
 		<div className='inventoryView'>
 			<div className='bone-ui'>
+				<Row
+					className={ actualPoseDiffers ? '' : 'invisible' }
+					alignX='center'
+					alignY='stretch'
+				>
+					<SelectionIndicator
+						active
+						justify='center'
+						align='center'
+						className='requestedPoseIndicatorText'
+					>
+						Items are forcing this character into a different pose.
+					</SelectionIndicator>
+					<Button
+						slim
+						onClick={ () => {
+							setPose(CloneDeepMutable(characterState.actualPose));
+						} }
+					>
+						Stay in it
+					</Button>
+				</Row>
 				<WardrobePoseCategoriesInternal poses={ poses } setPose={ setPose } />
 				<ChatroomManualYOffsetControl character={ character } />
 				<FieldsetToggle legend='Manual pose' persistent='bone-ui-dev-pose'>

--- a/pandora-client-web/src/components/wardrobe/wardrobe.scss
+++ b/pandora-client-web/src/components/wardrobe/wardrobe.scss
@@ -410,22 +410,8 @@ $drop-overlay-gap: 0.3em;
 		margin: 0 1em;
 
 		.pose {
-			border: solid 2px transparent;
-			border-radius: 0.5em;
-			transition: all 150ms linear;
-			padding: 2px;
-
 			&.pose-unavailable {
 				opacity: 60%;
-			}
-
-			&.pose-requested {
-				border-color: #000;
-			}
-
-			&.pose-active:not(.pose-requested) {
-				border-color: #000;
-				border-style: dashed;
 			}
 		}
 	}

--- a/pandora-client-web/src/components/wardrobe/wardrobe.scss
+++ b/pandora-client-web/src/components/wardrobe/wardrobe.scss
@@ -407,19 +407,25 @@ $drop-overlay-gap: 0.3em;
 	}
 
 	.pose-row {
-		display: flex;
-		flex-flow: row wrap;
-		gap: 0.5em;
 		margin: 0 1em;
 
-		.Button:disabled {
-			background-color: $grey-lighter;
-			color: $grey-darkest;
+		.pose {
+			border: solid 2px transparent;
+			border-radius: 0.5em;
+			transition: all 150ms linear;
+			padding: 2px;
 
 			&.pose-unavailable {
-				background-color: $grey-darker;
-				color: $grey-mid;
-				opacity: 40%;
+				opacity: 60%;
+			}
+
+			&.pose-requested {
+				border-color: #000;
+			}
+
+			&.pose-active:not(.pose-requested) {
+				border-color: #000;
+				border-style: dashed;
 			}
 		}
 	}

--- a/pandora-client-web/src/components/wardrobe/wardrobe.scss
+++ b/pandora-client-web/src/components/wardrobe/wardrobe.scss
@@ -420,6 +420,16 @@ $drop-overlay-gap: 0.3em;
 		}
 	}
 
+	.armPositioningTable {
+		margin: 0.5em;
+		&, td {
+			border: solid 1px black;
+			border-collapse: collapse;
+			padding: 0.25em;
+			text-align: center;
+		}
+	}
+
 	.bone-rotation {
 		display: flex;
 		flex-flow: row;

--- a/pandora-client-web/src/components/wardrobe/wardrobe.scss
+++ b/pandora-client-web/src/components/wardrobe/wardrobe.scss
@@ -406,6 +406,10 @@ $drop-overlay-gap: 0.3em;
 		margin: 0 0 0 0.5em;
 	}
 
+	.requestedPoseIndicatorText {
+		padding: 0 0.5em;
+	}
+
 	.pose-row {
 		margin: 0 1em;
 

--- a/pandora-client-web/src/components/wardrobe/wardrobeGraphics.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobeGraphics.tsx
@@ -38,7 +38,7 @@ export function WardrobeCharacterPreview({ character, characterState }: {
 	const [onClick, processing] = useAppearanceActionEvent({
 		type: 'setView',
 		target: character.id,
-		view: characterState.view === 'front' ? 'back' : 'front',
+		view: characterState.requestedPose.view === 'front' ? 'back' : 'front',
 	});
 
 	const sceneOptions = useMemo<GraphicsSceneProps>(() => ({

--- a/pandora-client-web/src/editor/components/bones/bones.tsx
+++ b/pandora-client-web/src/editor/components/bones/bones.tsx
@@ -96,14 +96,14 @@ export function BoneUI(): ReactElement {
 			{
 				allBones
 					.filter((bone) => bone.type === 'pose')
-					.map((bone) => <BoneRowElement key={ bone.name } definition={ bone } rotation={ characterState.getRequestedPoseBoneValue(bone.name) } onChange={ (value) => character.getAppearance().setPose(bone.name, value) } />)
+					.map((bone) => <BoneRowElement key={ bone.name } definition={ bone } characterState={ characterState } onChange={ (value) => character.getAppearance().setPose(bone.name, value) } />)
 			}
 			<hr />
 			<h4>Body bones</h4>
 			{
 				allBones
 					.filter((bone) => bone.type === 'body')
-					.map((bone) => <BoneRowElement key={ bone.name } definition={ bone } rotation={ characterState.getRequestedPoseBoneValue(bone.name) } onChange={ (value) => character.getAppearance().setPose(bone.name, value) } />)
+					.map((bone) => <BoneRowElement key={ bone.name } definition={ bone } characterState={ characterState } onChange={ (value) => character.getAppearance().setPose(bone.name, value) } />)
 			}
 		</Scrollbar>
 	);

--- a/pandora-client-web/src/editor/components/bones/bones.tsx
+++ b/pandora-client-web/src/editor/components/bones/bones.tsx
@@ -38,8 +38,8 @@ export function BoneUI(): ReactElement {
 					} }
 				/>
 			</div>
-			<WardrobeArmPoses armsPose={ characterState.requestedPose } setPose={ setPose } />
-			<WardrobeLegsPose legs={ characterState.requestedPose.legs } setPose={ setPose } />
+			<WardrobeArmPoses characterState={ characterState } setPose={ setPose } />
+			<WardrobeLegsPose characterState={ characterState } setPose={ setPose } />
 			<div>
 				<label htmlFor='back-view-toggle'>Show back view</label>
 				<input

--- a/pandora-client-web/src/editor/components/bones/bones.tsx
+++ b/pandora-client-web/src/editor/components/bones/bones.tsx
@@ -1,6 +1,5 @@
 import { AppearanceArmPose, AssetFrameworkCharacterState, CharacterArmsPose, PartialAppearancePose } from 'pandora-common';
 import React, { ReactElement, useCallback, useMemo, useState } from 'react';
-import { useCharacterAppearanceArmsPose, useCharacterAppearancePose } from '../../../character/character';
 import { Button } from '../../../components/common/button/button';
 import { Column, Row } from '../../../components/common/container/container';
 import { FieldsetToggle } from '../../../components/common/fieldsetToggle';
@@ -18,11 +17,12 @@ export function BoneUI(): ReactElement {
 	const characterState = useEditorCharacterState();
 	const character = editor.character;
 
-	const bones = useCharacterAppearancePose(characterState);
+	const assetManager = characterState.assetManager;
+	const allBones = useMemo(() => assetManager.getAllBones(), [assetManager]);
 	const showBones = useObservable(editor.showBones);
 
 	const setPose = useCallback((pose: PartialAppearancePose) => {
-		character.getAppearance().produceState((state) => state.produceWithPose(pose, 'pose', false));
+		character.getAppearance().produceState((state) => state.produceWithPose(pose, 'pose'));
 	}, [character]);
 
 	return (
@@ -38,14 +38,14 @@ export function BoneUI(): ReactElement {
 					} }
 				/>
 			</div>
-			<WardrobeArmPoses armsPose={ characterState.arms } setPose={ setPose } />
-			<WardrobeLegsPose legs={ characterState.legs } setPose={ setPose } />
+			<WardrobeArmPoses armsPose={ characterState.requestedPose } setPose={ setPose } />
+			<WardrobeLegsPose legs={ characterState.requestedPose.legs } setPose={ setPose } />
 			<div>
 				<label htmlFor='back-view-toggle'>Show back view</label>
 				<input
 					id='back-view-toggle'
 					type='checkbox'
-					checked={ characterState.view === 'back' }
+					checked={ characterState.requestedPose.view === 'back' }
 					onChange={ (e) => {
 						character.getAppearance().setView(e.target.checked ? 'back' : 'front');
 					} }
@@ -94,37 +94,46 @@ export function BoneUI(): ReactElement {
 				</ContextHelpButton>
 			</h4>
 			{
-				bones
-					.filter((bone) => bone.definition.type === 'pose')
-					.map((bone) => <BoneRowElement key={ bone.definition.name } bone={ bone } onChange={ (value) => character.getAppearance().setPose(bone.definition.name, value) } />)
+				allBones
+					.filter((bone) => bone.type === 'pose')
+					.map((bone) => <BoneRowElement key={ bone.name } definition={ bone } rotation={ characterState.getRequestedPoseBoneValue(bone.name) } onChange={ (value) => character.getAppearance().setPose(bone.name, value) } />)
 			}
 			<hr />
 			<h4>Body bones</h4>
 			{
-				bones
-					.filter((bone) => bone.definition.type === 'body')
-					.map((bone) => <BoneRowElement key={ bone.definition.name } bone={ bone } onChange={ (value) => character.getAppearance().setPose(bone.definition.name, value) } />)
+				allBones
+					.filter((bone) => bone.type === 'body')
+					.map((bone) => <BoneRowElement key={ bone.name } definition={ bone } rotation={ characterState.getRequestedPoseBoneValue(bone.name) } onChange={ (value) => character.getAppearance().setPose(bone.name, value) } />)
 			}
 		</Scrollbar>
 	);
 }
 
 function PoseExportGui({ characterState }: { character: EditorCharacter; characterState: AssetFrameworkCharacterState; }) {
+	const assetManager = characterState.assetManager;
 	const [open, setOpen] = useState(false);
 
-	const pose = useCharacterAppearancePose(characterState);
-	const arms = useCharacterAppearanceArmsPose(characterState);
+	const bonesText = useMemo(() => {
+		let result = '';
+		for (const bone of assetManager.getAllBones()) {
+			if (bone.type !== 'pose')
+				continue;
+			const value = characterState.requestedPose.bones[bone.name];
+			if (value == null || value === 0)
+				continue;
+			result += `\n\t\t${bone.name}: ${value},`;
+		}
+		return result;
+	}, [assetManager, characterState.requestedPose]);
 
 	const typeScriptValue = useMemo(() => {
 		return `{
 	name: '[Pose Preset Name]',
-	bones: {${pose.reduce((acc, value) => (value.rotation === 0 || value.definition.type !== 'pose')
-			? acc
-			: acc + `\n\t\t${value.definition.name}: ${value.rotation},`, '')}
+	bones: {${bonesText}
 	},
-	${CharacterArmsPoseToString(arms)}
+	${CharacterArmsPoseToString(characterState.requestedPose)}
 },`;
-	}, [pose, arms]);
+	}, [bonesText, characterState]);
 
 	if (!open) {
 		return <Button onClick={ () => setOpen(true) }>Show pose export</Button>;

--- a/pandora-client-web/src/editor/graphics/character/appearanceEditor.ts
+++ b/pandora-client-web/src/editor/graphics/character/appearanceEditor.ts
@@ -54,7 +54,7 @@ export class AppearanceEditor extends CharacterAppearance {
 		// This asserts existence of bone
 		this.getPose(bone);
 
-		return this.produceState((state) => state.produceWithPose({ bones: { [bone]: value } }, true, false));
+		return this.produceState((state) => state.produceWithPose({ bones: { [bone]: value } }, true));
 	}
 
 	public addItem(asset: Asset, context: ActionProcessingContext = {}): boolean {

--- a/pandora-client-web/src/graphics/graphicsCharacter.tsx
+++ b/pandora-client-web/src/graphics/graphicsCharacter.tsx
@@ -5,7 +5,7 @@ import * as PIXI from 'pixi.js';
 import React, { ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
 import { AssetGraphics, AssetGraphicsLayer } from '../assets/assetGraphics';
 import { GraphicsManagerInstance } from '../assets/graphicsManager';
-import { useCharacterAppearanceArmsPose, useCharacterAppearanceItems, useCharacterAppearanceView } from '../character/character';
+import { useCharacterAppearanceItems } from '../character/character';
 import { ChildrenProps } from '../common/reactTypes';
 import { useObservable } from '../observable';
 import { ComputedLayerPriority, COMPUTED_LAYER_ORDERING, ComputeLayerPriority, LayerState, LayerStateOverrides, PRIORITY_ORDER_REVERSE_PRIORITIES } from './def';
@@ -145,10 +145,9 @@ function GraphicsCharacterWithManagerImpl({
 		return result;
 	}, [items, graphicsGetter, layerStateOverrideGetter]);
 
-	const armsPose = useCharacterAppearanceArmsPose(characterState);
-	const view = useCharacterAppearanceView(characterState);
+	const { view } = characterState.actualPose;
 
-	const priorities = useLayerPriorityResolver(layers, armsPose);
+	const priorities = useLayerPriorityResolver(layers, characterState.actualPose);
 
 	const priorityLayers = useMemo<ReadonlyMap<ComputedLayerPriority, ReactElement>>(() => {
 		const result = new Map<ComputedLayerPriority, ReactElement>();

--- a/pandora-client-web/src/styles/_forms.scss
+++ b/pandora-client-web/src/styles/_forms.scss
@@ -41,7 +41,9 @@ button {
 	outline: 0;
 	border: 0;
 	font-size: 1em;
-	transition: all 150ms linear;
+	transition:
+		all 150ms linear,
+		visibility 0ms;
 
 	&:hover {
 		cursor: pointer;

--- a/pandora-common/src/assets/appearance.ts
+++ b/pandora-common/src/assets/appearance.ts
@@ -25,14 +25,20 @@ function GetDefaultAppearanceArmPose(): AppearanceArmPose {
 	};
 }
 
-export function GetDefaultAppearanceBundle(): AppearanceBundle {
+export function GetDefaultAppearancePose(): AppearancePose {
 	return {
-		items: [],
 		bones: {},
 		leftArm: GetDefaultAppearanceArmPose(),
 		rightArm: GetDefaultAppearanceArmPose(),
 		legs: 'standing',
 		view: 'front',
+	};
+}
+
+export function GetDefaultAppearanceBundle(): AppearanceBundle {
+	return {
+		items: [],
+		requestedPose: GetDefaultAppearancePose(),
 	};
 }
 
@@ -91,18 +97,24 @@ export class CharacterAppearance implements RoomActionTargetCharacter {
 	}
 
 	public getPose(bone: string): BoneState {
-		const state = this.characterState.pose.get(bone);
-		if (!state)
+		const definition = this.assetManager.getBoneByName(bone);
+		if (definition == null)
 			throw new Error(`Attempt to get pose for unknown bone: ${bone}`);
-		return { ...state };
+		return {
+			definition,
+			rotation: this.characterState.actualPose.bones[definition.name] || 0,
+		};
 	}
 
 	public getArmsPose(): CharacterArmsPose {
-		return this.characterState.arms;
+		return {
+			leftArm: this.characterState.actualPose.leftArm,
+			rightArm: this.characterState.actualPose.rightArm,
+		};
 	}
 
 	public getView(): CharacterView {
-		return this.characterState.view;
+		return this.characterState.actualPose.view;
 	}
 
 	public getSafemode(): Readonly<SafemodeData> | null {

--- a/pandora-common/src/assets/appearanceActions.ts
+++ b/pandora-common/src/assets/appearanceActions.ts
@@ -1207,17 +1207,6 @@ export function ActionRoomDeviceLeave({
 				},
 			});
 		}
-
-		const exitPose = asset.definition.exitPose ?? item.asset.definition.exitPose;
-		if (exitPose != null && !manipulator.produceCharacterState(occupyingCharacterId, (character) => character.produceWithPosePreset(exitPose))) {
-			return {
-				result: 'restrictionError',
-				restriction: {
-					type: 'exitPose',
-					asset: item.asset.id,
-				},
-			};
-		}
 	}
 
 	// Only after freeing character remove the reservation from the device - to do things in opposite order of putting character into it

--- a/pandora-common/src/assets/appearanceActions.ts
+++ b/pandora-common/src/assets/appearanceActions.ts
@@ -455,7 +455,7 @@ export function DoAppearanceAction(
 			}
 
 			if (!manipulator.produceCharacterState(action.target, (character) => {
-				return character.produceWithPose(action, action.type, false);
+				return character.produceWithPose(action, action.type);
 			})) {
 				return { result: 'invalidAction' };
 			}

--- a/pandora-common/src/assets/appearanceActions.ts
+++ b/pandora-common/src/assets/appearanceActions.ts
@@ -66,6 +66,7 @@ export const AppearanceActionPose = z.object({
 	leftArm: AppearanceArmPoseSchema.partial().optional(),
 	rightArm: AppearanceArmPoseSchema.partial().optional(),
 	legs: LegsPoseSchema.optional(),
+	view: CharacterViewSchema.optional(),
 });
 
 export const AppearanceActionBody = z.object({

--- a/pandora-common/src/assets/appearanceLimit.ts
+++ b/pandora-common/src/assets/appearanceLimit.ts
@@ -2,7 +2,7 @@ import { Immutable } from 'immer';
 import _ from 'lodash';
 import { ZodEnum } from 'zod';
 import { CloneDeepMutable, IntervalSetIntersection } from '../utility';
-import { GetDefaultAppearanceBundle } from './appearance';
+import { GetDefaultAppearancePose } from './appearance';
 import type { AssetDefinitionPoseLimit, AssetDefinitionPoseLimits, PartialAppearancePose } from './definitions';
 import { ArmFingersSchema, ArmPoseSchema, ArmRotationSchema, CharacterViewSchema, LegsPoseSchema } from './graphics/graphics';
 import type { AppearanceArmPose, AppearancePose } from './state/characterState';
@@ -237,11 +237,11 @@ export class AppearanceLimitTree {
 		return this.root != null && this.root.hasNoLimits();
 	}
 
-	public validate(pose: PartialAppearancePose): boolean {
+	public validate(pose: Immutable<PartialAppearancePose>): boolean {
 		return this.root != null && this.root.validate(FromPose(pose));
 	}
 
-	public force(pose: AppearancePose): { pose: AppearancePose; changed: boolean; } {
+	public force(pose: Immutable<AppearancePose>): { pose: AppearancePose; changed: boolean; } {
 		if (this.root == null)
 			return { pose, changed: false };
 
@@ -270,7 +270,7 @@ function CreateTreeNode(limits: Immutable<AssetDefinitionPoseLimits>): TreeNode 
 	return new TreeNode(FromLimit(limits), nodeChildren);
 }
 
-function FromPose({ bones, leftArm, rightArm, arms, legs, view }: PartialAppearancePose): Map<string, number> {
+function FromPose({ bones, leftArm, rightArm, arms, legs, view }: Immutable<PartialAppearancePose>): Map<string, number> {
 	const data = new Map<string, number>();
 
 	if (bones) {
@@ -336,7 +336,7 @@ function ToArmPose(data: ReadonlyMap<string, number>, prefix: 'leftArm' | 'right
 }
 
 function ToPose(data: ReadonlyMap<string, number>): AppearancePose {
-	const pose = GetDefaultAppearanceBundle();
+	const pose = GetDefaultAppearancePose();
 
 	ToArmPose(data, 'leftArm', pose);
 	ToArmPose(data, 'rightArm', pose);

--- a/pandora-common/src/assets/appearanceValidation.ts
+++ b/pandora-common/src/assets/appearanceValidation.ts
@@ -25,10 +25,6 @@ export type AppearanceValidationError =
 		problem: 'poseConflict';
 	}
 	| {
-		// There is a possible valid pose, but the current pose is not valid
-		problem: 'invalidPose';
-	}
-	| {
 		problem: 'tooManyItems';
 		asset: AssetId | null;
 		limit: number;

--- a/pandora-common/src/assets/definitions.ts
+++ b/pandora-common/src/assets/definitions.ts
@@ -224,8 +224,6 @@ export interface RoomDeviceAssetDefinition<A extends AssetDefinitionExtraArgs = 
 	staticAttributes?: (A['attributes'])[];
 	/** Extra pose presets available when inside this device */
 	posePresets?: AssetsPosePreset<A['bones']>[];
-	/** Pose thats gets applied to character exiting this device */
-	exitPose?: AssetsPosePreset<A['bones']>;
 	/**
 	 * Chat specific settings for this asset
 	 *
@@ -256,8 +254,6 @@ export interface RoomDeviceWearablePartAssetDefinition<A extends AssetDefinition
 	hasGraphics: boolean;
 	/** Extra pose presets available when wearing this asset, extends device's pose presets */
 	posePresets?: AssetsPosePreset<A['bones']>[];
-	/** Pose thats gets applied to character exiting this slot, overrides device's exit pose */
-	exitPose?: AssetsPosePreset<A['bones']>;
 	/**
 	 * Chat specific settings for this asset
 	 *

--- a/pandora-common/src/assets/manipulators/globalStateManipulator.ts
+++ b/pandora-common/src/assets/manipulators/globalStateManipulator.ts
@@ -65,9 +65,7 @@ export class AssetFrameworkGlobalStateManipulator {
 
 			return this.produceCharacterState(
 				target.characterId,
-				(character) => character
-					.produceWithItems(wearableItems)
-					.enforcePoseLimits(),
+				(character) => character.produceWithItems(wearableItems),
 			);
 		} else if (target.type === 'roomInventory') {
 			return this.produceRoomState(

--- a/pandora-common/src/character/restrictionsManager.ts
+++ b/pandora-common/src/character/restrictionsManager.ts
@@ -97,10 +97,6 @@ export type Restriction =
 	| {
 		type: 'blockedHands';
 	}
-	| {
-		type: 'exitPose';
-		asset: AssetId;
-	}
 	// Generic catch-all problem, supposed to be used when something simply went wrong (like bad data, target not found, and so on...)
 	| {
 		type: 'invalid';

--- a/pandora-common/src/networking/shard_directory.ts
+++ b/pandora-common/src/networking/shard_directory.ts
@@ -1,7 +1,7 @@
 import type { SocketInterfaceRequest, SocketInterfaceResponse, SocketInterfaceHandlerResult, SocketInterfaceHandlerPromiseResult, SocketInterfaceDefinitionVerified } from './helpers';
-import { CharacterDataAccessSchema, CharacterDataIdSchema, CharacterDataSchema, CharacterDataUpdateSchema, CharacterIdSchema } from '../character';
+import { CharacterDataAccessSchema, CharacterDataIdSchema, CharacterDataSchema, CharacterDataUpdateSchema, CharacterIdSchema, ICharacterData } from '../character';
 import { DirectoryShardUpdateSchema, ShardCharacterDefinitionSchema, ShardChatRoomDefinitionSchema } from './directory_shard';
-import { ChatRoomDataSchema, ChatRoomDataShardUpdateSchema, RoomIdSchema, ShardFeatureSchema } from '../chatroom/room';
+import { ChatRoomDataSchema, ChatRoomDataShardUpdateSchema, IChatRoomData, RoomIdSchema, ShardFeatureSchema } from '../chatroom/room';
 import { z } from 'zod';
 import { Satisfies } from '../utility';
 
@@ -12,7 +12,7 @@ export type IChatRoomDataAccess = z.infer<typeof ChatRoomDataAccessSchema>;
 import type { } from '../assets/appearance';
 import type { } from '../character/pronouns';
 import type { } from '../chatroom/chat';
-import type { } from '../validation';
+import { ZodCast } from '../validation';
 
 export const ShardDirectorySchema = {
 	shardRegister: {
@@ -60,7 +60,10 @@ export const ShardDirectorySchema = {
 	//#region Database
 	getCharacter: {
 		request: CharacterDataAccessSchema,
-		response: CharacterDataSchema,
+		response: z.object({
+			// Response is intentionally not checked, as DB might contain outdated data and migration happens on the shard
+			result: ZodCast<ICharacterData>().nullable(),
+		}),
 	},
 	setCharacter: {
 		request: CharacterDataUpdateSchema,
@@ -70,7 +73,10 @@ export const ShardDirectorySchema = {
 	},
 	getChatRoom: {
 		request: ChatRoomDataAccessSchema,
-		response: ChatRoomDataSchema,
+		response: z.object({
+			// Response is intentionally not checked, as DB might contain outdated data and migration happens on the shard
+			result: ZodCast<IChatRoomData>().nullable(),
+		}),
 	},
 	setChatRoom: {
 		request: z.object({

--- a/pandora-server-directory/src/networking/manager_shard.ts
+++ b/pandora-server-directory/src/networking/manager_shard.ts
@@ -1,4 +1,4 @@
-import { IShardDirectory, MessageHandler, IShardDirectoryPromiseResult, IShardDirectoryArgument, BadMessageError, IMessageHandler, AssertNotNullable } from 'pandora-common';
+import { IShardDirectory, MessageHandler, IShardDirectoryPromiseResult, IShardDirectoryArgument, BadMessageError, IMessageHandler } from 'pandora-common';
 import type { IConnectionShard } from './common';
 import { GetDatabase } from '../database/databaseProvider';
 import { ShardManager } from '../shard/shardManager';
@@ -119,7 +119,9 @@ export const ConnectionManagerShard = new class ConnectionManagerShard implement
 		if (!connection.shard?.getConnectedCharacter(id))
 			throw new BadMessageError();
 
-		return GetDatabase().getCharacter(id, accessId) as IShardDirectoryPromiseResult['getCharacter'];
+		return {
+			result: await GetDatabase().getCharacter(id, accessId),
+		};
 	}
 
 	private async handleSetCharacter(args: IShardDirectoryArgument['setCharacter'], connection: IConnectionShard): IShardDirectoryPromiseResult['setCharacter'] {
@@ -136,9 +138,9 @@ export const ConnectionManagerShard = new class ConnectionManagerShard implement
 		if (!connection.shard?.getConnectedRoom(id))
 			throw new BadMessageError();
 
-		const result = await GetDatabase().getChatRoomById(id, accessId);
-		AssertNotNullable(result);
-		return result;
+		return {
+			result: await GetDatabase().getChatRoomById(id, accessId),
+		};
 	}
 
 	private async handleSetChatRoom({ id, data, accessId }: IShardDirectoryArgument['setChatRoom'], connection: IConnectionShard): IShardDirectoryPromiseResult['setChatRoom'] {

--- a/pandora-server-shard/src/database/directoryDb.ts
+++ b/pandora-server-shard/src/database/directoryDb.ts
@@ -21,7 +21,8 @@ export default class DirectoryDatabase implements ShardDatabase {
 		if (DirectoryConnector.state !== DirectoryConnectionState.CONNECTED)
 			return false;
 
-		return await DirectoryConnector.awaitResponse('getCharacter', { id, accessId });
+		const { result } = await DirectoryConnector.awaitResponse('getCharacter', { id, accessId });
+		return result;
 	}
 
 	public async setCharacter(data: ICharacterDataUpdate): Promise<boolean> {
@@ -37,8 +38,13 @@ export default class DirectoryDatabase implements ShardDatabase {
 		if (DirectoryConnector.state !== DirectoryConnectionState.CONNECTED)
 			return false;
 
+		const { result } = await DirectoryConnector.awaitResponse('getChatRoom', { id, accessId });
+
+		if (result == null)
+			return null;
+
 		return _.omit(
-			await DirectoryConnector.awaitResponse('getChatRoom', { id, accessId }),
+			result,
 			['config', 'accessId', 'owners'],
 		);
 	}


### PR DESCRIPTION
Fixes: #272 

This PR reworks how poses work:
- Poses are not split into requested pose and actual pose
- Requested pose can be selected arbitrarily by user
- Actual pose is always calculated by applying limits (finding closest possible pose) to the requested pose
- The UI shows when actual and requested poses don't match and allows setting requested pose to actual
- Reworked parts of pose UI to work better with the new system
- Changed view from being a toggle into a preset (looks nicer and easier to click)
- Removed room device exit pose as it is no longer needed

This allows trying on items that limit poses and removing them in a way that character simply returns to the previous pose. Same applies to room devices.

Complimentary asset PR:  [pandora-assets#165](https://github.com/Project-Pandora-Game/pandora-assets/pull/165)