### PR TITLE
[FEATURE] Room device modules

### DIFF
--- a/pandora-client-web/src/assets/appearanceValidation.ts
+++ b/pandora-client-web/src/assets/appearanceValidation.ts
@@ -62,7 +62,10 @@ export function RenderAppearanceActionProblem(assetManager: AssetManagerClient, 
 				return `The ${DescribeAsset(assetManager, e.asset)} cannot be added or removed${e.self ? ' on yourself' : ''}.`;
 			case 'blockedModule': {
 				const asset = assetManager.getAssetById(e.asset);
-				const visibleModuleName: string = (asset?.isType('personal') && asset.definition.modules?.[e.module]?.name) || `[UNKNOWN MODULE '${e.module}']`;
+				const visibleModuleName: string =
+					(asset?.isType('personal') && asset.definition.modules?.[e.module]?.name) ||
+					(asset?.isType('roomDevice') && asset.definition.modules?.[e.module]?.name) ||
+					`[UNKNOWN MODULE '${e.module}']`;
 				return `The ${DescribeAsset(assetManager, e.asset)}'s ${visibleModuleName} cannot be modified${e.self ? ' on yourself' : ''}.`;
 			}
 			case 'blockedSlot':

--- a/pandora-client-web/src/assets/appearanceValidation.ts
+++ b/pandora-client-web/src/assets/appearanceValidation.ts
@@ -99,7 +99,7 @@ export function RenderAppearanceActionProblem(assetManager: AssetManagerClient, 
 				const attribute = assetManager.getAttributeDefinition(attributeName);
 				const description = attribute ? `"${attribute.description}"` : `[UNKNOWN ATTRIBUTE '${attributeName}']`;
 				if (e.asset) {
-					return `The ${DescribeAsset(assetManager, e.asset)} ${negative ? 'conflicts with' : 'requires'} ${description}.`;
+					return `The ${DescribeAsset(assetManager, e.asset)} ${negative ? 'conflicts with' : 'requires'} ${description} (${negative ? 'must not' : 'must'} be worn under the ${DescribeAsset(assetManager, e.asset)}).`;
 				} else {
 					return `The item ${negative ? 'must not' : 'must'} be ${description}.`;
 				}

--- a/pandora-client-web/src/components/chatroom/chatRoomDevice.tsx
+++ b/pandora-client-web/src/components/chatroom/chatRoomDevice.tsx
@@ -1,4 +1,4 @@
-import { AssertNever, AssetFrameworkCharacterState, CalculateCharacterMaxYForBackground, CharacterSize, CloneDeepMutable, EMPTY_ARRAY, ICharacterRoomData, IChatroomBackgroundData, IRoomDeviceGraphicsCharacterPosition, IRoomDeviceGraphicsLayerSlot, IRoomDeviceGraphicsLayerSprite, ItemRoomDevice, RoomDeviceDeployment, ZodMatcher } from 'pandora-common';
+import { AssertNever, AssetFrameworkCharacterState, CalculateCharacterMaxYForBackground, CharacterSize, CloneDeepMutable, Coordinates, EMPTY_ARRAY, ICharacterRoomData, IChatroomBackgroundData, IRoomDeviceGraphicsCharacterPosition, IRoomDeviceGraphicsLayerSlot, IRoomDeviceGraphicsLayerSprite, ItemRoomDevice, RoomDeviceDeployment, ZodMatcher } from 'pandora-common';
 import React, { ReactElement, useCallback, useEffect, useMemo, useRef } from 'react';
 import * as PIXI from 'pixi.js';
 import { useObservable } from '../../observable';
@@ -330,6 +330,10 @@ function RoomDeviceGraphicsLayerSprite({ item, layer, getTexture }: {
 		return layer.imageOverrides?.find((img) => EvaluateCondition(img.condition, (c) => evaluator.evalCondition(c, item)))?.image ?? layer.image;
 	}, [evaluator, item, layer]);
 
+	const offset = useMemo<Coordinates | undefined>(() => {
+		return layer.offsetOverrides?.find((o) => EvaluateCondition(o.condition, (c) => evaluator.evalCondition(c, item)))?.offset ?? layer.offset;
+	}, [evaluator, item, layer]);
+
 	const texture = useTexture(image, undefined, getTexture);
 
 	const { color, alpha } = useItemColor(EMPTY_ARRAY, item, layer.colorizationKey);
@@ -339,8 +343,8 @@ function RoomDeviceGraphicsLayerSprite({ item, layer, getTexture }: {
 
 	return (
 		<Sprite
-			x={ layer.offsetX ?? 0 }
-			y={ layer.offsetY ?? 0 }
+			x={ offset?.x ?? 0 }
+			y={ offset?.y ?? 0 }
 			scale={ 1 }
 			texture={ texture }
 			tint={ color }

--- a/pandora-client-web/src/components/chatroom/chatRoomDevice.tsx
+++ b/pandora-client-web/src/components/chatroom/chatRoomDevice.tsx
@@ -21,6 +21,8 @@ import { BrowserStorage } from '../../browserStorage';
 import { useCharacterDisplayFilters, usePlayerVisionFilters } from './chatRoomScene';
 import { useChatRoomCharacterOffsets } from './chatRoomCharacter';
 import { RoomDeviceRenderContext } from './chatRoomDeviceContext';
+import { EvaluateCondition } from '../../graphics/utility';
+import { useStandaloneConditionEvaluator } from '../../graphics/appearanceConditionEvaluator';
 
 const PIVOT_TO_LABEL_OFFSET = 100 - CHARACTER_BASE_Y_OFFSET;
 const DEVICE_WAIT_DRAG_THRESHOLD = 400; // ms
@@ -317,13 +319,15 @@ const RoomDeviceGraphics = React.forwardRef(RoomDeviceGraphicsImpl);
 
 function RoomDeviceGraphicsLayerSprite({ item, layer, getTexture }: {
 	item: ItemRoomDevice;
-	layer: IRoomDeviceGraphicsLayerSprite;
+	layer: Immutable<IRoomDeviceGraphicsLayerSprite>;
 	getTexture?: (path: string) => PIXI.Texture;
 }): ReactElement | null {
 
+	const evaluator = useStandaloneConditionEvaluator(item.assetManager);
+
 	const image = useMemo<string>(() => {
-		return layer.image;
-	}, [layer]);
+		return layer.imageOverrides?.find((img) => EvaluateCondition(img.condition, (c) => evaluator.evalCondition(c, item)))?.image ?? layer.image;
+	}, [evaluator, item, layer]);
 
 	const texture = useTexture(image, undefined, getTexture);
 

--- a/pandora-client-web/src/components/chatroom/chatRoomDevice.tsx
+++ b/pandora-client-web/src/components/chatroom/chatRoomDevice.tsx
@@ -82,6 +82,7 @@ export function ChatRoomDevice({
 	const scaling = background.scaling;
 	const x = Math.min(width, deployment.x);
 	const y = Math.min(height, deployment.y);
+	const yOffsetExtra = Math.round(deployment.yOffset);
 
 	const scale = 1 - (y * scaling) / height;
 
@@ -181,7 +182,7 @@ export function ChatRoomDevice({
 			<RoomDeviceGraphics
 				ref={ roomDeviceContainer }
 				item={ item }
-				position={ { x, y: height - y } }
+				position={ { x, y: height - y - yOffsetExtra } }
 				scale={ { x: scale, y: scale } }
 				pivot={ errorCorrectedPivot }
 				hitArea={ hitArea }

--- a/pandora-client-web/src/components/common/tabs/tabs.tsx
+++ b/pandora-client-web/src/components/common/tabs/tabs.tsx
@@ -153,7 +153,7 @@ export function UrlTabContainer({
 					defaultTabPath ? (
 						<Route
 							path='*'
-							element={ <Navigate to={ defaultTabPath } /> }
+							element={ <Navigate to={ defaultTabPath } replace /> }
 						/>
 					) : null
 				}

--- a/pandora-client-web/src/components/settings/settings.tsx
+++ b/pandora-client-web/src/components/settings/settings.tsx
@@ -51,7 +51,7 @@ export function Settings(): ReactElement | null {
 							</div>
 						</div>
 					</Tab>
-					<Tab name='◄ Back' tabClassName='slim' onClick={ () => navigate(-1) } />
+					<Tab name='◄ Back' tabClassName='slim' onClick={ () => navigate('/pandora_lobby') } />
 				</TabContainer>
 			</div>
 			<footer>Version: { GIT_DESCRIBE }</footer>

--- a/pandora-client-web/src/components/wardrobe/itemDetail/_wardrobeItemDetail.tsx
+++ b/pandora-client-web/src/components/wardrobe/itemDetail/_wardrobeItemDetail.tsx
@@ -26,7 +26,7 @@ export function WardrobeItemConfigMenu({
 
 	const containerPath = SplitContainerPath(item.container);
 	const containerItem = useWardrobeTargetItem(target, containerPath?.itemPath);
-	const containerModule = containerPath != null ? containerItem?.modules.get(containerPath.module) : undefined;
+	const containerModule = containerPath != null ? containerItem?.getModules().get(containerPath.module) : undefined;
 	const singleItemContainer = containerModule != null && containerModule instanceof ItemModuleLockSlot;
 	const isRoomInventory = target.type === 'room' && item.container.length === 0;
 
@@ -134,7 +134,7 @@ export function WardrobeItemConfigMenu({
 					) : null
 				}
 				{
-					Array.from(wornItem.modules.entries())
+					Array.from(wornItem.getModules().entries())
 						.map(([moduleName, m]) => (
 							<FieldsetToggle legend={ `Module: ${m.config.name}` } key={ moduleName }>
 								<WardrobeModuleConfig item={ item } moduleName={ moduleName } m={ m } setFocus={ setFocus } />

--- a/pandora-client-web/src/components/wardrobe/itemDetail/wardrobeItemRoomDevice.tsx
+++ b/pandora-client-web/src/components/wardrobe/itemDetail/wardrobeItemRoomDevice.tsx
@@ -51,6 +51,7 @@ export function WardrobeRoomDeviceDeployment({ roomDevice, item }: {
 				deployment: {
 					x: 0,
 					y: 0,
+					yOffset: 0,
 				},
 			} }>
 				Deploy the device
@@ -78,6 +79,7 @@ function WardrobeRoomDeviceDeploymentPosition({ deployment, item }: {
 
 	const [positionX, setPositionX] = useUpdatedUserInput(deployment.x, [item]);
 	const [positionY, setPositionY] = useUpdatedUserInput(deployment.y, [item]);
+	const [positionYOffset, setPositionYOffset] = useUpdatedUserInput(deployment.yOffset, [item]);
 
 	const checkResult = useStaggeredAppearanceActionResult({
 		type: 'roomDeviceDeploy',
@@ -104,8 +106,9 @@ function WardrobeRoomDeviceDeploymentPosition({ deployment, item }: {
 		};
 		setPositionX(newPosition.x);
 		setPositionY(newPosition.y);
+		setPositionYOffset(newPosition.yOffset);
 		onChangeCallerThrottled(newPosition);
-	}, [deployment, setPositionX, setPositionY, onChangeCallerThrottled]);
+	}, [deployment, setPositionX, setPositionY, setPositionYOffset, onChangeCallerThrottled]);
 
 	return (
 		<Row padding='medium' alignY='center'>
@@ -122,6 +125,14 @@ function WardrobeRoomDeviceDeploymentPosition({ deployment, item }: {
 				value={ positionY }
 				onChange={ (ev) => {
 					changeCallback({ y: ev.target.valueAsNumber });
+				} }
+				disabled={ disabled }
+			/>
+			<label>Y offset:</label>
+			<input type='number'
+				value={ positionYOffset }
+				onChange={ (ev) => {
+					changeCallback({ yOffset: ev.target.valueAsNumber });
 				} }
 				disabled={ disabled }
 			/>

--- a/pandora-client-web/src/components/wardrobe/views/wardrobeExpressionsView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobeExpressionsView.tsx
@@ -24,7 +24,7 @@ export function WardrobeExpressionGui({ characterState }: {
 				{
 					appearance
 						.flatMap((item) => (
-							Array.from(item.modules.entries())
+							Array.from(item.getModules().entries())
 								.filter((m) => m[1].config.expression)
 								.map(([moduleName, m]) => (
 									<FieldsetToggle legend={ m.config.expression } key={ `${item.id}:${moduleName}` }>

--- a/pandora-client-web/src/components/wardrobe/views/wardrobeItemView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobeItemView.tsx
@@ -46,7 +46,7 @@ export function InventoryItemView({
 		const steps: string[] = [];
 		for (const step of focus.container) {
 			const item = items.find((it) => it.id === step.item);
-			const module = item?.modules.get(step.module);
+			const module = item?.getModules().get(step.module);
 			if (!item || !module)
 				return [[], undefined, []];
 			steps.push(`${item.asset.definition.name} (${module.config.name})`);

--- a/pandora-client-web/src/components/wardrobe/wardrobe.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobe.tsx
@@ -80,7 +80,7 @@ function WardrobeRoom({ room: _room }: {
 							<WardrobeItemManipulation />
 						</div>
 					</Tab>
-					<Tab name='◄ Back' tabClassName='slim' onClick={ () => navigate(-1) } />
+					<Tab name='◄ Back' tabClassName='slim' onClick={ () => navigate('/pandora_lobby') } />
 				</TabContainer>
 			</div>
 		</div>
@@ -134,7 +134,7 @@ function WardrobeCharacter({ character }: {
 							<WardrobeOutfitGui character={ character } />
 						</div>
 					</Tab>
-					<Tab name='◄ Back' tabClassName='slim' onClick={ () => navigate(-1) } />
+					<Tab name='◄ Back' tabClassName='slim' onClick={ () => navigate('/pandora_lobby') } />
 				</TabContainer>
 			</div>
 		</div>

--- a/pandora-client-web/src/components/wardrobe/wardrobeItems.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobeItems.tsx
@@ -57,7 +57,7 @@ export function useWardrobeItems(): {
 	const containerPath = useMemo(() => SplitContainerPath(currentFocus.container), [currentFocus.container]);
 	const containerItem = useWardrobeTargetItem(target, containerPath?.itemPath);
 	const containerContentsFilter = useMemo<(asset: Asset) => boolean>(() => {
-		const module = containerPath ? containerItem?.modules.get(containerPath.module) : undefined;
+		const module = containerPath ? containerItem?.getModules().get(containerPath.module) : undefined;
 		return module?.acceptedContentFilter?.bind(module) ?? (() => true);
 	}, [containerPath, containerItem]);
 
@@ -93,7 +93,7 @@ export function WardrobeItemManipulation({ className }: { className?: string; })
 		let container: IItemModule | undefined;
 		for (const step of currentFocus.container) {
 			const item = items.find((it) => it.id === step.item);
-			const module = item?.modules.get(step.module);
+			const module = item?.getModules().get(step.module);
 			if (!item || !module)
 				return false;
 			container = module;

--- a/pandora-client-web/src/editor/components/assetInfo/assetInfo.tsx
+++ b/pandora-client-web/src/editor/components/assetInfo/assetInfo.tsx
@@ -116,7 +116,7 @@ function Modules({ modules }: { modules: Immutable<AssetDefinition<'personal'>>[
 	);
 }
 
-function Module({ name, module }: { name: string; module: Immutable<AssetModuleDefinition>; }): ReactElement {
+function Module({ name, module }: { name: string; module: Immutable<AssetModuleDefinition<unknown>>; }): ReactElement {
 	const moduleInfo = useMemo(() => {
 		switch (module.type) {
 			case 'typed':
@@ -137,7 +137,7 @@ function Module({ name, module }: { name: string; module: Immutable<AssetModuleD
 	);
 }
 
-function UnknownModule({ module }: { module: Immutable<AssetModuleDefinition>; }): ReactElement {
+function UnknownModule({ module }: { module: Immutable<IModuleConfigCommon<ModuleType>>; }): ReactElement {
 	return (
 		<div>
 			Unknown module type: { String(module.type) }
@@ -145,7 +145,7 @@ function UnknownModule({ module }: { module: Immutable<AssetModuleDefinition>; }
 	);
 }
 
-function TypedModule({ module }: { module: Immutable<IModuleConfigTyped>; }): ReactElement {
+function TypedModule({ module }: { module: Immutable<IModuleConfigTyped<unknown>>; }): ReactElement {
 	return (
 		<FieldsetToggle legend='Variants' className='slim-padding-inner'>
 			{ module.variants.map((variant, index) => (
@@ -155,7 +155,7 @@ function TypedModule({ module }: { module: Immutable<IModuleConfigTyped>; }): Re
 	);
 }
 
-function TypedModuleOptions({ options }: { options: Immutable<IModuleTypedOption>; }): ReactElement {
+function TypedModuleOptions({ options }: { options: Immutable<IModuleTypedOption<unknown>>; }): ReactElement {
 	const id = useId();
 	return (
 		<div>
@@ -171,7 +171,6 @@ function TypedModuleOptions({ options }: { options: Immutable<IModuleTypedOption
 				<label htmlFor={ `module-type-${id}-default` }>Default: </label>
 				<input id={ `module-type-${id}-default` } type='checkbox' checked={ options.default } disabled />
 			</div>
-			<Effects effects={ options.effects } id={ `module-type-${id}-` } />
 		</div>
 	);
 }

--- a/pandora-client-web/src/editor/parsing.ts
+++ b/pandora-client-web/src/editor/parsing.ts
@@ -1,5 +1,5 @@
 import { Immutable } from 'immer';
-import { ArmFingersSchema, ArmRotationSchema, Assert, AssertNever, AtomicCondition, Condition, ConditionOperatorSchema, LayerImageOverride, TransformDefinition, ZodMatcher, AtomicConditionLegsSchema, CharacterViewSchema } from 'pandora-common';
+import { ArmFingersSchema, ArmRotationSchema, Assert, AssertNever, AtomicCondition, Condition, ConditionOperatorSchema, LayerImageOverride, TransformDefinition, ZodMatcher, AtomicConditionLegsSchema, CharacterViewSchema, SplitStringFirstOccurrence } from 'pandora-common';
 
 const IsConditionOperator = ZodMatcher(ConditionOperatorSchema);
 
@@ -8,11 +8,6 @@ export function SplitAndClean(input: string, separator: string): string[] {
 		.split(separator)
 		.map((l) => l.trim())
 		.filter(Boolean);
-}
-
-function SplitFirst(input: string, separator: string): [string, string] {
-	const index = input.indexOf(separator);
-	return index < 0 ? [input, ''] : [input.substring(0, index), input.substring(index + 1)];
 }
 
 function ParseFloat(input: string): number {
@@ -244,7 +239,7 @@ export function SerializeLayerImageOverride(imageOverride: Immutable<LayerImageO
 }
 
 export function ParseLayerImageOverride(input: string, validBones: string[]): LayerImageOverride {
-	const [condition, image] = SplitFirst(input.trim(), ' ').map((i) => i.trim());
+	const [condition, image] = SplitStringFirstOccurrence(input.trim(), ' ').map((i) => i.trim());
 	return {
 		image,
 		condition: ParseCondition(condition, validBones),

--- a/pandora-client-web/src/graphics/appearanceConditionEvaluator.ts
+++ b/pandora-client-web/src/graphics/appearanceConditionEvaluator.ts
@@ -19,7 +19,7 @@ export class AppearanceConditionEvaluator {
 	public evalCondition(condition: Immutable<AtomicCondition>, item: Item | null): boolean {
 		if ('module' in condition) {
 			Assert(condition.module != null);
-			const m = item?.modules.get(condition.module);
+			const m = item?.getModules().get(condition.module);
 			// If there is no item or no module, the value is always not equal
 			if (!m) {
 				return condition.operator === '!=';

--- a/pandora-client-web/src/graphics/appearanceConditionEvaluator.ts
+++ b/pandora-client-web/src/graphics/appearanceConditionEvaluator.ts
@@ -102,7 +102,8 @@ export class AppearanceConditionEvaluator extends ConditionEvaluatorBase {
 	public override evalCondition(condition: Immutable<AtomicCondition>, item: Item | null): boolean {
 		if ('module' in condition) {
 			Assert(condition.module != null);
-			const m = item?.getModules().get(condition.module);
+			const m = (item?.isType('roomDeviceWearablePart') ? item?.roomDevice?.getModules() : item?.getModules())
+				?.get(condition.module);
 			// If there is no item or no module, the value is always not equal
 			if (!m) {
 				return condition.operator === '!=';

--- a/pandora-client-web/src/graphics/appearanceConditionEvaluator.ts
+++ b/pandora-client-web/src/graphics/appearanceConditionEvaluator.ts
@@ -3,20 +3,103 @@ import { useMemo } from 'react';
 import { EvaluateCondition, RotateVector } from './utility';
 import type { Immutable } from 'immer';
 
-export class AppearanceConditionEvaluator {
+export abstract class ConditionEvaluatorBase {
 	public readonly assetManager: AssetManager;
+
+	constructor(assetManager: AssetManager) {
+		this.assetManager = assetManager;
+	}
+
+	//#region Point transform
+	public abstract evalCondition(condition: Immutable<AtomicCondition>, item: Item | null): boolean;
+
+	protected _evalConditionCore<T extends string | number>({ operator, value }: AtomicCondition & { value: T; operator: ConditionOperator; }, currentValue: T): boolean {
+		let diff = 0;
+		if (typeof currentValue === 'string' && typeof value === 'string') {
+			diff = currentValue.localeCompare(value);
+		} else if (typeof currentValue === 'number' && typeof value === 'number') {
+			diff = currentValue - value;
+		} else {
+			AssertNever();
+		}
+		switch (operator) {
+			case '>':
+				return diff > 0;
+			case '<':
+				return diff < 0;
+			case '=':
+				return diff === 0;
+			case '!=':
+				return diff !== 0;
+			case '>=':
+				return diff >= 0;
+			case '<=':
+				return diff <= 0;
+		}
+		AssertNever(operator);
+	}
+
+	public evalTransform([x, y]: [number, number], transforms: readonly TransformDefinition[], _mirror: boolean, item: Item | null, valueOverrides?: Record<BoneName, number>): [number, number] {
+		let [resX, resY] = [x, y];
+		for (const transform of transforms) {
+			const { type, condition } = transform;
+			if (valueOverrides != null && (type === 'const-shift' || type === 'const-rotate')) {
+				continue;
+			}
+			if (condition && !EvaluateCondition(condition, (c) => this.evalCondition(c, item))) {
+				continue;
+			}
+			if (type === 'const-shift') {
+				resX += transform.value.x;
+				resY += transform.value.y;
+				continue;
+			}
+			const boneName = transform.bone;
+			const bone = this._getBone(boneName);
+			const rotation = valueOverrides ? (valueOverrides[boneName] ?? 0) : bone.rotation;
+
+			switch (type) {
+				case 'const-rotate':
+				case 'rotate': {
+					let vecX = resX - bone.definition.x;
+					let vecY = resY - bone.definition.y;
+					const value = type === 'const-rotate' ? transform.value : transform.value * rotation;
+					[vecX, vecY] = RotateVector(vecX, vecY, value);
+					resX = bone.definition.x + vecX;
+					resY = bone.definition.y + vecY;
+					break;
+				}
+				case 'shift': {
+					const percent = rotation / 180;
+					resX += percent * transform.value.x;
+					resY += percent * transform.value.y;
+					break;
+				}
+			}
+		}
+		return [resX, resY];
+	}
+	//#endregion
+
+	protected abstract _getBone(bone: string): BoneState;
+
+	public getBoneLikeValue(name: string): number {
+		return this._getBone(name).rotation;
+	}
+}
+
+export class AppearanceConditionEvaluator extends ConditionEvaluatorBase {
 	public readonly pose: Immutable<AppearancePose>;
 	public readonly attributes: ReadonlySet<string>;
 
 	constructor(character: AssetFrameworkCharacterState) {
-		this.assetManager = character.assetManager;
+		super(character.assetManager);
 		this.pose = character.actualPose;
 		this.attributes = AppearanceItemProperties(character.items).attributes;
 	}
 
-	//#region Point transform
 	private readonly _evalCache = new Map<string, boolean>();
-	public evalCondition(condition: Immutable<AtomicCondition>, item: Item | null): boolean {
+	public override evalCondition(condition: Immutable<AtomicCondition>, item: Item | null): boolean {
 		if ('module' in condition) {
 			Assert(condition.module != null);
 			const m = item?.getModules().get(condition.module);
@@ -64,75 +147,7 @@ export class AppearanceConditionEvaluator {
 		}
 	}
 
-	private _evalConditionCore<T extends string | number>({ operator, value }: AtomicCondition & { value: T; operator: ConditionOperator; }, currentValue: T): boolean {
-		let diff = 0;
-		if (typeof currentValue === 'string' && typeof value === 'string') {
-			diff = currentValue.localeCompare(value);
-		} else if (typeof currentValue === 'number' && typeof value === 'number') {
-			diff = currentValue - value;
-		} else {
-			AssertNever();
-		}
-		switch (operator) {
-			case '>':
-				return diff > 0;
-			case '<':
-				return diff < 0;
-			case '=':
-				return diff === 0;
-			case '!=':
-				return diff !== 0;
-			case '>=':
-				return diff >= 0;
-			case '<=':
-				return diff <= 0;
-		}
-		AssertNever(operator);
-	}
-
-	public evalTransform([x, y]: [number, number], transforms: readonly TransformDefinition[], _mirror: boolean, item: Item | null, valueOverrides?: Record<BoneName, number>): [number, number] {
-		let [resX, resY] = [x, y];
-		for (const transform of transforms) {
-			const { type, condition } = transform;
-			if (valueOverrides != null && (type === 'const-shift' || type === 'const-rotate')) {
-				continue;
-			}
-			if (condition && !EvaluateCondition(condition, (c) => this.evalCondition(c, item))) {
-				continue;
-			}
-			if (type === 'const-shift') {
-				resX += transform.value.x;
-				resY += transform.value.y;
-				continue;
-			}
-			const boneName = transform.bone;
-			const bone = this.getBone(boneName);
-			const rotation = valueOverrides ? (valueOverrides[boneName] ?? 0) : bone.rotation;
-
-			switch (type) {
-				case 'const-rotate':
-				case 'rotate': {
-					let vecX = resX - bone.definition.x;
-					let vecY = resY - bone.definition.y;
-					const value = type === 'const-rotate' ? transform.value : transform.value * rotation;
-					[vecX, vecY] = RotateVector(vecX, vecY, value);
-					resX = bone.definition.x + vecX;
-					resY = bone.definition.y + vecY;
-					break;
-				}
-				case 'shift': {
-					const percent = rotation / 180;
-					resX += percent * transform.value.x;
-					resY += percent * transform.value.y;
-					break;
-				}
-			}
-		}
-		return [resX, resY];
-	}
-	//#endregion
-
-	private getBone(bone: string): BoneState {
+	protected override _getBone(bone: string): BoneState {
 		const definition = this.assetManager.getBoneByName(bone);
 		if (definition == null)
 			throw new Error(`Attempt to get pose for unknown bone: ${bone}`);
@@ -141,12 +156,48 @@ export class AppearanceConditionEvaluator {
 			rotation: this.pose.bones[definition.name] || 0,
 		};
 	}
-
-	public getBoneLikeValue(name: string): number {
-		return this.getBone(name).rotation;
-	}
 }
 
 export function useAppearanceConditionEvaluator(characterState: AssetFrameworkCharacterState): AppearanceConditionEvaluator {
 	return useMemo(() => new AppearanceConditionEvaluator(characterState), [characterState]);
+}
+
+export class StandaloneConditionEvaluator extends ConditionEvaluatorBase {
+	private readonly _evalCache = new Map<string, boolean>();
+	public override evalCondition(condition: Immutable<AtomicCondition>, item: Item | null): boolean {
+		if ('module' in condition) {
+			Assert(condition.module != null);
+			const m = item?.getModules().get(condition.module);
+			// If there is no item or no module, the value is always not equal
+			if (!m) {
+				return condition.operator === '!=';
+			}
+			return m.evalCondition(condition.operator, condition.value);
+		} else if ('bone' in condition) {
+			Assert(condition.bone != null);
+			return false;
+		} else if ('armType' in condition) {
+			Assert(condition.armType != null);
+			return false;
+		} else if ('attribute' in condition) {
+			Assert(condition.attribute != null);
+			return false;
+		} else if ('legs' in condition) {
+			Assert(condition.legs != null);
+			return false;
+		} else if ('view' in condition) {
+			Assert(condition.view != null);
+			return false;
+		} else {
+			AssertNever(condition);
+		}
+	}
+
+	protected override _getBone(_bone: string): BoneState {
+		throw new Error(`Attempt to get bone in standalone evaluator`);
+	}
+}
+
+export function useStandaloneConditionEvaluator(assetManager: AssetManager): StandaloneConditionEvaluator {
+	return useMemo(() => new StandaloneConditionEvaluator(assetManager), [assetManager]);
 }

--- a/pandora-client-web/src/graphics/graphicsLayer.tsx
+++ b/pandora-client-web/src/graphics/graphicsLayer.tsx
@@ -8,7 +8,7 @@ import { IArrayBuffer, Rectangle, Texture } from 'pixi.js';
 import React, { createContext, ReactElement, useCallback, useContext, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { AssetGraphicsLayer, PointDefinitionCalculated, useLayerCalculatedPoints, useLayerDefinition, useLayerHasAlphaMasks } from '../assets/assetGraphics';
 import { ChildrenProps } from '../common/reactTypes';
-import { AppearanceConditionEvaluator, useAppearanceConditionEvaluator } from './appearanceConditionEvaluator';
+import { ConditionEvaluatorBase, useAppearanceConditionEvaluator } from './appearanceConditionEvaluator';
 import { LayerStateOverrides } from './def';
 import { GraphicsMaskLayer } from './graphicsMaskLayer';
 import { useGraphicsSettings } from './graphicsSettings';
@@ -68,7 +68,7 @@ export function MirrorPoint([x, y]: CoordinatesCompressed, mirror: LayerMirror, 
 }
 
 export function useLayerVertices(
-	evaluator: AppearanceConditionEvaluator,
+	evaluator: ConditionEvaluatorBase,
 	points: readonly PointDefinitionCalculated[],
 	layer: AssetGraphicsLayer,
 	item: Item | null,

--- a/pandora-common/src/assets/appearanceActions.ts
+++ b/pandora-common/src/assets/appearanceActions.ts
@@ -1015,7 +1015,7 @@ export function ActionRoomDeviceEnter({
 
 	if (!processingContext.manipulator.produceCharacterState(
 		action.character.characterId,
-		(character) => character.updateRoomStateLink(processingContext.manipulator.currentState.room),
+		(character) => character.updateRoomStateLink(processingContext.manipulator.currentState.room, false),
 	))
 		return processingContext.invalid();
 

--- a/pandora-common/src/assets/appearanceActions.ts
+++ b/pandora-common/src/assets/appearanceActions.ts
@@ -819,6 +819,8 @@ export function ActionAppearanceRandomize({
 		properties = item.getPropertiesParts().reduce(MergeAssetProperties, properties);
 	});
 
+	const room = processingContext.manipulator.currentState.room;
+
 	// Build body if running full randomization
 	if (kind === 'full') {
 		const usedSingularBodyparts = new Set<string>();
@@ -854,11 +856,11 @@ export function ActionAppearanceRandomize({
 		}
 
 		// Re-load the appearance we have to make sure body is valid
-		newAppearance = CharacterAppearanceLoadAndValidate(assetManager, newAppearance).slice();
+		newAppearance = CharacterAppearanceLoadAndValidate(assetManager, newAppearance, room).slice();
 	}
 
 	// Make sure the appearance is valid (required for items step)
-	let r = ValidateAppearanceItems(assetManager, newAppearance);
+	let r = ValidateAppearanceItems(assetManager, newAppearance, room);
 	if (!r.success) {
 		processingContext.addProblem({
 			result: 'validationError',
@@ -894,7 +896,7 @@ export function ActionAppearanceRandomize({
 			const item = assetManager.createItem(`i/${nanoid()}`, asset, null);
 			const newItems: Item<WearableAssetType>[] = [...newAppearance, item];
 
-			r = ValidateAppearanceItemsPrefix(assetManager, newItems);
+			r = ValidateAppearanceItemsPrefix(assetManager, newItems, room);
 			if (r.success) {
 				newAppearance = newItems;
 				usedAssets.add(asset);
@@ -981,10 +983,7 @@ export function ActionRoomDeviceEnter({
 
 	const wearableItem = assetManager
 		.createItem(action.itemId, asset, null)
-		.withLink({
-			device: item.id,
-			slot: action.slot,
-		});
+		.withLink(item, action.slot);
 	// Player adding the item must be able to use it
 	r = playerRestrictionManager.canUseItemDirect(processingContext, targetCharacter, [], wearableItem, ItemInteractionType.ADD_REMOVE);
 	if (!r.allowed) {
@@ -1012,6 +1011,12 @@ export function ActionRoomDeviceEnter({
 		return processingContext.invalid();
 
 	if (!characterManipulator.addItem(wearableItem))
+		return processingContext.invalid();
+
+	if (!processingContext.manipulator.produceCharacterState(
+		action.character.characterId,
+		(character) => character.updateRoomStateLink(processingContext.manipulator.currentState.room),
+	))
 		return processingContext.invalid();
 
 	// Change message to chat

--- a/pandora-common/src/assets/appearanceHelpers.ts
+++ b/pandora-common/src/assets/appearanceHelpers.ts
@@ -7,6 +7,7 @@ import { AppearanceItems, AppearanceItemsFixBodypartOrder } from './appearanceVa
 import { Assert, AssertNever } from '../utility';
 import { AssetFrameworkGlobalStateManipulator } from './manipulators/globalStateManipulator';
 import { CharacterId } from '../character';
+import { AssetFrameworkGlobalState } from './state/globalState';
 
 export function SplitContainerPath(path: ItemContainerPath): {
 	itemPath: ItemPath;
@@ -58,6 +59,8 @@ export abstract class AppearanceManipulator {
 	public abstract readonly containerPath: IContainerPathActual | null;
 
 	public readonly assetManager: AssetManager;
+
+	public abstract get currentState(): AssetFrameworkGlobalState;
 
 	constructor(assetManager: AssetManager) {
 		this.assetManager = assetManager;
@@ -143,6 +146,10 @@ class AppearanceContainerManipulator extends AppearanceManipulator {
 		];
 	}
 
+	public override get currentState(): AssetFrameworkGlobalState {
+		return this._base.currentState;
+	}
+
 	constructor(base: AppearanceManipulator, item: ItemId, module: string) {
 		super(base.assetManager);
 		this._base = base;
@@ -175,6 +182,10 @@ export class AppearanceRootManipulator extends AppearanceManipulator {
 
 	public readonly container: null = null;
 	public readonly containerPath: IContainerPathActual = [];
+
+	public override get currentState(): AssetFrameworkGlobalState {
+		return this._base.currentState;
+	}
 
 	constructor(base: AssetFrameworkGlobalStateManipulator, target: RoomTargetSelector) {
 		super(base.assetManager);

--- a/pandora-common/src/assets/appearanceHelpers.ts
+++ b/pandora-common/src/assets/appearanceHelpers.ts
@@ -131,12 +131,12 @@ class AppearanceContainerManipulator extends AppearanceManipulator {
 
 	public get container(): IItemModule | null {
 		const item = this._base.getItems().find((i) => i.id === this._item);
-		return item?.modules.get(this._module) ?? null;
+		return item?.getModules().get(this._module) ?? null;
 	}
 	public get containerPath(): IContainerPathActual | null {
 		const basePath = this._base.containerPath;
 		const item = this._base.getItems().find((i) => i.id === this._item);
-		const module = item?.modules.get(this._module);
+		const module = item?.getModules().get(this._module);
 		return (!basePath || !item || !module) ? null : [
 			...basePath,
 			{ item, moduleName: this._module, module },

--- a/pandora-common/src/assets/asset.ts
+++ b/pandora-common/src/assets/asset.ts
@@ -30,7 +30,7 @@ export class Asset<Type extends AssetType = AssetType> {
 		if (definition.type === 'personal') {
 			definition.attributes?.forEach((a) => staticAttributes.add(a));
 			for (const module of Object.values(definition.modules ?? {})) {
-				GetModuleStaticAttributes(module).forEach((a) => staticAttributes.add(a));
+				GetModuleStaticAttributes(module, (p) => new Set(p.attributes)).forEach((a) => staticAttributes.add(a));
 			}
 		} else if (definition.type === 'roomDevice') {
 			definition.staticAttributes?.forEach((a) => staticAttributes.add(a));

--- a/pandora-common/src/assets/assetManager.ts
+++ b/pandora-common/src/assets/assetManager.ts
@@ -5,7 +5,7 @@ import type { ItemId } from './appearanceTypes';
 import { Asset } from './asset';
 import { AppearanceRandomizationData, AssetAttributeDefinition, AssetBodyPart, AssetId, AssetsDefinitionFile, AssetSlotDefinition, AssetsPosePresets, AssetType, BackgroundTagDefinition, IChatroomBackgroundInfo } from './definitions';
 import { BoneDefinition, BoneDefinitionCompressed, CharacterSize } from './graphics';
-import { CreateItem, Item, ItemBundle } from './item';
+import { LoadItemFromBundle, Item, ItemBundle } from './item';
 
 export class AssetManager {
 	protected readonly _assets: ReadonlyMap<AssetId, Asset>;
@@ -191,7 +191,7 @@ export class AssetManager {
 
 	public createItem<T extends AssetType>(id: ItemId, asset: Asset<T>, bundle: ItemBundle | null, logger?: Logger): Item<T> {
 		Assert(this._assets.get(asset.id) === asset);
-		return CreateItem<T>(id, asset, bundle ?? {
+		return LoadItemFromBundle<T>(asset, bundle ?? {
 			id,
 			asset: asset.id,
 		}, {

--- a/pandora-common/src/assets/definitions.ts
+++ b/pandora-common/src/assets/definitions.ts
@@ -153,7 +153,7 @@ export interface PersonalAssetDefinition<A extends AssetDefinitionExtraArgs = As
 	/**
 	 * Modules this asset has
 	 */
-	modules?: Record<string, AssetModuleDefinition<A>>;
+	modules?: Record<string, AssetModuleDefinition<AssetProperties<A>>>;
 
 	/** If this item has any graphics to be loaded or is only virtual */
 	hasGraphics: boolean;

--- a/pandora-common/src/assets/definitions.ts
+++ b/pandora-common/src/assets/definitions.ts
@@ -10,6 +10,7 @@ import { Immutable, freeze, produce } from 'immer';
 import { AssetManager } from './assetManager';
 import _ from 'lodash';
 import { BONE_MAX, BONE_MIN } from './appearance';
+import { RoomDeviceProperties } from './roomDeviceProperties';
 
 export const AssetIdSchema = ZodTemplateString<`a/${string}`>(z.string(), /^a\//);
 export type AssetId = z.infer<typeof AssetIdSchema>;
@@ -218,6 +219,8 @@ export interface RoomDeviceAssetDefinition<A extends AssetDefinitionExtraArgs = 
 	pivot: Coordinates;
 	/** Slots that can be entered by characters */
 	slots: Record<string, RoomDeviceSlot<A>>;
+	/** Modules this device has */
+	modules?: Record<string, AssetModuleDefinition<RoomDeviceProperties<A>>>;
 	/** The graphical display of the device */
 	graphicsLayers: IRoomDeviceGraphicsLayer[];
 	/** Attributes that are used strictly for filtering, no effect on character */

--- a/pandora-common/src/assets/definitions.ts
+++ b/pandora-common/src/assets/definitions.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import type { IChatroomBackgroundData } from '../chatroom';
 import { HexRGBAColorString, ZodTemplateString } from '../validation';
 import type { AppearanceArmPose, AppearancePose } from './state/characterState';
-import type { BoneDefinitionCompressed, BoneName, BoneType, CharacterView, Coordinates, LayerImageOverride, LegsPose } from './graphics';
+import type { BoneDefinitionCompressed, BoneName, BoneType, CharacterView, Condition, Coordinates, LayerImageOverride, LegsPose } from './graphics';
 import { AssetModuleDefinition } from './modules';
 import { AssetLockProperties, AssetProperties } from './properties';
 import { Satisfies } from '../utility';
@@ -185,28 +185,36 @@ export type IRoomDeviceGraphicsLayerSprite = {
 	offsetY?: number;
 };
 
+export type IRoomDeviceGraphicsCharacterPosition = {
+	offsetX: number;
+	offsetY: number;
+	/**
+	 * Is the factor by which the character is made bigger or smaller inside the room device slot,
+	 * compared to this room device scaled inside the room
+	 * @default 1
+	 */
+	relativeScale?: number;
+	/**
+	 * Prevents pose from changing character's offset while inside this room device slot
+	 * (for slots that allow different poses, but require precision)
+	 * @default false
+	 */
+	disablePoseOffset?: boolean;
+};
+
+export type IRoomDeviceGraphicsCharacterPositionOverride = {
+	position: IRoomDeviceGraphicsCharacterPosition;
+	condition: Condition;
+};
+
 export type IRoomDeviceGraphicsLayerSlot = {
 	type: 'slot';
 	/**
 	 * Is the name of the character slot that is drawn on this layer.
 	 */
 	slot: string;
-	characterPosition: {
-		offsetX: number;
-		offsetY: number;
-		/**
-		 * Is the factor by which the character is made bigger or smaller inside the room device slot,
-		 * compared to this room device scaled inside the room
-		 * @default 1
-		 */
-		relativeScale?: number;
-		/**
-		 * Prevents pose from changing character's offset while inside this room device slot
-		 * (for slots that allow different poses, but require precision)
-		 * @default false
-		 */
-		disablePoseOffset?: boolean;
-	};
+	characterPosition: IRoomDeviceGraphicsCharacterPosition;
+	characterPositionOverrides?: IRoomDeviceGraphicsCharacterPositionOverride[];
 };
 
 export type IRoomDeviceGraphicsLayer = IRoomDeviceGraphicsLayerSprite | IRoomDeviceGraphicsLayerSlot;

--- a/pandora-common/src/assets/definitions.ts
+++ b/pandora-common/src/assets/definitions.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import type { IChatroomBackgroundData } from '../chatroom';
 import { HexRGBAColorString, ZodTemplateString } from '../validation';
 import type { AppearanceArmPose, AppearancePose } from './state/characterState';
-import type { BoneDefinitionCompressed, BoneName, BoneType, CharacterView, Coordinates, LegsPose } from './graphics';
+import type { BoneDefinitionCompressed, BoneName, BoneType, CharacterView, Coordinates, LayerImageOverride, LegsPose } from './graphics';
 import { AssetModuleDefinition } from './modules';
 import { AssetLockProperties, AssetProperties } from './properties';
 import { Satisfies } from '../utility';
@@ -170,6 +170,7 @@ export type RoomDeviceSlot<A extends AssetDefinitionExtraArgs = AssetDefinitionE
 export type IRoomDeviceGraphicsLayerSprite = {
 	type: 'sprite';
 	image: string;
+	imageOverrides?: LayerImageOverride[];
 	/** Name of colorization key used to color this sprite layer */
 	colorizationKey?: string;
 	/**

--- a/pandora-common/src/assets/definitions.ts
+++ b/pandora-common/src/assets/definitions.ts
@@ -174,15 +174,14 @@ export type IRoomDeviceGraphicsLayerSprite = {
 	/** Name of colorization key used to color this sprite layer */
 	colorizationKey?: string;
 	/**
-	 * Horizontal offset of this sprite relative to cage's origin point
-	 * @default 0
+	 * Offset of this sprite relative to cage's origin point
+	 * @default { x: 0, y: 0 }
 	 */
-	offsetX?: number;
-	/**
-	 * Vertical offset of this sprite relative to cage's origin point
-	 * @default 0
-	 */
-	offsetY?: number;
+	offset?: Coordinates;
+	offsetOverrides?: {
+		offset: Coordinates;
+		condition: Condition;
+	}[];
 };
 
 export type IRoomDeviceGraphicsCharacterPosition = {

--- a/pandora-common/src/assets/index.ts
+++ b/pandora-common/src/assets/index.ts
@@ -13,5 +13,6 @@ export * from './modules';
 export * from './state/_index';
 export * from './properties';
 export * from './graphics';
+export * from './roomDeviceProperties';
 export * from './roomInventory';
 export * from './roomValidation';

--- a/pandora-common/src/assets/item.ts
+++ b/pandora-common/src/assets/item.ts
@@ -23,6 +23,7 @@ export type ItemColorBundle = Readonly<z.infer<typeof ItemColorBundleSchema>>;
 export const RoomDeviceDeploymentSchema = z.object({
 	x: z.number(),
 	y: z.number(),
+	yOffset: z.number().int().catch(0),
 }).nullable();
 export type RoomDeviceDeployment = z.infer<typeof RoomDeviceDeploymentSchema>;
 

--- a/pandora-common/src/assets/modules/common.ts
+++ b/pandora-common/src/assets/modules/common.ts
@@ -1,7 +1,6 @@
 import type { Asset } from '../asset';
 import type { ConditionOperator } from '../graphics';
 import type { ItemInteractionType } from '../../character';
-import type { AssetProperties } from '../properties';
 import type { AppearanceItems, AppearanceValidationResult } from '../appearanceValidation';
 import type { AssetManager } from '../assetManager';
 import type { IItemLoadContext, IItemLocationDescriptor } from '../item';
@@ -25,30 +24,30 @@ export interface IModuleActionCommon<Type extends ModuleType> {
 }
 
 export interface IAssetModuleDefinition<Type extends ModuleType> {
-	parseData(config: IModuleConfigCommon<Type>, data: unknown, assetManager: AssetManager): IAssetModuleTypes[Type]['data'];
-	loadModule(config: IModuleConfigCommon<Type>, data: IAssetModuleTypes[Type]['data'], context: IItemLoadContext): IItemModule<Type>;
-	getStaticAttributes(config: IModuleConfigCommon<Type>): ReadonlySet<string>;
+	parseData(config: IModuleConfigCommon<Type>, data: unknown, assetManager: AssetManager): IAssetModuleTypes<unknown>[Type]['data'];
+	loadModule<TProperties>(config: IModuleConfigCommon<Type>, data: IAssetModuleTypes<unknown>[Type]['data'], context: IItemLoadContext): IItemModule<TProperties, Type>;
+	getStaticAttributes<TProperties>(config: IModuleConfigCommon<Type>, staticAttributesExtractor: (properties: TProperties) => ReadonlySet<string>): ReadonlySet<string>;
 }
 
 export interface IExportOptions {
 	clientOnly?: true;
 }
 
-export interface IItemModule<Type extends ModuleType = ModuleType> {
+export interface IItemModule<out TProperties = unknown, Type extends ModuleType = ModuleType> {
 	readonly type: Type;
-	readonly config: IAssetModuleTypes[Type]['config'];
+	readonly config: IAssetModuleTypes<TProperties>[Type]['config'];
 
 	/** The module specifies what kind of interaction type interacting with it is */
 	readonly interactionType: ItemInteractionType;
 
-	exportData(options: IExportOptions): IAssetModuleTypes[Type]['data'];
+	exportData(options: IExportOptions): IAssetModuleTypes<TProperties>[Type]['data'];
 
 	validate(location: IItemLocationDescriptor): AppearanceValidationResult;
 
-	getProperties(): AssetProperties;
+	getProperties(): readonly TProperties[];
 
 	evalCondition(operator: ConditionOperator, value: string): boolean;
-	doAction(context: AppearanceModuleActionContext, action: IAssetModuleTypes[Type]['actions']): IItemModule<Type> | null;
+	doAction(context: AppearanceModuleActionContext, action: IAssetModuleTypes<TProperties>[Type]['actions']): IItemModule<TProperties, Type> | null;
 
 	/** If the contained items are physically equipped (meaning they are cheked for 'allow add/remove' when being added and removed) */
 	readonly contentsPhysicallyEquipped: boolean;
@@ -57,7 +56,7 @@ export interface IItemModule<Type extends ModuleType = ModuleType> {
 	getContents(): AppearanceItems;
 
 	/** Sets content of this module */
-	setContents(items: AppearanceItems): IItemModule<Type> | null;
+	setContents(items: AppearanceItems): IItemModule<TProperties, Type> | null;
 
 	acceptedContentFilter?(asset: Asset): boolean;
 }

--- a/pandora-common/src/assets/modules/common.ts
+++ b/pandora-common/src/assets/modules/common.ts
@@ -3,7 +3,7 @@ import type { ConditionOperator } from '../graphics';
 import type { ItemInteractionType } from '../../character';
 import type { AppearanceItems, AppearanceValidationResult } from '../appearanceValidation';
 import type { AssetManager } from '../assetManager';
-import type { IItemLoadContext, IItemLocationDescriptor } from '../item';
+import type { IItemLoadContext, IItemValidationContext } from '../item';
 import type { AppearanceModuleActionContext } from '../appearanceActions';
 import type { IAssetModuleTypes, ModuleType } from '../modules';
 
@@ -42,7 +42,7 @@ export interface IItemModule<out TProperties = unknown, Type extends ModuleType 
 
 	exportData(options: IExportOptions): IAssetModuleTypes<TProperties>[Type]['data'];
 
-	validate(location: IItemLocationDescriptor): AppearanceValidationResult;
+	validate(context: IItemValidationContext): AppearanceValidationResult;
 
 	getProperties(): readonly TProperties[];
 

--- a/pandora-common/src/assets/roomDeviceProperties.ts
+++ b/pandora-common/src/assets/roomDeviceProperties.ts
@@ -1,0 +1,37 @@
+import { Immutable } from 'immer';
+import type { AssetDefinitionExtraArgs } from './definitions';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export interface RoomDeviceProperties<A extends AssetDefinitionExtraArgs = AssetDefinitionExtraArgs> {
+	/**
+	 * Prevents listed modules from being modified by anyone, including on oneself
+	 * @default []
+	 */
+	blockModules?: string[];
+
+	/**
+		 * Prevents listed modules from being modified by anyone wearing this item
+		 * @default []
+		 */
+	blockSelfModules?: string[];
+
+}
+
+export interface RoomDevicePropertiesResult {
+	blockModules: Set<string>;
+	blockSelfModules: Set<string>;
+}
+
+export function CreateRoomDevicePropertiesResult(): RoomDevicePropertiesResult {
+	return {
+		blockModules: new Set(),
+		blockSelfModules: new Set(),
+	};
+}
+
+export function MergeRoomDeviceProperties<T extends RoomDevicePropertiesResult>(base: T, properties: Immutable<RoomDeviceProperties>): T {
+	properties.blockModules?.forEach((a) => base.blockModules.add(a));
+	properties.blockSelfModules?.forEach((a) => base.blockSelfModules.add(a));
+
+	return base;
+}

--- a/pandora-common/src/assets/roomDeviceProperties.ts
+++ b/pandora-common/src/assets/roomDeviceProperties.ts
@@ -1,8 +1,14 @@
 import { Immutable } from 'immer';
 import type { AssetDefinitionExtraArgs } from './definitions';
+import { AssetProperties } from './properties';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface RoomDeviceProperties<A extends AssetDefinitionExtraArgs = AssetDefinitionExtraArgs> {
+	/**
+	 * Properties for individual slots.
+	 * @default {}
+	 */
+	slotProperties?: Partial<Record<string, AssetProperties<A>>>;
+
 	/**
 	 * Prevents listed modules from being modified by anyone, including on oneself
 	 * @default []
@@ -10,28 +16,70 @@ export interface RoomDeviceProperties<A extends AssetDefinitionExtraArgs = Asset
 	blockModules?: string[];
 
 	/**
-		 * Prevents listed modules from being modified by anyone wearing this item
-		 * @default []
-		 */
+	 * Prevents listed modules from being modified by anyone wearing this item
+	 * @default []
+	 */
 	blockSelfModules?: string[];
 
+	/**
+	 * Prevents this slot from being entered or exited by anyone, including on oneself
+	 * @default false
+	 */
+	blockSlotsEnterLeave?: string[];
+
+	/**
+	 * Prevents this slot from being entered or exited by the character herself
+	 * @default false
+	 */
+	blockSlotsSelfEnterLeave?: string[];
 }
 
 export interface RoomDevicePropertiesResult {
+	slotProperties: Partial<Record<string, Immutable<AssetProperties>[]>>;
 	blockModules: Set<string>;
 	blockSelfModules: Set<string>;
+	blockSlotsEnterLeave: Set<string>;
+	blockSlotsSelfEnterLeave: Set<string>;
 }
 
 export function CreateRoomDevicePropertiesResult(): RoomDevicePropertiesResult {
 	return {
+		slotProperties: {},
 		blockModules: new Set(),
 		blockSelfModules: new Set(),
+		blockSlotsEnterLeave: new Set(),
+		blockSlotsSelfEnterLeave: new Set(),
 	};
 }
 
 export function MergeRoomDeviceProperties<T extends RoomDevicePropertiesResult>(base: T, properties: Immutable<RoomDeviceProperties>): T {
+	for (const [slot, slotProperties] of Object.entries(properties.slotProperties ?? {})) {
+		if (slotProperties == null)
+			continue;
+
+		(base.slotProperties[slot] ??= []).push(slotProperties);
+	}
+
 	properties.blockModules?.forEach((a) => base.blockModules.add(a));
 	properties.blockSelfModules?.forEach((a) => base.blockSelfModules.add(a));
+	properties.blockSlotsEnterLeave?.forEach((a) => base.blockSlotsEnterLeave.add(a));
+	properties.blockSlotsSelfEnterLeave?.forEach((a) => base.blockSlotsSelfEnterLeave.add(a));
 
 	return base;
+}
+
+export function GetPropertiesForSlot(deviceProperties: RoomDevicePropertiesResult, slot: string): Immutable<AssetProperties>[] {
+	const result: Immutable<AssetProperties>[] = [];
+
+	const slotProperties = deviceProperties.slotProperties[slot];
+	if (slotProperties != null) {
+		result.push(...slotProperties);
+	}
+
+	result.push({
+		blockAddRemove: deviceProperties.blockSlotsEnterLeave.has(slot),
+		blockSelfAddRemove: deviceProperties.blockSlotsSelfEnterLeave.has(slot),
+	});
+
+	return result;
 }

--- a/pandora-common/src/assets/roomValidation.ts
+++ b/pandora-common/src/assets/roomValidation.ts
@@ -22,7 +22,10 @@ export function ValidateRoomInventoryItemsPrefix(_assetManager: AssetManager, it
 		ids.add(item.id);
 
 		// Run internal item validation
-		const r = item.validate('roomInventory');
+		const r = item.validate({
+			roomState: null, // Cannot access room state while validating the room itself
+			location: 'roomInventory',
+		});
 		if (!r.success)
 			return r;
 	}

--- a/pandora-common/src/assets/state/characterState.ts
+++ b/pandora-common/src/assets/state/characterState.ts
@@ -1,6 +1,6 @@
 import { AppearanceItemProperties, AppearanceItems, AppearanceValidationResult, CharacterAppearanceLoadAndValidate, ValidateAppearanceItems } from '../appearanceValidation';
 import { AssetsPosePreset, MergePartialAppearancePoses, PartialAppearancePose, ProduceAppearancePose, WearableAssetType } from '../definitions';
-import { Assert, MemoizeNoArg } from '../../utility';
+import { Assert, IsNotNullable, MemoizeNoArg } from '../../utility';
 import { ZodArrayWithInvalidDrop } from '../../validation';
 import { Immutable, freeze } from 'immer';
 import { z } from 'zod';
@@ -81,14 +81,13 @@ export class AssetFrameworkCharacterState implements AssetFrameworkCharacterStat
 		this.safemode = 'safemode' in override ? override.safemode : props.safemode;
 	}
 
-	public isValid(): boolean {
-		return this.validate().success;
+	public isValid(roomState: AssetFrameworkRoomState | null): boolean {
+		return this.validate(roomState).success;
 	}
 
-	@MemoizeNoArg
-	public validate(): AppearanceValidationResult {
+	public validate(roomState: AssetFrameworkRoomState | null): AppearanceValidationResult {
 		{
-			const r = ValidateAppearanceItems(this.assetManager, this.items);
+			const r = ValidateAppearanceItems(this.assetManager, this.items, roomState);
 			if (!r.success)
 				return r;
 		}
@@ -187,44 +186,52 @@ export class AssetFrameworkCharacterState implements AssetFrameworkCharacterStat
 		return new AssetFrameworkCharacterState(this, { safemode: freeze(value ?? undefined, true) });
 	}
 
-	public cleanupRoomDeviceWearables(roomInventory: AssetFrameworkRoomState | null): AssetFrameworkCharacterState {
-		const cleanedUpItems = this.items.filter((item) => {
+	public updateRoomStateLink(roomInventory: AssetFrameworkRoomState | null): AssetFrameworkCharacterState {
+		const updatedItems = this.items.map((item) => {
 			if (item.isType('roomDeviceWearablePart')) {
 				const link = item.roomDeviceLink;
 				if (!roomInventory || !link)
-					return false;
+					return null;
 
 				// Target device must exist
 				const device = roomInventory.items.find((roomItem) => roomItem.id === link.device);
 				if (!device || !device.isType('roomDevice'))
-					return false;
+					return null;
 
 				// The device must have a matching slot
 				if (device.asset.definition.slots[item.roomDeviceLink.slot]?.wearableAsset !== item.asset.id)
-					return false;
+					return null;
 
 				// The device must be deployed with this character in target slot
 				if (!device.deployment || device.slotOccupancy.get(item.roomDeviceLink.slot) !== this.id)
-					return false;
-			}
-			return true;
-		});
+					return null;
 
-		if (cleanedUpItems.length === this.items.length)
+				return item.updateRoomStateLink(device);
+			}
+			return item;
+		}).filter(IsNotNullable);
+
+		if (
+			updatedItems.length === this.items.length &&
+			updatedItems.every((item, i) => this.items[i] === item)
+		) {
 			return this;
+		}
 
 		// Re-validate items as forceful removal might have broken dependencies
-		const newItems = CharacterAppearanceLoadAndValidate(this.assetManager, cleanedUpItems);
-		Assert(ValidateAppearanceItems(this.assetManager, newItems).success);
+		const newItems = CharacterAppearanceLoadAndValidate(this.assetManager, updatedItems, roomInventory);
+		Assert(ValidateAppearanceItems(this.assetManager, newItems, roomInventory).success);
 
-		return new AssetFrameworkCharacterState(this, { items: newItems });
+		return new AssetFrameworkCharacterState(this, {
+			items: newItems,
+		});
 	}
 
 	public static createDefault(assetManager: AssetManager, characterId: CharacterId): AssetFrameworkCharacterState {
-		return AssetFrameworkCharacterState.loadFromBundle(assetManager, characterId, undefined, undefined);
+		return AssetFrameworkCharacterState.loadFromBundle(assetManager, characterId, undefined, null, undefined);
 	}
 
-	public static loadFromBundle(assetManager: AssetManager, characterId: CharacterId, bundle: AppearanceBundle | undefined, logger: Logger | undefined): AssetFrameworkCharacterState {
+	public static loadFromBundle(assetManager: AssetManager, characterId: CharacterId, bundle: AppearanceBundle | undefined, roomState: AssetFrameworkRoomState | null, logger: Logger | undefined): AssetFrameworkCharacterState {
 		bundle = AppearanceBundleSchema.parse(bundle ?? GetDefaultAppearanceBundle());
 
 		// Load all items
@@ -237,12 +244,22 @@ export class AssetFrameworkCharacterState implements AssetFrameworkCharacterStat
 				continue;
 			}
 
-			const item = assetManager.createItem(itemBundle.id, asset, itemBundle, logger);
+			let item = assetManager.createItem(itemBundle.id, asset, itemBundle, logger);
+
+			// Properly link room device wearable parts
+			if (item.isType('roomDeviceWearablePart')) {
+				const link = item.roomDeviceLink;
+				const device = roomState?.items.find((roomItem) => roomItem.id === link?.device);
+				if (device?.isType('roomDevice')) {
+					item = item.updateRoomStateLink(device);
+				}
+			}
+
 			loadedItems.push(item);
 		}
 
 		// Validate and add all items
-		const newItems = CharacterAppearanceLoadAndValidate(assetManager, loadedItems, logger);
+		const newItems = CharacterAppearanceLoadAndValidate(assetManager, loadedItems, roomState, logger);
 
 		// Load pose
 		const requestedPose = _.cloneDeep(bundle.requestedPose);
@@ -261,15 +278,18 @@ export class AssetFrameworkCharacterState implements AssetFrameworkCharacterStat
 		}
 
 		// Create the final state
-		const resultState = freeze(new AssetFrameworkCharacterState({
-			assetManager,
-			id: characterId,
-			items: newItems,
-			requestedPose,
-			safemode: bundle.safemode,
-		}), true);
+		const resultState = freeze(
+			new AssetFrameworkCharacterState({
+				assetManager,
+				id: characterId,
+				items: newItems,
+				requestedPose,
+				safemode: bundle.safemode,
+			}).updateRoomStateLink(roomState),
+			true,
+		);
 
-		Assert(resultState.isValid(), 'State is invalid after load');
+		Assert(resultState.isValid(roomState), 'State is invalid after load');
 
 		return resultState;
 	}

--- a/pandora-common/src/assets/state/characterState.ts
+++ b/pandora-common/src/assets/state/characterState.ts
@@ -186,8 +186,8 @@ export class AssetFrameworkCharacterState implements AssetFrameworkCharacterStat
 		return new AssetFrameworkCharacterState(this, { safemode: freeze(value ?? undefined, true) });
 	}
 
-	public updateRoomStateLink(roomInventory: AssetFrameworkRoomState | null): AssetFrameworkCharacterState {
-		const updatedItems = this.items.map((item) => {
+	public updateRoomStateLink(roomInventory: AssetFrameworkRoomState | null, revalidate: boolean): AssetFrameworkCharacterState {
+		let updatedItems: AppearanceItems<WearableAssetType> = this.items.map((item) => {
 			if (item.isType('roomDeviceWearablePart')) {
 				const link = item.roomDeviceLink;
 				if (!roomInventory || !link)
@@ -218,12 +218,14 @@ export class AssetFrameworkCharacterState implements AssetFrameworkCharacterStat
 			return this;
 		}
 
-		// Re-validate items as forceful removal might have broken dependencies
-		const newItems = CharacterAppearanceLoadAndValidate(this.assetManager, updatedItems, roomInventory);
-		Assert(ValidateAppearanceItems(this.assetManager, newItems, roomInventory).success);
+		if (revalidate) {
+			// Re-validate items as forceful removal might have broken dependencies
+			updatedItems = CharacterAppearanceLoadAndValidate(this.assetManager, updatedItems, roomInventory);
+			Assert(ValidateAppearanceItems(this.assetManager, updatedItems, roomInventory).success);
+		}
 
 		return new AssetFrameworkCharacterState(this, {
-			items: newItems,
+			items: updatedItems,
 		});
 	}
 
@@ -285,7 +287,7 @@ export class AssetFrameworkCharacterState implements AssetFrameworkCharacterStat
 				items: newItems,
 				requestedPose,
 				safemode: bundle.safemode,
-			}).updateRoomStateLink(roomState),
+			}).updateRoomStateLink(roomState, true),
 			true,
 		);
 

--- a/pandora-common/src/assets/state/globalState.ts
+++ b/pandora-common/src/assets/state/globalState.ts
@@ -146,7 +146,7 @@ export class AssetFrameworkGlobalState {
 		for (const [id, character] of newCharacters) {
 			newCharacters.set(
 				id,
-				character.updateRoomStateLink(newState),
+				character.updateRoomStateLink(newState, false),
 			);
 		}
 

--- a/pandora-common/src/assets/state/globalState.ts
+++ b/pandora-common/src/assets/state/globalState.ts
@@ -62,7 +62,7 @@ export class AssetFrameworkGlobalState {
 		}
 
 		for (const character of this.characters.values()) {
-			const r = character.validate();
+			const r = character.validate(this.room);
 			if (!r.success)
 				return r;
 		}
@@ -146,7 +146,7 @@ export class AssetFrameworkGlobalState {
 		for (const [id, character] of newCharacters) {
 			newCharacters.set(
 				id,
-				character.cleanupRoomDeviceWearables(newState),
+				character.updateRoomStateLink(newState),
 			);
 		}
 
@@ -213,16 +213,16 @@ export class AssetFrameworkGlobalState {
 	public static loadFromBundle(assetManager: AssetManager, bundle: AssetFrameworkGlobalStateBundle, logger: Logger | undefined): AssetFrameworkGlobalState {
 		const characters = new Map<CharacterId, AssetFrameworkCharacterState>();
 
+		const room = bundle.room == null ? null : AssetFrameworkRoomState.loadFromBundle(assetManager, bundle.room, logger);
+
 		for (const [key, characterData] of Object.entries(bundle.characters)) {
 			AssertNotNullable(characterData);
 			const characterId = CharacterIdSchema.parse(key);
 			characters.set(
 				characterId,
-				AssetFrameworkCharacterState.loadFromBundle(assetManager, characterId, characterData, logger),
+				AssetFrameworkCharacterState.loadFromBundle(assetManager, characterId, characterData, room, logger),
 			);
 		}
-
-		const room = bundle.room == null ? null : AssetFrameworkRoomState.loadFromBundle(assetManager, bundle.room, logger);
 
 		const resultState = new AssetFrameworkGlobalState(
 			assetManager,

--- a/pandora-common/src/character/restrictionsManager.ts
+++ b/pandora-common/src/character/restrictionsManager.ts
@@ -496,7 +496,7 @@ export class CharacterRestrictionsManager {
 		if (interaction === ItemInteractionType.ACCESS_ONLY)
 			return { allowed: true };
 
-		const properties = item.getProperties();
+		const properties = item.isType('roomDevice') ? item.getRoomDeviceProperties() : item.getProperties();
 
 		// If item blocks this module, fail
 		if (properties.blockModules.has(moduleName) && !this.isInSafemode())

--- a/pandora-common/src/character/restrictionsManager.ts
+++ b/pandora-common/src/character/restrictionsManager.ts
@@ -261,7 +261,7 @@ export class CharacterRestrictionsManager {
 
 	public hasPermissionForItemContents(context: AppearanceActionProcessingContext, target: RoomActionTarget, item: Item): RestrictionResult {
 		// Iterate over whole content
-		for (const module of item.modules.keys()) {
+		for (const module of item.getModules().keys()) {
 			for (const innerItem of item.getModuleItems(module)) {
 				let r = this.canUseItemDirect(context, target, [], innerItem, ItemInteractionType.ACCESS_ONLY);
 				if (!r.allowed)
@@ -326,7 +326,8 @@ export class CharacterRestrictionsManager {
 		// Must be able to access all upper items
 		const upperPath = SplitContainerPath(container);
 		if (upperPath) {
-			const containingModule = target.getItem(upperPath.itemPath)?.modules.get(upperPath.module);
+			const upperItem = target.getItem(upperPath.itemPath);
+			const containingModule = upperItem?.getModules().get(upperPath.module);
 			if (!containingModule)
 				return {
 					allowed: false,
@@ -472,7 +473,7 @@ export class CharacterRestrictionsManager {
 
 	public canUseItemModuleDirect(context: AppearanceActionProcessingContext, target: RoomActionTarget, container: ItemContainerPath, item: Item, moduleName: string, interaction?: ItemInteractionType): RestrictionResult {
 		// The module must exist
-		const module = item.modules.get(moduleName);
+		const module = item.getModules().get(moduleName);
 		if (!module)
 			return {
 				allowed: false,

--- a/pandora-common/src/utility.ts
+++ b/pandora-common/src/utility.ts
@@ -141,6 +141,11 @@ export function ShuffleArray<T extends unknown[]>(array: T): T {
 	return array;
 }
 
+export function SplitStringFirstOccurrence(input: string, separator: string): [string, string] {
+	const index = input.indexOf(separator);
+	return index < 0 ? [input, ''] : [input.substring(0, index), input.substring(index + 1)];
+}
+
 /**
  * Returns longest preffix all input strings have in common (case sensitive)
  */

--- a/pandora-common/src/utility.ts
+++ b/pandora-common/src/utility.ts
@@ -360,7 +360,7 @@ export function IntervalSetUnion(a: ReadonlyIntervalSet, b: ReadonlyIntervalSet)
 /**
  * Decorates a member function so it memoizes the result of the first call, the function must take no arguments
  */
-export function MemoizeNoArg<Return, This extends object>(method: (...args: never[]) => Return, _context: ClassMethodDecoratorContext<This>) {
+export function MemoizeNoArg<Return, This extends object>(method: () => Return, _context: ClassMethodDecoratorContext<This>) {
 	const cache = new WeakMap<object, Return>();
 	return function (this: This) {
 		if (cache.has(this)) {

--- a/pandora-server-shard/src/character/character.ts
+++ b/pandora-server-shard/src/character/character.ts
@@ -206,8 +206,13 @@ export class Character {
 				.withCharacter(
 					this.id,
 					AssetFrameworkCharacterState
-						.loadFromBundle(assetManager, this.id, appearance, this.logger.prefixMessages('Appearance load:'))
-						.cleanupRoomDeviceWearables(null),
+						.loadFromBundle(
+							assetManager,
+							this.id,
+							appearance,
+							null,
+							this.logger.prefixMessages('Appearance load:'),
+						),
 				),
 		);
 	}

--- a/pandora-server-shard/src/room/room.ts
+++ b/pandora-server-shard/src/room/room.ts
@@ -281,8 +281,13 @@ export class Room extends ServerRoom<IShardClient> {
 			// Add the character to the room
 			this.characters.add(character);
 			const characterState = AssetFrameworkCharacterState
-				.loadFromBundle(assetManager, character.id, appearance, this.logger.prefixMessages(`Character ${character.id} join:`))
-				.cleanupRoomDeviceWearables(roomState.room);
+				.loadFromBundle(
+					assetManager,
+					character.id,
+					appearance,
+					roomState.room,
+					this.logger.prefixMessages(`Character ${character.id} join:`),
+				);
 			roomState = roomState.withCharacter(character.id, characterState);
 
 			this.roomState.setState(roomState);


### PR DESCRIPTION
Resolves: #265 

This PR adds module support to the room devices, namely:
- Modules are generic w.r.t. the "properties" they result in (this needed changes to the config, asset repo PR ports old assets)
- Reworks appearance actions to work more directly rather than through serializing and deserializing items every step of the way (was needed to preserve new links on room device wearable parts)
- Updates modules usage to work on both wearable part and room devices
- Adds a new kind of properties for room devices `RoomDeviceProperties`
- Adds support for image overrides to the static layers of room devices (+condition evaluator updates to make that happen)

Todo:
- Test things that worked before to find what was broken
- Make some room devices that use modules
- Test the new room devices
- Fix all that is broken