### PR TITLE
[ADD] adds a new wiki tab with the history of pandora

### DIFF
--- a/pandora-client-web/src/components/wiki/pages/greeting.tsx
+++ b/pandora-client-web/src/components/wiki/pages/greeting.tsx
@@ -33,7 +33,7 @@ export function WikiGreeting(): ReactElement {
 					During your stay you will often encounter various restraints.
 					Restraints in Pandora are very secure and can really get you stuck with no one else being able to help so please be mindful of that.<br />
 					While communication with others is the most important tool, Pandora also offers several mechanisms to keep you safe.<br />
-					First of those is ability to enforce your own limits through <i>permissions</i> - allowing you to prevent others from doing some things to your character.
+					First of those is the ability to enforce your own limits through <i>permissions</i> - allowing you to prevent others from doing some things to your character.
 					Right now other visitors can interact with you as they wish, which you can change in the settings via the "cog" icon on the top right.<br />
 					<br />
 					Second important mechanism is for when communication fails or others don't respect your safeword - for such a case there is a safemode feature,

--- a/pandora-client-web/src/components/wiki/pages/history.tsx
+++ b/pandora-client-web/src/components/wiki/pages/history.tsx
@@ -12,7 +12,7 @@ export function WikiHistory(): ReactElement {
 				In early 2021, most BC developers at that time concluded that they do not want to support BC any more, as they see various issues with it that
 				cannot realistically be solved.<br />
 				It was an often voiced desire from parts of the community to have an alternative to BC and therefore talks about making a new platform started.
-				In August 2021, "Project Pandora" officially started with the creation of the Pandora Discord. The first half year was focusing on looking for
+				In August 2021, "Project Pandora" officially started with the creation of the Pandora Discord. The first half year was focused on looking for
 				suitable technologies, asset basis, and architecture planning.<br />
 				Progress was slow but steady, as making such a platform is really a lot of work and requires careful planning and thinking.
 				Moreover, it is merely a hobby for everyone, spending free time here and there besides the actual day-time job, friends & family, etc.
@@ -22,13 +22,14 @@ export function WikiHistory(): ReactElement {
 
 			<p>
 				Not at all! Pandora has a different vision, wanting to be a secure, consensual roleplaying platform that focuses on text-heavy interactions.
-				BC was a bit like that in its first year before more and more game-like features were added that changed public rooms and the community quite
-				a bit over time. Also the fact that console-usage/scripts/mods/extensions in BC are so all-powerful has certain drawbacks and is exploited often.
+				BC was a bit like that in its first year before more and more game-like features were added that changed the focus of public rooms and the
+				interests of parts of the community slowly. Also the fact that console-usage/scripts/mods/extensions in BC are so all-powerful has certain
+				drawbacks and is exploited quite often.<br />
 				In a way, Pandora will offer an improved "classic" experience, focusing on roleplaying and clear house rules. It will not be tolerated that
-				some users can cheat or gain intransparent feature advantages that others do not have available without having to risk running external scripts.
+				some users can cheat or gain intransparent feature advantages that others do not have, unless they risk running external scripts.
 			</p>
 
-			<h4>What issues did some of the devs see with BC?</h4>
+			<h4>What issues with BC were seen?</h4>
 
 			<p>
 				<ul>
@@ -39,16 +40,16 @@ export function WikiHistory(): ReactElement {
 					</li>
 					<li>Not Open-Source: While the source code of BC is public, it is not licensed under any open-source license. That means that every part of BC
 						is proprietary and owned by its authors and that would mean that one cannot legally use the BC code anywhere else or copy it and further
-						develop it without the explicit permission by every person who ever contributed to BC which is almost impossible. The longevity of BC is
-						therefore questionable and contributing to BC can be seen as a risk to invest time into a black hole.
+						develop it without the explicit permission by every person who ever contributed to BC which makes that almost impossible. The longevity of BC is
+						therefore doubtful and contributing to BC can be seen as a risk to invest time into a black hole.
 					</li>
-					<li>BC Project Management: The desire for a different project management approach and development process was strong.</li>
-					<li>BC server architecture: It is singular and cannot scale beyond a certain number of users, where lag and disconnects get slowly worse.
+					<li>BC project management: The desire for a different project management approach and development process was strong.</li>
+					<li>BC server architecture: It is singular and cannot scale beyond a certain number of users, where lag and disconnects slowly get worse.
 						Starting from scratch with a modern and scalable approach seemed like the best option to give users a stable experience.
 					</li>
 					<li>
-						Lack of server validation: In many cases the server in BC does not validate what the client does, which makes it easy to alter things
-						like locks, restraints, or messages. The overall lack of security was a concern voiced by many.
+						Lack of server validation: In many cases the server in BC does not validate what the client does, which makes it possible for everyone
+						to alter things like locks, restraints, or messages. The overall lack of security was a concern voiced by many.
 					</li>
 					<li>Asset creation: Asset creation in BC needs many variants of the same image and it is an extreme effort to add new poses.</li>
 					<li>Legality of assets: In BC there is no process for vetoing assets. Most of them are not providing where they originate
@@ -58,7 +59,7 @@ export function WikiHistory(): ReactElement {
 			</p>
 
 			<h4>The people behind Pandora (Last updated: 1-11-2023)</h4>
-
+			<br />
 			<p>
 				<strong>Lead Developers</strong>
 				<ul>

--- a/pandora-client-web/src/components/wiki/pages/history.tsx
+++ b/pandora-client-web/src/components/wiki/pages/history.tsx
@@ -1,0 +1,115 @@
+import React, { ReactElement } from 'react';
+
+export function WikiHistory(): ReactElement {
+	return (
+		<>
+			<h2>Pandora's history</h2>
+
+			<h4>How it all started</h4>
+
+			<p>
+				Pandora was founded by many developers and contributors of a free and open-to-contribute project called "Bondage Club" (BC).
+				In early 2021, most BC developers at that time concluded that they do not want to support BC any more, as they see various issues with it that
+				cannot realistically be solved.<br />
+				It was an often voiced desire from parts of the community to have an alternative to BC and therefore talks about making a new platform started.
+				In August 2021, "Project Pandora" officially started with the creation of the Pandora Discord. The first half year was focusing on looking for
+				suitable technologies, asset basis, and architecture planning.<br />
+				Progress was slow but steady, as making such a platform is really a lot of work and requires careful planning and thinking.
+				Moreover, it is merely a hobby for everyone, spending free time here and there besides the actual day-time job, friends & family, etc.
+			</p>
+
+			<h4>Does Pandora want to replace BC?</h4>
+
+			<p>
+				Not at all! Pandora has a different vision, wanting to be a secure, consensual roleplaying platform that focuses on text-heavy interactions.
+				BC was a bit like that in its first year before more and more game-like features were added that changed public rooms and the community quite
+				a bit over time. Also the fact that console-usage/scripts/mods/extensions in BC are so all-powerful has certain drawbacks and is exploited often.
+				In a way, Pandora will offer an improved "classic" experience, focusing on roleplaying and clear house rules. It will not be tolerated that
+				some users can cheat or gain intransparent feature advantages that others do not have available without having to risk running external scripts.
+			</p>
+
+			<h4>What issues did the devs see with BC?</h4>
+
+			<p>
+				<ul>
+					<li>Technical quality of BC: The source code of BC was not of good quality and while it improved quite a bit over the years (to a large degree
+						thanks to the people who founded Pandora), it is essentially still something held together by many band aids and compromises.
+						Contributing to it is not exactly pleasant and beginner friendly. Starting from scratch seemed like a more sensible decision than
+						trying to improve it further.
+					</li>
+					<li>Not Open-Source: While the source code of BC is public, it is not licensed under any open-source license. That means that every part of BC
+						is proprietary and owned by its authors and that would mean that one cannot legally use the BC code anywhere else or copy it and further
+						develop it without the explicit permission by every person who ever contributed to BC which is almost impossible. The longevity of BC is
+						therefore questionable and contributing to BC can be seen as a risk to invest time into a black hole.
+					</li>
+					<li>BC Project Management: The desire for a different project management approach and development process was strong.</li>
+					<li>BC server architecture: It is singular and cannot scale beyond a certain number of users, where lag and disconnects get slowly worse.
+						Starting from scratch with a modern and scalable approach seemed like the best option to give users a stable experience.
+					</li>
+					<li>
+						Lack of server validation: In many cases the server in BC does not validate what the client does, which makes it easy to alter things
+						like locks or restraints or messages. The overall lack of security was a concern voiced by many.
+					</li>
+					<li>Asset creation: Asset creation in BC is quite some effort, especially the coding part, and not very beginner friendly.</li>
+					<li>Legality of some assets: The BC character models and some other assets are copied from a commercial game and other sources, where
+						permission for usage in BC is not demonstrated.
+					</li>
+				</ul>
+			</p>
+
+			<h4>The people behind Pandora (Last updated: 1-11-2023)</h4>
+
+			<p>
+				<strong>Admins</strong>
+				<ul>
+					<li>Ace</li>
+					<li>Ellie</li>
+					<li>Jomshir (Clare)</li>
+					<li>Sekkmer</li>
+				</ul>
+				<strong>Lead Developers</strong>
+				<ul>
+					<li>Claudia</li>
+					<li>Jomshir (Clare)</li>
+					<li>Sekkmer</li>
+				</ul>
+				<strong>Developers</strong>
+				<ul>
+					<li>Kane</li>
+					<li>Nina</li>
+					<li>Nythaleath</li>
+					<li>Sandrine</li>
+					<li>TechTheAwesome</li>
+					<li>Titania</li>
+				</ul>
+				<strong>Founders</strong>
+				<ul>
+					<li>Ace</li>
+					<li>Ada</li>
+					<li>Cecilia</li>
+					<li>Claudia</li>
+					<li>Ellie</li>
+					<li>EmilyR</li>
+					<li>Estsanatlehi</li>
+					<li>Eve</li>
+					<li>Jenn</li>
+					<li>Jomshir (Clare)</li>
+					<li>Kane</li>
+					<li>Kimei Nishimura</li>
+					<li>Natsuki</li>
+					<li>Nina</li>
+					<li>Nosey Gatey (Gatetrek)</li>
+					<li>Nythaleath</li>
+					<li>ruilove</li>
+					<li>Sandrine</li>
+					<li>Sekkmer</li>
+					<li>Sidsel</li>
+					<li>TechTheAwesome</li>
+					<li>Titania</li>
+					<li>Verity</li>
+				</ul>
+			</p>
+
+		</>
+	);
+}

--- a/pandora-client-web/src/components/wiki/pages/history.tsx
+++ b/pandora-client-web/src/components/wiki/pages/history.tsx
@@ -49,11 +49,11 @@ export function WikiHistory(): ReactElement {
 						Starting from scratch with a modern and scalable approach seemed like the best option to give users a stable experience.
 					</li>
 					<li>
-						Lack of server validation / security: In many cases the server in BC does not validate what the client does, which makes it possible for everyone
-						to alter things like locks, restraints, or messages. The overall lack of security was a concern voiced by many.
+						Lack of server validation: In many cases the server in BC does not validate what the client does, which makes it possible for everyone
+						to alter things like locks, restraints, or messages. The overall lack of security was a concern often voiced.
 					</li>
 					<li>Asset creation: Asset creation in BC needs many variants of the same image and it is an extreme effort to add new poses.</li>
-					<li>Legality of assets / images: In BC there is no process for vetoing assets. Most of them are not providing where they originate
+					<li>Legality of assets/images: In BC there is no process for vetoing assets. Most of them are not providing where they originate
 						from or how the sources used for the assets were licensed. Proper licensing is the correct and safe way.
 					</li>
 				</ul>

--- a/pandora-client-web/src/components/wiki/pages/history.tsx
+++ b/pandora-client-web/src/components/wiki/pages/history.tsx
@@ -28,12 +28,12 @@ export function WikiHistory(): ReactElement {
 				some users can cheat or gain intransparent feature advantages that others do not have available without having to risk running external scripts.
 			</p>
 
-			<h4>What issues did the devs see with BC?</h4>
+			<h4>What issues did some of the devs see with BC?</h4>
 
 			<p>
 				<ul>
-					<li>Technical quality of BC: The source code of BC was not of good quality and while it improved quite a bit over the years (to a large degree
-						thanks to the people who founded Pandora), it is essentially still something held together by many band aids and compromises.
+					<li>Technical quality of BC: The source code of BC was not of good quality and while it improved quite a bit over the years (to a large part
+						thanks to the same people who founded Pandora), it is essentially still something held together by many band aids and compromises.
 						Contributing to it is not exactly pleasant and beginner friendly. Starting from scratch seemed like a more sensible decision than
 						trying to improve it further.
 					</li>
@@ -48,11 +48,11 @@ export function WikiHistory(): ReactElement {
 					</li>
 					<li>
 						Lack of server validation: In many cases the server in BC does not validate what the client does, which makes it easy to alter things
-						like locks or restraints or messages. The overall lack of security was a concern voiced by many.
+						like locks, restraints, or messages. The overall lack of security was a concern voiced by many.
 					</li>
-					<li>Asset creation: Asset creation in BC is quite some effort, especially the coding part, and not very beginner friendly.</li>
-					<li>Legality of some assets: The BC character models and some other assets are copied from a commercial game and other sources, where
-						permission for usage in BC is not demonstrated.
+					<li>Asset creation: Asset creation in BC needs many variants of the same image and it is an extreme effort to add new poses.</li>
+					<li>Legality of assets: In BC there is no process for vetoing assets. Most of them are not providing where they originate
+						from or how the sources used for the assets were licensed. Proper licensing is the correct and safe way.
 					</li>
 				</ul>
 			</p>
@@ -60,16 +60,11 @@ export function WikiHistory(): ReactElement {
 			<h4>The people behind Pandora (Last updated: 1-11-2023)</h4>
 
 			<p>
-				<strong>Admins</strong>
-				<ul>
-					<li>Ace</li>
-					<li>Ellie</li>
-					<li>Jomshir (Clare)</li>
-					<li>Sekkmer</li>
-				</ul>
 				<strong>Lead Developers</strong>
 				<ul>
+					<li>Ace</li>
 					<li>Claudia</li>
+					<li>Ellie</li>
 					<li>Jomshir (Clare)</li>
 					<li>Sekkmer</li>
 				</ul>

--- a/pandora-client-web/src/components/wiki/pages/history.tsx
+++ b/pandora-client-web/src/components/wiki/pages/history.tsx
@@ -9,10 +9,14 @@ export function WikiHistory(): ReactElement {
 
 			<p>
 				Pandora was founded by many developers and contributors of a free and open-to-contribute project called "Bondage Club" (BC).
-				In early 2021, most BC developers at that time concluded that they do not want to support BC any more, as they see various issues with it that
+				In early 2021, most BC developers at that time concluded that they do not want to support BC anymore, as they see various issues with it that
 				cannot realistically be solved.<br />
 				It was an often voiced desire from parts of the community to have an alternative to BC and therefore talks about making a new platform started.
-				In August 2021, "Project Pandora" officially started with the creation of the Pandora Discord.<br />
+				In August 2021, "Project Pandora" officially started with the creation of the
+				<a href='https://discord.gg/EnaPvuQf8d' target='_blank' rel='external nofollow noopener noreferrer'>
+					Pandora Discord
+				</a>
+				.<br />
 				<br />
 				The first half year was focused on looking for suitable technologies, asset basis, and architecture planning.
 				Progress was slow but steady, as making such a platform is really a lot of work and requires careful planning and thinking.
@@ -26,8 +30,8 @@ export function WikiHistory(): ReactElement {
 				BC was a bit like that in its first year before more and more game-like features were added that changed the focus of public rooms and the
 				interests of parts of the community slowly. Also the fact that console-usage/scripts/mods/extensions in BC are so all-powerful has certain
 				drawbacks and is exploited quite often.<br />
-				In a way, Pandora will offer an improved "classic" experience, focusing on roleplaying and clear house rules. It will not be tolerated that
-				some users can cheat or gain intransparent feature advantages that others do not have, unless they risk running external scripts.
+				In a way, Pandora will offer an improved "classic" experience, focusing on roleplaying and clear house rules. We will actively remove
+				ways with which users can cheat or gain intransparent feature advantages that others do not have, unless they risk running external scripts.
 			</p>
 
 			<h4>What issues with BC were seen?</h4>
@@ -41,7 +45,7 @@ export function WikiHistory(): ReactElement {
 					</li>
 					<li>Not Open-Source: While the source code of BC is public, it is not licensed under any open-source license. That means that every part of BC
 						is proprietary and owned by its authors and that would mean that one cannot legally use the BC code anywhere else or copy it and further
-						develop it without the explicit permission by every person who ever contributed to BC which makes that almost impossible. The longevity of BC is
+						develop it without the explicit permission of every person who ever contributed to BC which makes that almost impossible. The longevity of BC is
 						therefore doubtful and contributing to BC can be seen as a risk to invest time into a black hole.
 					</li>
 					<li>BC project management: The desire for a different project management approach and development process was strong.</li>
@@ -53,7 +57,7 @@ export function WikiHistory(): ReactElement {
 						to alter things like locks, restraints, or messages. The overall lack of security was a concern often voiced.
 					</li>
 					<li>Asset creation: Asset creation in BC needs many variants of the same image and it is an extreme effort to add new poses.</li>
-					<li>Legality of assets/images: In BC there is no process for vetoing assets. Most of them are not providing where they originate
+					<li>Legality of assets/images: In BC there is no process for vetoing assets. Most of them do not provide where they originate
 						from or how the sources used for the assets were licensed. Proper licensing is the correct and safe way.
 					</li>
 				</ul>

--- a/pandora-client-web/src/components/wiki/pages/history.tsx
+++ b/pandora-client-web/src/components/wiki/pages/history.tsx
@@ -12,10 +12,11 @@ export function WikiHistory(): ReactElement {
 				In early 2021, most BC developers at that time concluded that they do not want to support BC any more, as they see various issues with it that
 				cannot realistically be solved.<br />
 				It was an often voiced desire from parts of the community to have an alternative to BC and therefore talks about making a new platform started.
-				In August 2021, "Project Pandora" officially started with the creation of the Pandora Discord. The first half year was focused on looking for
-				suitable technologies, asset basis, and architecture planning.<br />
+				In August 2021, "Project Pandora" officially started with the creation of the Pandora Discord.<br />
+				<br />
+				The first half year was focused on looking for suitable technologies, asset basis, and architecture planning.
 				Progress was slow but steady, as making such a platform is really a lot of work and requires careful planning and thinking.
-				Moreover, it is merely a hobby for everyone, spending free time here and there besides the actual day-time job, friends & family, etc.
+				Moreover, it is merely a hobby for everyone, spending free time here and there besides the actual day-time work, friends & family, etc.
 			</p>
 
 			<h4>Does Pandora want to replace BC?</h4>
@@ -48,11 +49,11 @@ export function WikiHistory(): ReactElement {
 						Starting from scratch with a modern and scalable approach seemed like the best option to give users a stable experience.
 					</li>
 					<li>
-						Lack of server validation: In many cases the server in BC does not validate what the client does, which makes it possible for everyone
+						Lack of server validation / security: In many cases the server in BC does not validate what the client does, which makes it possible for everyone
 						to alter things like locks, restraints, or messages. The overall lack of security was a concern voiced by many.
 					</li>
 					<li>Asset creation: Asset creation in BC needs many variants of the same image and it is an extreme effort to add new poses.</li>
-					<li>Legality of assets: In BC there is no process for vetoing assets. Most of them are not providing where they originate
+					<li>Legality of assets / images: In BC there is no process for vetoing assets. Most of them are not providing where they originate
 						from or how the sources used for the assets were licensed. Proper licensing is the correct and safe way.
 					</li>
 				</ul>

--- a/pandora-client-web/src/components/wiki/pages/intro.tsx
+++ b/pandora-client-web/src/components/wiki/pages/intro.tsx
@@ -4,7 +4,7 @@ import { MESSAGE_EDIT_TIMEOUT } from '../../gameContext/chatRoomContextProvider'
 export function WikiIntroduction(): ReactElement {
 	return (
 		<>
-			<h3>Introduction to Pandora with some quick hints to get you started</h3>
+			<h2>Introduction to Pandora with some quick hints to get you started</h2>
 
 			<p>
 				Pandora's vision is to establish a strict & secure, consensual roleplay platform that focuses on text-heavy interactions.
@@ -84,6 +84,7 @@ export function WikiIntroduction(): ReactElement {
 			<h4>Stable code base</h4>
 			<p>
 				Pandora aims for a stable experience without random disconnects. But even if a short disconnect happens, the character will not be shown as disconnected for some time, and you will still receive all the missed chat messages on reconnect, not losing anything.
+				Additionally, Pandora's server architecture is scalable to support future growth of its user base without compromising stability.
 			</p>
 
 			<h4>Reliable gag talk & locks</h4>

--- a/pandora-client-web/src/components/wiki/pages/intro.tsx
+++ b/pandora-client-web/src/components/wiki/pages/intro.tsx
@@ -101,7 +101,7 @@ export function WikiIntroduction(): ReactElement {
 				you have to either look for the account name of the user you want to exchange messages with on the left, or
 				you have to search for them via the bottom left input field using their <b>account ID</b>. You can find the account
 				ID either under the "Contacts"-tab or in the "Room"-tab while with a character in the same room. The account ID is
-				the rightmost number behind the character name.
+				the rightmost number behind the character name. Direct messages are end-to-end encrypted.
 			</p>
 
 			<h4>No safeword feature, but a safemode that makes it harder to be misused</h4>
@@ -128,6 +128,7 @@ export function WikiIntroduction(): ReactElement {
 				<li>Hearing impairment effect by assets</li>
 				<li>Advanced permission feature</li>
 				<li>Character rules</li>
+				<li>Connecting rooms with each other into a small housing area with a customized layout and ways to move from room to room</li>
 				<li>Creating character contracts to temporarily or permanently agree on sets of rules and permissions between specific characters</li>
 				<li>Improvements to the new player experience & safety</li>
 				... and many more, which can be found by looking at Pandora's issue list on <a href='https://github.com/Project-Pandora-Game/pandora/issues' target='_blank' rel='external nofollow noopener noreferrer'>GitHub</a>

--- a/pandora-client-web/src/components/wiki/wiki.tsx
+++ b/pandora-client-web/src/components/wiki/wiki.tsx
@@ -8,6 +8,7 @@ import './wiki.scss';
 import { WikiIntroduction } from './pages/intro';
 import { WikiGreeting } from './pages/greeting';
 import { WikiContact } from './pages/contact';
+import { WikiHistory } from './pages/history';
 
 export function Wiki(): ReactElement {
 	const navigate = useNavigate();
@@ -18,6 +19,11 @@ export function Wiki(): ReactElement {
 			<UrlTab name='Introduction' default urlChunk='introduction'>
 				<WikiContent>
 					<WikiIntroduction />
+				</WikiContent>
+			</UrlTab>
+			<UrlTab name='Pandora History' urlChunk='history'>
+				<WikiContent>
+					<WikiHistory />
 				</WikiContent>
 			</UrlTab>
 			<UrlTab name='Greeting' urlChunk='greeting'>


### PR DESCRIPTION
This page can also be linked on Discord when users ask about how Pandora came to be and who is involved.
It should also answer potentially frequently asked questions in advance.