### PR TITLE
[FIX] Fix DiscordBot hanging shutdown when not in use

### DIFF
--- a/pandora-server-directory/src/lifecycle.ts
+++ b/pandora-server-directory/src/lifecycle.ts
@@ -45,8 +45,9 @@ async function StopGracefully(): Promise<void> {
 	destroying = 'AccountManager Accounts';
 	accountManager.onDestroyAccounts();
 	// Disconnect database
-	destroying = 'AccountManager Database';
+	destroying = 'Database';
 	await CloseDatabase();
+	destroying = '[done]';
 }
 
 export function Stop(): Promise<void> {

--- a/pandora-server-directory/src/services/discord/discordBot.ts
+++ b/pandora-server-directory/src/services/discord/discordBot.ts
@@ -62,12 +62,19 @@ export const DiscordBot = new class DiscordBot implements Service {
 		if (!this._client) {
 			return;
 		}
-		this.setOnlineStatus.cancel();
+		this._setOnlineStatusInternal.cancel();
 		this._client.user?.setStatus('dnd');
 		await this._client.destroy();
 	}
 
-	public readonly setOnlineStatus = _.throttle((status: Partial<DiscordBotStatus>): void => {
+	public setOnlineStatus(status: Partial<DiscordBotStatus>): void {
+		if (this._destroyed || !this._client) {
+			return;
+		}
+		this._setOnlineStatusInternal(status);
+	}
+
+	private readonly _setOnlineStatusInternal = _.throttle((status: Partial<DiscordBotStatus>): void => {
 		if (this._destroyed || !this._client) {
 			return;
 		}


### PR DESCRIPTION
Prevents the throttle from being invoked (and such creating 10 minute timer that isn't stopped), allowing Directory to shut down cleanly even when not using the bot.
Also fixes misleading progress message.