### PR TITLE
[DEV] Fix firefox debugger breaking when reload happens

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -64,7 +64,7 @@
 			"type": "firefox",
 			"reAttach": true,
 			"url": "http://localhost:6969",
-			"webRoot": "${workspaceFolder}/pandora-client-web",
+			"webRoot": "${workspaceFolder}/pandora-client-web/dist",
 			"preLaunchTask": "pandora-client-web: dev",
 			"pathMappings": [
 				{

--- a/pandora-client-web/webpack.config.ts
+++ b/pandora-client-web/webpack.config.ts
@@ -61,9 +61,12 @@ export default function (env: WebpackEnv): Configuration {
 					runtimeErrors: false,
 				},
 			},
+			devMiddleware: {
+				writeToDisk: true,
+			},
 			port: WEBPACK_DEV_SERVER_PORT,
 		},
-		devtool: env.prod ? 'source-map' : 'eval-source-map',
+		devtool: env.prod ? 'source-map' : 'inline-source-map',
 		entry: {
 			'index': join(SRC_DIR, 'index.tsx'),
 			'editor/index': join(SRC_DIR, 'editor', 'index.tsx'),


### PR DESCRIPTION
The Firefox debugger doesn't like it when exception is thrown in a file that has _no_ physical counterpart on the disk - this happens for example when dev server forces full reload when it can't do HMR.
This change makes even development version of Webpack emit the files and uses inlined source maps to allow proper resolution.