### PR TITLE
[FIX] Fix alphamask change sometimes not trigerring redraw

### DIFF
--- a/pandora-client-web/src/components/wardrobe/views/wardrobeExpressionsView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobeExpressionsView.tsx
@@ -27,7 +27,7 @@ export function WardrobeExpressionGui({ characterState }: {
 							Array.from(item.modules.entries())
 								.filter((m) => m[1].config.expression)
 								.map(([moduleName, m]) => (
-									<FieldsetToggle legend={ m.config.expression } key={ moduleName }>
+									<FieldsetToggle legend={ m.config.expression } key={ `${item.id}:${moduleName}` }>
 										<WardrobeModuleConfig
 											item={ { container: [], itemId: item.id } }
 											moduleName={ moduleName }

--- a/pandora-client-web/src/graphics/graphicsLayer.tsx
+++ b/pandora-client-web/src/graphics/graphicsLayer.tsx
@@ -457,6 +457,7 @@ function MaskContainerCustom({
 		const g = maskGeometryFinal.current = maskMesh ? new PIXI.MeshGeometry(maskMesh.vertices, maskMesh.uvs, maskMesh.indices) : undefined;
 		maskLayer.current?.updateGeometry(g);
 		return () => {
+			maskLayer.current?.updateGeometry(undefined);
 			maskGeometryFinal.current?.destroy();
 			maskGeometryFinal.current = null;
 		};

--- a/pandora-client-web/src/graphics/graphicsMaskLayer.ts
+++ b/pandora-client-web/src/graphics/graphicsMaskLayer.ts
@@ -26,14 +26,11 @@ export class GraphicsMaskLayer {
 	}
 
 	private _render() {
-		requestAnimationFrame(() => {
-			if (!this._textureParent || !this._result) {
-				return;
-			}
-			this._textureParent.texture = this._texture;
-			this._pixiApp.renderer.render(this._result, { renderTexture: this._renderTexture });
-			this._pixiApp.ticker.update();
-		});
+		if (!this._textureParent || !this._result) {
+			return;
+		}
+		this._textureParent.texture = this._texture;
+		this._pixiApp.renderer.render(this._result, { renderTexture: this._renderTexture });
 	}
 
 	public destroy() {


### PR DESCRIPTION
Also avoids crashing when the mask is set to empty (which was why the original code was written in the way it was).
Adds a small fix to fix React's warning about duplicate key in wardrobe expressions, when two items have modules with same name.