### PR TITLE
[FEATURE] Add confirmation for actions you can't undo

### DIFF
--- a/pandora-client-web/src/common/useEvent.ts
+++ b/pandora-client-web/src/common/useEvent.ts
@@ -25,7 +25,14 @@ export function useEvent<R, Args extends unknown[]>(callback: (...args: Args) =>
 export function useAsyncEvent<R, Args extends unknown[]>(
 	callback: (...args: Args) => Promise<R>,
 	updateComponent: (result: R) => void,
-	{ errorHandler }: { errorHandler?: (error: unknown) => void; } = {},
+	{
+		errorHandler,
+		updateAfterUnmount = false,
+	}: {
+		errorHandler?: (error: unknown) => void;
+		/** If update should trigger even after the component was unmounted */
+		updateAfterUnmount?: boolean;
+	} = {},
 ): [(...args: Args) => void, boolean] {
 	const [processing, setProcessing] = useState(false);
 	const mounted = useMounted();
@@ -38,13 +45,13 @@ export function useAsyncEvent<R, Args extends unknown[]>(
 
 		callback(...args)
 			.then((result: R) => {
-				if (mounted.current) {
+				if (updateAfterUnmount || mounted.current) {
 					setProcessing(false);
 					updateComponent(result);
 				}
 			})
 			.catch((e) => {
-				if (mounted.current) {
+				if (updateAfterUnmount || mounted.current) {
 					setProcessing(false);
 					errorHandler?.(e);
 				}

--- a/pandora-client-web/src/components/contextMenu/contextMenu.scss
+++ b/pandora-client-web/src/components/contextMenu/contextMenu.scss
@@ -36,7 +36,6 @@ $context-menu-themes: (
 	button {
 		color: white;
 		background-color: transparent;
-		text-decoration: none;
 		padding: 0.5em 0.8em;
 
 		&:hover {

--- a/pandora-client-web/src/components/wardrobe/itemDetail/wardrobeItemRoomDevice.tsx
+++ b/pandora-client-web/src/components/wardrobe/itemDetail/wardrobeItemRoomDevice.tsx
@@ -114,6 +114,7 @@ function WardrobeRoomDeviceDeploymentPosition({ deployment, item }: {
 		<Row padding='medium' alignY='center'>
 			<label>X:</label>
 			<input type='number'
+				id='positioning-input'
 				value={ positionX }
 				onChange={ (ev) => {
 					changeCallback({ x: ev.target.valueAsNumber });
@@ -122,6 +123,7 @@ function WardrobeRoomDeviceDeploymentPosition({ deployment, item }: {
 			/>
 			<label>Y:</label>
 			<input type='number'
+				id='positioning-input'
 				value={ positionY }
 				onChange={ (ev) => {
 					changeCallback({ y: ev.target.valueAsNumber });
@@ -130,6 +132,7 @@ function WardrobeRoomDeviceDeploymentPosition({ deployment, item }: {
 			/>
 			<label>Y offset:</label>
 			<input type='number'
+				id='positioning-input'
 				value={ positionYOffset }
 				onChange={ (ev) => {
 					changeCallback({ yOffset: ev.target.valueAsNumber });

--- a/pandora-client-web/src/components/wardrobe/itemDetail/wardrobeItemRoomDevice.tsx
+++ b/pandora-client-web/src/components/wardrobe/itemDetail/wardrobeItemRoomDevice.tsx
@@ -114,7 +114,7 @@ function WardrobeRoomDeviceDeploymentPosition({ deployment, item }: {
 		<Row padding='medium' alignY='center'>
 			<label>X:</label>
 			<input type='number'
-				id='positioning-input'
+				className='positioning-input'
 				value={ positionX }
 				onChange={ (ev) => {
 					changeCallback({ x: ev.target.valueAsNumber });
@@ -123,7 +123,7 @@ function WardrobeRoomDeviceDeploymentPosition({ deployment, item }: {
 			/>
 			<label>Y:</label>
 			<input type='number'
-				id='positioning-input'
+				className='positioning-input'
 				value={ positionY }
 				onChange={ (ev) => {
 					changeCallback({ y: ev.target.valueAsNumber });
@@ -132,7 +132,7 @@ function WardrobeRoomDeviceDeploymentPosition({ deployment, item }: {
 			/>
 			<label>Y offset:</label>
 			<input type='number'
-				id='positioning-input'
+				className='positioning-input'
 				value={ positionYOffset }
 				onChange={ (ev) => {
 					changeCallback({ yOffset: ev.target.valueAsNumber });

--- a/pandora-client-web/src/components/wardrobe/views/wardrobePoseView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobePoseView.tsx
@@ -529,7 +529,7 @@ function ChatroomManualYOffsetControl({ character }: {
 	return (
 		<Row padding='small'>
 			<Row alignY='center'>Character Y Offset:</Row>
-			<input type='number' id='positioning-input' step='1' value={ yOffset } onChange={ onInput } />
+			<input type='number' className='positioning-input' step='1' value={ yOffset } onChange={ onInput } />
 			<Button className='slim' onClick={ () => setYOffset(0) } disabled={ yOffset === 0 }>
 				↺
 			</Button>

--- a/pandora-client-web/src/components/wardrobe/views/wardrobePoseView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobePoseView.tsx
@@ -529,7 +529,7 @@ function ChatroomManualYOffsetControl({ character }: {
 	return (
 		<Row padding='small'>
 			<Row alignY='center'>Character Y Offset:</Row>
-			<input type='number' step='1' value={ yOffset } onChange={ onInput } />
+			<input type='number' id='positioning-input' step='1' value={ yOffset } onChange={ onInput } />
 			<Button className='slim' onClick={ () => setYOffset(0) } disabled={ yOffset === 0 }>
 				↺
 			</Button>

--- a/pandora-client-web/src/components/wardrobe/wardrobe.scss
+++ b/pandora-client-web/src/components/wardrobe/wardrobe.scss
@@ -491,3 +491,7 @@ $drop-overlay-gap: 0.3em;
 		transform: scale(1.6);
 	}
 }
+
+#positioning-input {
+	width: 8em;
+}

--- a/pandora-client-web/src/components/wardrobe/wardrobe.scss
+++ b/pandora-client-web/src/components/wardrobe/wardrobe.scss
@@ -492,6 +492,6 @@ $drop-overlay-gap: 0.3em;
 	}
 }
 
-#positioning-input {
+.positioning-input {
 	width: 8em;
 }

--- a/pandora-client-web/src/components/wardrobe/wardrobeComponents.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobeComponents.tsx
@@ -17,7 +17,7 @@ import { useStaggeredAppearanceActionResult } from './wardrobeCheckQueue';
 import _ from 'lodash';
 import { usePermissionCheck } from '../gameContext/permissionCheckProvider';
 
-export function ActionWarning({ problems, parent }: { problems: readonly AppearanceActionProblem[]; parent: HTMLElement | null; }) {
+export function ActionWarningContent({ problems }: { problems: readonly AppearanceActionProblem[]; }): ReactElement {
 	const assetManager = useAssetManager();
 	const reasons = useMemo(() => (
 		_.uniq(
@@ -27,28 +27,34 @@ export function ActionWarning({ problems, parent }: { problems: readonly Appeara
 		)
 	), [assetManager, problems]);
 
+	if (reasons.length === 0) {
+		return (
+			<>
+				This action isn't possible.
+			</>
+		);
+	}
+
+	return (
+		<>
+			This action isn't possible, because:
+			<ul>
+				{
+					reasons.map((reason, i) => (<li key={ i }>{ reason }</li>))
+				}
+			</ul>
+		</>
+	);
+}
+
+export function ActionWarning({ problems, parent }: { problems: readonly AppearanceActionProblem[]; parent: HTMLElement | null; }) {
 	if (problems.length === 0) {
 		return null;
 	}
 
 	return (
 		<HoverElement parent={ parent } className='action-warning'>
-			{
-				reasons.length === 0 ? (
-					<>
-						This action isn't possible.
-					</>
-				) : (
-					<>
-						This action isn't possible, because:
-						<ul>
-							{
-								reasons.map((reason, i) => (<li key={ i }>{ reason }</li>))
-							}
-						</ul>
-					</>
-				)
-			}
+			<ActionWarningContent problems={ problems } />
 		</HoverElement>
 	);
 }

--- a/pandora-client-web/src/components/wardrobe/wardrobeContext.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobeContext.tsx
@@ -22,11 +22,12 @@ import { useCurrentAccount } from '../gameContext/directoryConnectorContextProvi
 import { WardrobeContext, WardrobeContextExtraItemActionComponent, WardrobeHeldItem, WardrobeTarget } from './wardrobeTypes';
 import { useAsyncEvent } from '../../common/useEvent';
 import { toast } from 'react-toastify';
-import { TOAST_OPTIONS_ERROR } from '../../persistentToast';
+import { TOAST_OPTIONS_ERROR, TOAST_OPTIONS_WARNING } from '../../persistentToast';
 import { RenderAppearanceActionProblem } from '../../assets/appearanceValidation';
 import { Column } from '../common/container/container';
 import { useConfirmDialog } from '../dialog/dialog';
 import { WardrobeCheckResultForConfirmationWarnings } from './wardrobeUtils';
+import { ActionWarningContent } from './wardrobeComponents';
 
 export const wardrobeContext = createContext<WardrobeContext | null>(null);
 
@@ -154,6 +155,7 @@ export function useWardrobeExecuteCallback({ onSuccess, onFailure }: ExecuteCall
 				GetLogger('wardrobeExecute').error('Error executing action:', err);
 				toast(`Error performing action`, TOAST_OPTIONS_ERROR);
 			},
+			updateAfterUnmount: true,
 		},
 	);
 }
@@ -182,8 +184,13 @@ export function useWardrobeExecuteChecked(action: Nullable<AppearanceAction>, re
 
 	return [
 		useCallback(() => {
-			if (action == null || result == null || !result.valid || result.problems.length > 0)
+			if (action == null || result == null)
 				return;
+
+			if (!result.valid || result.problems.length > 0) {
+				toast(<ActionWarningContent problems={ result.problems } />, TOAST_OPTIONS_WARNING);
+				return;
+			}
 
 			// Detect need for confirmation
 			const warnings = WardrobeCheckResultForConfirmationWarnings(player, roomContext, result);

--- a/pandora-client-web/src/components/wardrobe/wardrobeContext.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobeContext.tsx
@@ -160,19 +160,6 @@ export function useWardrobeExecuteCallback({ onSuccess, onFailure }: ExecuteCall
 	);
 }
 
-export function useWardrobeExecute(action: Nullable<AppearanceAction>, props: ExecuteCallbackOptions = {}) {
-	const [execute, processing] = useWardrobeExecuteCallback(props);
-
-	return [
-		useCallback(() => {
-			if (action) {
-				execute(action);
-			}
-		}, [execute, action]),
-		processing,
-	] as const;
-}
-
 export function useWardrobeExecuteChecked(action: Nullable<AppearanceAction>, result?: AppearanceActionProcessingResult | null, props: ExecuteCallbackOptions = {}) {
 	const [execute, processing] = useWardrobeExecuteCallback(props);
 	const {

--- a/pandora-client-web/src/components/wardrobe/wardrobeContext.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobeContext.tsx
@@ -25,6 +25,8 @@ import { toast } from 'react-toastify';
 import { TOAST_OPTIONS_ERROR } from '../../persistentToast';
 import { RenderAppearanceActionProblem } from '../../assets/appearanceValidation';
 import { Column } from '../common/container/container';
+import { useConfirmDialog } from '../dialog/dialog';
+import { WardrobeCheckResultForConfirmationWarnings } from './wardrobeUtils';
 
 export const wardrobeContext = createContext<WardrobeContext | null>(null);
 
@@ -171,13 +173,41 @@ export function useWardrobeExecute(action: Nullable<AppearanceAction>, props: Ex
 
 export function useWardrobeExecuteChecked(action: Nullable<AppearanceAction>, result?: AppearanceActionProcessingResult | null, props: ExecuteCallbackOptions = {}) {
 	const [execute, processing] = useWardrobeExecuteCallback(props);
+	const {
+		player,
+		actions: { roomContext },
+	} = useWardrobeContext();
+
+	const confirm = useConfirmDialog();
 
 	return [
 		useCallback(() => {
-			if (action && result != null && result.problems.length === 0) {
+			if (action == null || result == null || !result.valid || result.problems.length > 0)
+				return;
+
+			// Detect need for confirmation
+			const warnings = WardrobeCheckResultForConfirmationWarnings(player, roomContext, result);
+
+			if (warnings.length > 0) {
+				confirm(
+					`You might not be able to undo this action without help. Continue?`,
+					(
+						<ul>
+							{
+								warnings.map((warning, i) => <li key={ i }>{ warning }</li>)
+							}
+						</ul>
+					),
+				).then((confirmResult) => {
+					if (confirmResult) {
+						execute(action);
+					}
+				}).catch(() => {/* NOOP */});
+			} else {
 				execute(action);
 			}
-		}, [execute, action, result]),
+
+		}, [execute, confirm, player, roomContext, action, result]),
 		processing,
 	] as const;
 }

--- a/pandora-client-web/src/persistentToast.ts
+++ b/pandora-client-web/src/persistentToast.ts
@@ -10,6 +10,14 @@ export const TOAST_OPTIONS_SUCCESS: ToastOptions = {
 	closeButton: true,
 	draggable: true,
 };
+export const TOAST_OPTIONS_WARNING: ToastOptions = {
+	type: 'warning',
+	isLoading: false,
+	autoClose: 10_000,
+	closeOnClick: true,
+	closeButton: true,
+	draggable: true,
+};
 export const TOAST_OPTIONS_ERROR: ToastOptions = {
 	type: 'error',
 	isLoading: false,

--- a/pandora-client-web/src/styles/globalUtils.scss
+++ b/pandora-client-web/src/styles/globalUtils.scss
@@ -104,6 +104,14 @@
 
 //#endregion
 
+//#region Text decoration
+
+.text-strikethrough {
+	text-decoration: line-through;
+}
+
+//#endregion
+
 //#region Misc
 
 .selectable {


### PR DESCRIPTION
Makes following changes:
- Updates "confirm" dialog to accept more complex body and uses simple bold text instead of h1
- Adds confirmation dialog before performing action you can't undo
  - Right now detects action that changed `blockHands` effect on `player` from `false` to `true`
- Improves room device menu
  - Buttons for invalid actions always show and are instead stricken through
  - Character button have background color based on their label color
  - Clicking invalid button displays toast with reason for the invalidity
  - Storing room device prompts for confirmation