### PR TITLE
[FIX] Add Wiki tests and downgrade react-router to avoid latest regression for nested routing

### DIFF
--- a/pandora-client-web/package.json
+++ b/pandora-client-web/package.json
@@ -38,8 +38,8 @@
 		"react-dom": "18.2.0",
 		"react-hook-form": "7.48.2",
 		"react-rnd": "10.4.1",
-		"react-router": "6.20.0",
-		"react-router-dom": "6.20.0",
+		"react-router": "6.18.0",
+		"react-router-dom": "6.18.0",
 		"react-toastify": "9.1.3",
 		"socket.io-client": "4.6.1",
 		"zod": "3.22.4"

--- a/pandora-tests/test/eula.test.ts
+++ b/pandora-tests/test/eula.test.ts
@@ -1,9 +1,10 @@
 import { test, expect } from '@playwright/test';
-import { TestOpenPandora } from './utils/helpers';
+import { TEST_EULA_TEXT, TestOpenPandora } from './utils/helpers';
 
 test.describe('EULA', () => {
 	test('Shows privacy policy', async ({ page }) => {
 		await TestOpenPandora(page, { agreeEula: false });
+		await expect(page.getByText(TEST_EULA_TEXT)).toBeVisible();
 
 		// Click privacy policy link
 		await page.getByRole('button', { name: 'privacy policy' }).click();
@@ -19,6 +20,7 @@ test.describe('EULA', () => {
 
 	test('Disagree navigates away', async ({ page }) => {
 		await TestOpenPandora(page, { agreeEula: false });
+		await expect(page.getByText(TEST_EULA_TEXT)).toBeVisible();
 
 		// Disagree button should navigate away from pandora
 		await page.getByRole('button', { name: 'Disagree' }).click();
@@ -32,13 +34,14 @@ test.describe('EULA', () => {
 			agreeEula: false,
 		});
 
-		// Disagree button should navigate away from pandora
+		await expect(page.getByText(TEST_EULA_TEXT)).toBeVisible();
 		await expect(page.getByRole('button', { name: 'Disagree' })).toBeVisible();
 		await expect(page.getByRole('button', { name: /^Agree/ })).toBeVisible();
 	});
 
 	test('Agree opens login', async ({ page }) => {
 		await TestOpenPandora(page, { agreeEula: false });
+		await expect(page.getByText(TEST_EULA_TEXT)).toBeVisible();
 
 		// Agree button opens login
 		await page.getByRole('button', { name: /^Agree/ }).click();
@@ -49,6 +52,7 @@ test.describe('EULA', () => {
 
 	test('Agreement is remembered', async ({ page }) => {
 		await TestOpenPandora(page, { agreeEula: false });
+		await expect(page.getByText(TEST_EULA_TEXT)).toBeVisible();
 
 		await page.getByRole('button', { name: /^Agree/ }).click();
 		await page.waitForURL('/login');
@@ -57,6 +61,7 @@ test.describe('EULA', () => {
 		await page.reload();
 
 		// No agreement needed
+		await expect(page.getByText(TEST_EULA_TEXT)).not.toBeVisible();
 		await page.waitForURL('/login');
 		await expect(page.getByRole('button', { name: 'Sign in', exact: true })).toBeVisible();
 	});
@@ -65,6 +70,7 @@ test.describe('EULA', () => {
 		await TestOpenPandora(page, { agreeEula: true });
 
 		// No agreement needed
+		await expect(page.getByText(TEST_EULA_TEXT)).not.toBeVisible();
 		await page.waitForURL('/login');
 		await expect(page.getByRole('button', { name: 'Sign in', exact: true })).toBeVisible();
 	});

--- a/pandora-tests/test/utils/helpers.ts
+++ b/pandora-tests/test/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { ConsoleMessage, Page } from '@playwright/test';
+import { ConsoleMessage, Page, expect } from '@playwright/test';
 
 const handleLog = (message: ConsoleMessage) => {
 	if (message.type() === 'error') {
@@ -35,7 +35,14 @@ export async function TestOpenPandora(page: Page, options: TestOpenPandoraOption
 	await page.goto(options.path ?? '/');
 
 	if (options.agreeEula !== false) {
-		await page.getByRole('button', { name: /^Agree/ }).click();
-		await page.waitForURL('/login');
+		await TestPandoraAgreeEula(page);
 	}
+}
+
+// EULA helper
+export const TEST_EULA_TEXT = 'By playing this game, you agree to the following:';
+async function TestPandoraAgreeEula(page: Page): Promise<void> {
+	await expect(page.getByText(TEST_EULA_TEXT)).toBeVisible();
+	await page.getByRole('button', { name: /^Agree/ }).click();
+	await expect(page.getByText(TEST_EULA_TEXT)).not.toBeVisible();
 }

--- a/pandora-tests/test/wiki.test.ts
+++ b/pandora-tests/test/wiki.test.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+import { TestOpenPandora } from './utils/helpers';
+
+test.describe('Wiki', () => {
+	test('Selects default tab', async ({ page }) => {
+		await TestOpenPandora(page, { path: '/wiki' });
+
+		await page.waitForURL('/wiki/introduction');
+		await expect(page.getByRole('button', { name: 'Introduction' })).toHaveClass('tab active');
+		await expect(page.getByRole('heading', { name: 'Introduction to Pandora' })).toBeVisible();
+	});
+
+	test('Loads specific tab directly based on url', async ({ page }) => {
+		await TestOpenPandora(page, { path: '/wiki/history' });
+
+		await expect(page.getByRole('button', { name: 'Introduction' })).toHaveClass('tab');
+		await expect(page.getByRole('button', { name: 'Pandora History' })).toHaveClass('tab active');
+		await expect(page.getByRole('heading', { name: `Pandora's history`, exact: true })).toBeVisible();
+	});
+
+	test('Switches tabs', async ({ page }) => {
+		await TestOpenPandora(page, { path: '/wiki/introduction' });
+
+		// Initial tab is introcution
+		await expect(page.getByRole('button', { name: 'Introduction' })).toHaveClass('tab active');
+		await expect(page.getByRole('button', { name: 'Contact' })).toHaveClass('tab');
+		await expect(page.getByRole('heading', { name: 'Introduction to Pandora' })).toBeVisible();
+		await page.waitForURL('/wiki/introduction');
+
+		// Nothing changes when clicking already selected tab
+		await page.getByRole('button', { name: 'Introduction' }).click();
+		await expect(page.getByRole('button', { name: 'Introduction' })).toHaveClass('tab active');
+		await expect(page.getByRole('button', { name: 'Contact' })).toHaveClass('tab');
+		await expect(page.getByRole('heading', { name: 'Introduction to Pandora' })).toBeVisible();
+		await page.waitForURL('/wiki/introduction');
+
+		// Switch to tab "Contact"
+		await page.getByRole('button', { name: 'Contact' }).click();
+		await expect(page.getByRole('button', { name: 'Contact' })).toHaveClass('tab active');
+		await expect(page.getByRole('heading', { name: 'Contact Us', exact: true })).toBeVisible();
+		await page.waitForURL('/wiki/contact');
+
+		await expect(page.getByRole('button', { name: 'Introduction' })).toHaveClass('tab');
+		await expect(page.getByRole('heading', { name: 'Introduction to Pandora' })).not.toBeVisible();
+	});
+
+	test('Uses back button', async ({ page }) => {
+		await TestOpenPandora(page, { path: '/wiki/introduction' });
+
+		// Initial tab is introcution
+		await expect(page.getByRole('button', { name: 'Introduction' })).toHaveClass('tab active');
+		await page.getByRole('button', { name: 'Back' }).click();
+		await page.waitForURL('/login');
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,11 +74,11 @@ importers:
         specifier: 10.4.1
         version: 10.4.1(react-dom@18.2.0)(react@18.2.0)
       react-router:
-        specifier: 6.20.0
-        version: 6.20.0(react@18.2.0)
+        specifier: 6.18.0
+        version: 6.18.0(react@18.2.0)
       react-router-dom:
-        specifier: 6.20.0
-        version: 6.20.0(react-dom@18.2.0)(react@18.2.0)
+        specifier: 6.18.0
+        version: 6.18.0(react-dom@18.2.0)(react@18.2.0)
       react-toastify:
         specifier: 9.1.3
         version: 9.1.3(react-dom@18.2.0)(react@18.2.0)
@@ -3842,8 +3842,8 @@ packages:
       webpack: 5.89.0(webpack-cli@5.1.4)
     dev: true
 
-  /@remix-run/router@1.13.0:
-    resolution: {integrity: sha512-5dMOnVnefRsl4uRnAdoWjtVTdh8e6aZqgM4puy9nmEADH72ck+uXwzpJLEKE9Q6F8ZljNewLgmTfkxUrBdv4WA==}
+  /@remix-run/router@1.11.0:
+    resolution: {integrity: sha512-BHdhcWgeiudl91HvVa2wxqZjSHbheSgIiDvxrF1VjFzBzpTtuDPkOdOi3Iqvc08kXtFkLjhbS+ML9aM8mJS+wQ==}
     engines: {node: '>=14.0.0'}
     dev: false
 
@@ -11117,26 +11117,26 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /react-router-dom@6.20.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-CbcKjEyiSVpA6UtCHOIYLUYn/UJfwzp55va4yEfpk7JBN3GPqWfHrdLkAvNCcpXr8QoihcDMuk0dzWZxtlB/mQ==}
+  /react-router-dom@6.18.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-Ubrue4+Ercc/BoDkFQfc6og5zRQ4A8YxSO3Knsne+eRbZ+IepAsK249XBH/XaFuOYOYr3L3r13CXTLvYt5JDjw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.13.0
+      '@remix-run/router': 1.11.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-router: 6.20.0(react@18.2.0)
+      react-router: 6.18.0(react@18.2.0)
     dev: false
 
-  /react-router@6.20.0(react@18.2.0):
-    resolution: {integrity: sha512-pVvzsSsgUxxtuNfTHC4IxjATs10UaAtvLGVSA1tbUE4GDaOSU1Esu2xF5nWLz7KPiMuW8BJWuPFdlGYJ7/rW0w==}
+  /react-router@6.18.0(react@18.2.0):
+    resolution: {integrity: sha512-vk2y7Dsy8wI02eRRaRmOs9g2o+aE72YCx5q9VasT1N9v+lrdB79tIqrjMfByHiY5+6aYkH2rUa5X839nwWGPDg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
     dependencies:
-      '@remix-run/router': 1.13.0
+      '@remix-run/router': 1.11.0
       react: 18.2.0
     dev: false
 


### PR DESCRIPTION
Tracking issue for upstream: https://github.com/remix-run/react-router/issues/11052