### PR TITLE
[DEV] Fix autoapprove job failing if run multiple times

### DIFF
--- a/.github/workflows/automation-autoapprove.yml
+++ b/.github/workflows/automation-autoapprove.yml
@@ -1,41 +1,14 @@
-name: PR
+name: Automation (Auto-approve)
 
 on:
   # Triggers the workflow on any pull request (but runs in context of target branch, having a bit higher rights)
   pull_request_target:
     types:
       - opened
-      - edited
-      - synchronize
-      - labeled
-      - unlabeled
-
-jobs:
-  title:
-    name: Validate PR title
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: amannn/action-semantic-pull-request@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          headerPattern: '^\[(\w*)\]:?\s*(.*)$'
-          headerPatternCorrespondence: type, subject
-          types: |
-            FEATURE
-            ADD
-            CHANGE
-            REMOVE
-            FIX
-            REFACTOR
-            DEV
-            CHORE
 
   automation:
     name: Automation tasks
     runs-on: ubuntu-latest
-    concurrency: automation
     permissions:
       pull-requests: write
 

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,33 @@
+name: Lint PR
+
+on:
+  # Triggers the workflow on any pull request (but runs in context of target branch, having a bit higher rights)
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
+
+jobs:
+  title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          headerPattern: '^\[(\w*)\]:?\s*(.*)$'
+          headerPatternCorrespondence: type, subject
+          types: |
+            FEATURE
+            ADD
+            CHANGE
+            REMOVE
+            FIX
+            REFACTOR
+            DEV
+            CHORE


### PR DESCRIPTION
GitHub's `concurrency` is quite broken in its current implementation: Instead of working as a lock and queuing any actions and running them in series, there can only be at most one running and one pending action. If new action enqueues any currently pending action is canceled.
This means that normally only the first and last job queued in quick succession runs, but those can be from different PRs.
This fix tries to avoid the race condition altogether by splitting the auto-approve into a separate workflow that only runs once on PR open.