### PR TITLE
[FIX] Hotfix: An important line got lost somewhere

### DIFF
--- a/.github/workflows/automation-autoapprove.yml
+++ b/.github/workflows/automation-autoapprove.yml
@@ -6,6 +6,7 @@ on:
     types:
       - opened
 
+jobs:
   automation:
     name: Automation tasks
     runs-on: ubuntu-latest


### PR DESCRIPTION
Unfortunately `pull_request_target` CI cannot be tested differently than having it somewhere on `master`...