### PR TITLE
[FEATURE] preview cutter

### DIFF
--- a/pandora-client-web/src/common/downloadHelper.ts
+++ b/pandora-client-web/src/common/downloadHelper.ts
@@ -1,0 +1,23 @@
+export function DownloadAsFile(content: Blob, filename: string): void;
+export function DownloadAsFile(content: string, filename: string, type?: string): void;
+export function DownloadAsFile(content: string | Blob, filename: string, type?: string): void {
+	let url = '';
+	if (typeof content === 'string') {
+		if (content.startsWith('data:')) {
+			url = content;
+		} else {
+			const blob = new Blob([content], { type });
+			url = URL.createObjectURL(blob);
+		}
+	} else {
+		url = URL.createObjectURL(content);
+	}
+	const a = document.createElement('a');
+	a.href = url;
+	a.download = filename;
+	a.style.display = 'none';
+	document.body.appendChild(a);
+	a.click();
+	a.remove();
+	URL.revokeObjectURL(url);
+}

--- a/pandora-client-web/src/common/downloadHelper.ts
+++ b/pandora-client-web/src/common/downloadHelper.ts
@@ -1,9 +1,13 @@
+export type DataString = `data:${string}`;
+
 export function DownloadAsFile(content: Blob, filename: string): void;
-export function DownloadAsFile(content: string, filename: string, type?: string): void;
+export function DownloadAsFile(content: DataString, filename: string): void;
+export function DownloadAsFile(content: string, filename: string, type: string): void;
 export function DownloadAsFile(content: string | Blob, filename: string, type?: string): void {
 	let url = '';
 	if (typeof content === 'string') {
-		if (content.startsWith('data:')) {
+		if (!type) {
+			AssertDataString(content);
 			url = content;
 		} else {
 			const blob = new Blob([content], { type });
@@ -19,5 +23,12 @@ export function DownloadAsFile(content: string | Blob, filename: string, type?: 
 	document.body.appendChild(a);
 	a.click();
 	a.remove();
-	URL.revokeObjectURL(url);
+	if (typeof content !== 'string' || type)
+		URL.revokeObjectURL(url);
+}
+
+export function AssertDataString(str: string): asserts str is DataString {
+	if (!str.startsWith('data:')) {
+		throw new Error('Not a data string');
+	}
 }

--- a/pandora-client-web/src/components/exportImport/exportDialog.tsx
+++ b/pandora-client-web/src/components/exportImport/exportDialog.tsx
@@ -8,6 +8,7 @@ import { ExportData } from './exportImportUtils';
 import { toast } from 'react-toastify';
 import { TOAST_OPTIONS_ERROR } from '../../persistentToast';
 import './exportDialog.scss';
+import { DownloadAsFile } from '../../common/downloadHelper';
 
 interface ExportDialogProps<T extends ZodType<unknown>> {
 	exportType: string;
@@ -56,13 +57,8 @@ export function ExportDialog<T extends ZodType<unknown>>({
 	const downloadAsFile = useCallback(() => {
 		if (!downloadFileName.trim())
 			return;
-		const element = document.createElement('a');
-		element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(exportString));
-		element.setAttribute('download', downloadFileName.trim());
-		element.style.display = 'none';
-		document.body.appendChild(element);
-		element.click();
-		document.body.removeChild(element);
+
+		DownloadAsFile(exportString, downloadFileName.trim(), 'text/plain;charset=utf-8');
 	}, [downloadFileName, exportString]);
 
 	const copyToClipboard = useCallback(() => {

--- a/pandora-client-web/src/components/input/numberInput.tsx
+++ b/pandora-client-web/src/components/input/numberInput.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { clamp } from 'lodash';
+
+export type InputNumberProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type' | 'onChange' | 'value' | 'defaultValue' | 'min' | 'max'> & {
+	onChange?: (value: number) => void;
+	parse?: (value: string, radix?: number) => number;
+	resetTimer?: number;
+	value?: number;
+	defaultValue?: number;
+	min?: number;
+	max?: number;
+	step?: number;
+};
+
+export const InputNumber = React.forwardRef<HTMLInputElement, InputNumberProps>(function InputNumber({
+	onChange,
+	parse = parseInt,
+	resetTimer = 1000,
+	value,
+	defaultValue,
+	...props
+}, ref) {
+	const [inputValue, setInputValue] = React.useState((value ?? defaultValue ?? props.min ?? props.max ?? 0).toString());
+	const resetTimeout = React.useRef<null | number>(null);
+
+	const onChangeEvent = React.useCallback((ev: React.ChangeEvent<HTMLInputElement>) => {
+		const newValue = ev.target.value;
+		setInputValue(newValue);
+
+		if (resetTimeout.current != null) {
+			clearTimeout(resetTimeout.current);
+			resetTimeout.current = null;
+		}
+
+		const parsed = parse(newValue, 10);
+		if (!isNaN(parsed)) {
+			const clamped = ClampAndStepValue(parsed, props.min, props.max, props.step);
+			onChange?.(clamped);
+			resetTimeout.current = setTimeout(() => {
+				setInputValue(clamped.toString());
+			}, resetTimer);
+		}
+	}, [onChange, parse, props.min, props.max, props.step, resetTimer]);
+
+	React.useEffect(() => {
+		if (value == null || value === parse(inputValue))
+			return;
+
+		if (resetTimeout.current != null) {
+			clearTimeout(resetTimeout.current);
+			resetTimeout.current = null;
+		}
+
+		resetTimeout.current = setTimeout(() => {
+			setInputValue(value.toString());
+		}, resetTimer);
+	}, [value, inputValue, parse, resetTimer]);
+
+	return <input { ...props } type='number' onChange={ onChangeEvent } value={ inputValue } ref={ ref } />;
+});
+
+function ClampAndStepValue(value: number, min: number = -Infinity, max: number = Infinity, step?: number) {
+	let clamped = clamp(value, min, max);
+	if (step != null) {
+		const stepCount = Math.round((clamped - min) / step);
+		clamped = stepCount * step + min;
+	}
+	return clamped;
+}

--- a/pandora-client-web/src/components/wardrobe/views/wardrobeAssetView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobeAssetView.tsx
@@ -199,7 +199,7 @@ function InventoryAssetViewListPickup({ asset, listMode }: {
 					},
 				});
 			} }>
-			<InventoryAssetPreview asset={ asset } />
+			<InventoryAssetPreview asset={ asset } small={ listMode } />
 			<span className='itemName'>{ asset.definition.name }</span>
 		</div>
 	);
@@ -271,7 +271,7 @@ function InventoryAssetViewListSpawn({ asset, container, listMode }: {
 					<ActionWarning problems={ finalProblems } parent={ ref } />
 				) : null
 			}
-			<InventoryAssetPreview asset={ asset } />
+			<InventoryAssetPreview asset={ asset } small={ listMode } />
 			<span className='itemName'>{ asset.definition.name }</span>
 		</div>
 	);

--- a/pandora-client-web/src/components/wardrobe/views/wardrobeItemView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobeItemView.tsx
@@ -277,7 +277,7 @@ function InventoryItemViewList({ item, selected = false, setFocus, singleItemCon
 						} }
 					/> : null
 			}
-			<InventoryAssetPreview asset={ asset } />
+			<InventoryAssetPreview asset={ asset } small={ true } />
 			<span className='itemName'>{ asset.definition.name }</span>
 			<div className='quickActions'>
 				{

--- a/pandora-client-web/src/components/wardrobe/views/wardrobeOutfitEditView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobeOutfitEditView.tsx
@@ -410,7 +410,7 @@ function OutfitEditViewItem({ itemTemplate, updateItemTemplate, reorderItemTempl
 						} }
 					/> : null
 			}
-			<InventoryAssetPreview asset={ asset } />
+			<InventoryAssetPreview asset={ asset } small={ true } />
 			<span className='itemName'>{ visibleName }</span>
 			<div className='quickActions'>
 				<button

--- a/pandora-client-web/src/components/wardrobe/views/wardrobeOutfitView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobeOutfitView.tsx
@@ -594,7 +594,7 @@ function OutfitEntryItem({ itemTemplate, targetContainer }: {
 						} }
 					/> : null
 			}
-			<InventoryAssetPreview asset={ asset } />
+			<InventoryAssetPreview asset={ asset } small={ true } />
 			<span className='itemName'>{ visibleName }</span>
 			<div className='quickActions'>
 				<WardrobeActionButton

--- a/pandora-client-web/src/components/wardrobe/views/wardrobeRoomInventoryView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobeRoomInventoryView.tsx
@@ -172,7 +172,7 @@ function RoomInventoryViewListItem({ room, item, characterContainer }: {
 						} }
 					/> : null
 			}
-			<InventoryAssetPreview asset={ asset } />
+			<InventoryAssetPreview asset={ asset } small={ true } />
 			<span className='itemName'>{ asset.definition.name }</span>
 			<div className='quickActions'>
 				{ showExtraActionButtons ? (

--- a/pandora-client-web/src/components/wardrobe/wardrobeComponents.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobeComponents.tsx
@@ -16,7 +16,7 @@ import { useWardrobeContext, useWardrobeExecuteChecked } from './wardrobeContext
 import { useStaggeredAppearanceActionResult } from './wardrobeCheckQueue';
 import _ from 'lodash';
 import { usePermissionCheck } from '../gameContext/permissionCheckProvider';
-import { useCurrentAccount } from '../gameContext/directoryConnectorContextProvider';
+import { useCurrentAccountSettings } from '../gameContext/directoryConnectorContextProvider';
 
 export function ActionWarningContent({ problems }: { problems: readonly AppearanceActionProblem[]; }): ReactElement {
 	const assetManager = useAssetManager();
@@ -228,12 +228,10 @@ export function InventoryAssetPreview({ asset, small }: {
 }
 
 function useAssetPreviewType(small: boolean): 'icon' | 'image' {
-	const account = useCurrentAccount();
-	if (!account)
-		return 'icon';
+	const settings = useCurrentAccountSettings();
 
 	if (small)
-		return account.settings.wardrobeSmallPreview;
+		return settings.wardrobeSmallPreview;
 
-	return account.settings.wardrobeBigPreview;
+	return settings.wardrobeBigPreview;
 }

--- a/pandora-client-web/src/components/wardrobe/wardrobeComponents.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobeComponents.tsx
@@ -185,7 +185,10 @@ export function InventoryAssetPreview({ asset }: {
 }): ReactElement {
 	const assetManager = useAssetManager();
 
-	const iconAttribute = useMemo(() => {
+	const preview = useMemo(() => {
+		if (asset.definition.preview != null)
+			return asset.definition.preview;
+
 		const validAttributes = Array.from(asset.staticAttributes)
 			.map((attributeName) => assetManager.getAttributeDefinition(attributeName))
 			.filter(IsNotNullable)
@@ -197,12 +200,12 @@ export function InventoryAssetPreview({ asset }: {
 		);
 
 		if (filterAttribute)
-			return filterAttribute;
+			return filterAttribute.icon;
 
-		return validAttributes.length > 0 ? validAttributes[0] : undefined;
+		return validAttributes.length > 0 ? validAttributes[0].icon : undefined;
 	}, [asset, assetManager]);
 
-	const icon = useGraphicsUrl(iconAttribute?.icon);
+	const icon = useGraphicsUrl(preview);
 
 	if (icon) {
 		return (

--- a/pandora-client-web/src/components/wardrobe/wardrobeComponents.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobeComponents.tsx
@@ -16,6 +16,7 @@ import { useWardrobeContext, useWardrobeExecuteChecked } from './wardrobeContext
 import { useStaggeredAppearanceActionResult } from './wardrobeCheckQueue';
 import _ from 'lodash';
 import { usePermissionCheck } from '../gameContext/permissionCheckProvider';
+import { useCurrentAccount } from '../gameContext/directoryConnectorContextProvider';
 
 export function ActionWarningContent({ problems }: { problems: readonly AppearanceActionProblem[]; }): ReactElement {
 	const assetManager = useAssetManager();
@@ -180,13 +181,15 @@ export function AttributeButton({ attribute, ...buttonProps }: {
 	);
 }
 
-export function InventoryAssetPreview({ asset }: {
+export function InventoryAssetPreview({ asset, small }: {
 	asset: Asset;
+	small: boolean;
 }): ReactElement {
 	const assetManager = useAssetManager();
+	const previewType = useAssetPreviewType(small);
 
 	const preview = useMemo(() => {
-		if (asset.definition.preview != null)
+		if (previewType === 'image' && asset.definition.preview != null)
 			return asset.definition.preview;
 
 		const validAttributes = Array.from(asset.staticAttributes)
@@ -203,7 +206,7 @@ export function InventoryAssetPreview({ asset }: {
 			return filterAttribute.icon;
 
 		return validAttributes.length > 0 ? validAttributes[0].icon : undefined;
-	}, [asset, assetManager]);
+	}, [asset, previewType, assetManager]);
 
 	const icon = useGraphicsUrl(preview);
 
@@ -222,4 +225,15 @@ export function InventoryAssetPreview({ asset }: {
 	return (
 		<div className='itemPreview missing'>?</div>
 	);
+}
+
+function useAssetPreviewType(small: boolean): 'icon' | 'image' {
+	const account = useCurrentAccount();
+	if (!account)
+		return 'icon';
+
+	if (small)
+		return account.settings.wardrobeSmallPreview;
+
+	return account.settings.wardrobeBigPreview;
 }

--- a/pandora-client-web/src/editor/assets/assetManager.ts
+++ b/pandora-client-web/src/editor/assets/assetManager.ts
@@ -3,6 +3,7 @@ import { Immutable } from 'immer';
 import { TypedEventEmitter, Assert, Asset, AssetDefinition, AssetGraphicsDefinition, AssetId, AssetsDefinitionFile } from 'pandora-common';
 import { AssetManagerClient, GetCurrentAssetManager, UpdateAssetManager, useAssetManager } from '../../assets/assetManager';
 import { ObservableProperty, ObservableClass } from '../../observable';
+import { DownloadAsFile } from '../../common/downloadHelper';
 
 export const ASSET_ID_PART_REGEX = /^[a-z][a-z0-9]*([-_][a-z0-9]+)*$/;
 
@@ -123,14 +124,7 @@ DefineAsset({
 		// get the ZIP stream in a Blob
 		const blob = await downloadZip(files).blob();
 
-		// make and click a temporary link to download the Blob
-		const link = document.createElement('a');
-		link.href = URL.createObjectURL(blob);
-		link.download = `${id.replace(/^a\//, '').replaceAll('/', '_')}_template.zip`;
-		link.style.display = 'none';
-		document.body.appendChild(link);
-		link.click();
-		link.remove();
+		DownloadAsFile(blob, `${id.replace(/^a\//, '').replaceAll('/', '_')}_template.zip`);
 	}
 }
 

--- a/pandora-client-web/src/editor/components/assets/assets.tsx
+++ b/pandora-client-web/src/editor/components/assets/assets.tsx
@@ -20,6 +20,7 @@ import './assets.scss';
 import { toast } from 'react-toastify';
 import { TOAST_OPTIONS_ERROR } from '../../../persistentToast';
 import { useEditorCharacterState } from '../../graphics/character/appearanceEditor';
+import { PreviewCutter } from '../previewCutter/previewCutter';
 
 export function AssetsUI(): ReactElement {
 	const editor = useEditor();
@@ -97,6 +98,7 @@ export function AssetsUI(): ReactElement {
 				</ContextHelpButton>
 			</h3>
 			<AssetCreatePrompt />
+			<PreviewCutter />
 			<ul>
 				{ view.categories.map((category) => <AssetCategoryElement key={ category.name } category={ category } />) }
 			</ul>

--- a/pandora-client-web/src/editor/components/previewCutter/previewCutter.scss
+++ b/pandora-client-web/src/editor/components/previewCutter/previewCutter.scss
@@ -1,0 +1,35 @@
+.previewCutter {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5em;
+
+	> div {
+		display: grid;
+		grid-template-columns: 0.3fr 0.7fr;
+	}
+
+	> div:first-of-type {
+		margin-top: 0.5em;
+	}
+
+	label {
+		text-align: right;
+		margin: auto;
+		width: 6em;
+	}
+
+	label::after {
+		content: ':';
+	}
+
+	input[type='checkbox'] {
+		scale: 1.5;
+		width: fit-content;
+	}
+
+	button {
+		margin: auto;
+		grid-column: 1 / span 2;
+		width: 100%;
+	}
+}

--- a/pandora-client-web/src/editor/components/previewCutter/previewCutter.tsx
+++ b/pandora-client-web/src/editor/components/previewCutter/previewCutter.tsx
@@ -10,6 +10,7 @@ import { useEvent } from '../../../common/useEvent';
 import { ImageExporter } from '../../graphics/export/imageExporter';
 import { DownloadAsFile } from '../../../common/downloadHelper';
 import { EditorSceneContext, useEditorSceneContext } from '../../graphics/editorScene';
+import { InputNumber } from '../../../components/input/numberInput';
 import './previewCutter.scss';
 
 type PreviewCutterState = Readonly<{
@@ -136,8 +137,7 @@ export function PreviewCutter() {
 			enabled,
 		};
 	}, []);
-	const setX = React.useCallback((ev: React.ChangeEvent<HTMLInputElement>) => {
-		const x = clamp(parseInt(ev.target.value, 10), -state.size, CharacterSize.WIDTH + state.size);
+	const setX = React.useCallback((x: number) => {
 		PREVIEW_CUTTER.value = {
 			...PREVIEW_CUTTER.value,
 			position: {
@@ -145,9 +145,8 @@ export function PreviewCutter() {
 				x,
 			},
 		};
-	}, [state.size]);
-	const setY = React.useCallback((ev: React.ChangeEvent<HTMLInputElement>) => {
-		const y = clamp(parseInt(ev.target.value, 10), -state.size, CharacterSize.HEIGHT + state.size);
+	}, []);
+	const setY = React.useCallback((y: number) => {
 		PREVIEW_CUTTER.value = {
 			...PREVIEW_CUTTER.value,
 			position: {
@@ -155,9 +154,8 @@ export function PreviewCutter() {
 				y,
 			},
 		};
-	}, [state.size]);
-	const setSize = React.useCallback((ev: React.ChangeEvent<HTMLInputElement>) => {
-		const size = clamp(parseInt(ev.target.value, 10), PREVIEW_CUTTER_MIN_SIZE, PREVIEW_CUTTER_MAX_SIZE);
+	}, []);
+	const setSize = React.useCallback((size: number) => {
 		PREVIEW_CUTTER.value = {
 			...PREVIEW_CUTTER.value,
 			size,
@@ -195,15 +193,15 @@ export function PreviewCutter() {
 		<FieldsetToggle legend='Preview Cutter' forceOpen={ state.enabled } onChange={ onChange } className='previewCutter'>
 			<div>
 				<label htmlFor='preview-cutter-x'>X</label>
-				<input id='preview-cutter-x' type='number' value={ state.position.x } onChange={ setX } />
+				<InputNumber id='preview-cutter-x' min={ -state.size } max={ CharacterSize.WIDTH + state.size } value={ state.position.x } onChange={ setX } />
 			</div>
 			<div>
 				<label htmlFor='preview-cutter-y'>Y</label>
-				<input id='preview-cutter-y' type='number' value={ state.position.y } onChange={ setY } />
+				<InputNumber id='preview-cutter-y' min={ -state.size } max={ CharacterSize.HEIGHT + state.size } value={ state.position.y } onChange={ setY } />
 			</div>
 			<div>
 				<label htmlFor='preview-cutter-size'>Size</label>
-				<input id='preview-cutter-size' type='number' value={ state.size } onChange={ setSize } />
+				<InputNumber id='preview-cutter-size' min={ PREVIEW_CUTTER_MIN_SIZE } max={ PREVIEW_CUTTER_MAX_SIZE } value={ state.size } onChange={ setSize } />
 			</div>
 			<div>
 				<label htmlFor='preview-cutter-centered'>Centered</label>

--- a/pandora-client-web/src/editor/components/previewCutter/previewCutter.tsx
+++ b/pandora-client-web/src/editor/components/previewCutter/previewCutter.tsx
@@ -30,6 +30,7 @@ const PREVIEW_CUTTER = new Observable<PreviewCutterState>({
 
 const PREVIEW_CUTTER_MIN_SIZE = 50;
 const PREVIEW_CUTTER_MAX_SIZE = CharacterSize.HEIGHT / 3 * 4;
+const PREVIEW_CUTTER_OUTPUT_SIZE = 256;
 
 export function PreviewCutterRectangle() {
 	const state = useObservable(PREVIEW_CUTTER);
@@ -176,12 +177,19 @@ export function PreviewCutter() {
 			return;
 		}
 		const exporter = new ImageExporter();
-		exporter.imageCut(container, {
-			x: (state.centered ? ((CharacterSize.WIDTH - state.size) / 2) : state.position.x),
-			y: state.position.y,
-			width: state.size,
-			height: state.size,
-		}, 'png')
+		exporter.imageCut(
+			container,
+			{
+				x: (state.centered ? ((CharacterSize.WIDTH - state.size) / 2) : state.position.x),
+				y: state.position.y,
+				width: state.size,
+				height: state.size,
+			},
+			'png',
+			{
+				width: PREVIEW_CUTTER_OUTPUT_SIZE,
+				height: PREVIEW_CUTTER_OUTPUT_SIZE,
+			})
 			.then((image) => DownloadAsFile(image, 'preview.png'))
 			.catch((error) => GetLogger('Editor').error('Error exporting image:', error));
 	});
@@ -189,15 +197,15 @@ export function PreviewCutter() {
 		<FieldsetToggle legend='Preview Cutter' forceOpen={ state.enabled } onChange={ onChange } className='previewCutter'>
 			<div>
 				<label htmlFor='preview-cutter-x'>X</label>
-				<input id='preview-cutter-x' type='number' defaultValue={ state.position.x } onChange={ setX } />
+				<input id='preview-cutter-x' type='number' value={ state.position.x } onChange={ setX } />
 			</div>
 			<div>
 				<label htmlFor='preview-cutter-y'>Y</label>
-				<input id='preview-cutter-y' type='number' defaultValue={ state.position.y } onChange={ setY } />
+				<input id='preview-cutter-y' type='number' value={ state.position.y } onChange={ setY } />
 			</div>
 			<div>
 				<label htmlFor='preview-cutter-size'>Size</label>
-				<input id='preview-cutter-size' type='number' defaultValue={ state.size } onChange={ setSize } />
+				<input id='preview-cutter-size' type='number' value={ state.size } onChange={ setSize } />
 			</div>
 			<div>
 				<label htmlFor='preview-cutter-centered'>Centered</label>

--- a/pandora-client-web/src/editor/components/previewCutter/previewCutter.tsx
+++ b/pandora-client-web/src/editor/components/previewCutter/previewCutter.tsx
@@ -14,7 +14,6 @@ import './previewCutter.scss';
 
 type PreviewCutterState = Readonly<{
 	enabled: boolean;
-	lineWidth: number;
 	size: number;
 	centered: boolean;
 	position: Readonly<{ x: number; y: number; }>;
@@ -22,12 +21,12 @@ type PreviewCutterState = Readonly<{
 
 const PREVIEW_CUTTER = new Observable<PreviewCutterState>({
 	enabled: false,
-	lineWidth: 2,
 	size: 200,
 	centered: true,
 	position: { x: 0, y: 100 },
 });
 
+const PREVIRE_CUTTER_LINE_WIDTH = 2;
 const PREVIEW_CUTTER_MIN_SIZE = 50;
 const PREVIEW_CUTTER_MAX_SIZE = CharacterSize.HEIGHT / 3 * 4;
 const PREVIEW_CUTTER_OUTPUT_SIZE = 256;
@@ -43,7 +42,6 @@ export function PreviewCutterRectangle() {
 let editorSceneContext: EditorSceneContext | null = null;
 
 function PreviewCutterRectangleInner({
-	lineWidth,
 	size,
 	centered,
 	position,
@@ -57,9 +55,9 @@ function PreviewCutterRectangleInner({
 		const color = dragging ? 0x00ff00 : 0x333333;
 		g
 			.clear()
-			.lineStyle(lineWidth, color, 1)
-			.drawRect(x - lineWidth / 2, y - lineWidth / 2, size + lineWidth, size + lineWidth);
-	}, [lineWidth, dragging, x, y, size]);
+			.lineStyle(PREVIRE_CUTTER_LINE_WIDTH, color, 1)
+			.drawRect(x - PREVIRE_CUTTER_LINE_WIDTH / 2, y - PREVIRE_CUTTER_LINE_WIDTH / 2, size + PREVIRE_CUTTER_LINE_WIDTH, size + PREVIRE_CUTTER_LINE_WIDTH);
+	}, [dragging, x, y, size]);
 	const onPointerDown = React.useCallback((ev: PIXI.FederatedPointerEvent) => {
 		ev.stopPropagation();
 		setDragging(true);
@@ -90,13 +88,13 @@ function PreviewCutterRectangleInner({
 				case '+':
 					PREVIEW_CUTTER.value = {
 						...PREVIEW_CUTTER.value,
-						size: clamp(size + delta, 10, CharacterSize.HEIGHT),
+						size: clamp(size + delta, PREVIEW_CUTTER_MIN_SIZE, PREVIEW_CUTTER_MAX_SIZE),
 					};
 					break;
 				case '-':
 					PREVIEW_CUTTER.value = {
 						...PREVIEW_CUTTER.value,
-						size: clamp(size - delta, 10, CharacterSize.HEIGHT),
+						size: clamp(size - delta, PREVIEW_CUTTER_MIN_SIZE, PREVIEW_CUTTER_MAX_SIZE),
 					};
 					break;
 			}
@@ -119,7 +117,7 @@ function PreviewCutterRectangleInner({
 		<Graphics
 			zIndex={ 0 }
 			interactive={ true }
-			hitArea={ new PIXI.Rectangle(x, y - lineWidth / 2, size, size) }
+			hitArea={ new PIXI.Rectangle(x, y, size, size) }
 			draw={ draw }
 			ref={ graphic }
 			onpointerdown={ onPointerDown }

--- a/pandora-client-web/src/editor/components/previewCutter/previewCutter.tsx
+++ b/pandora-client-web/src/editor/components/previewCutter/previewCutter.tsx
@@ -4,13 +4,13 @@ import * as PIXI from 'pixi.js';
 import { CharacterSize, GetLogger } from 'pandora-common';
 import { Observable, useObservable } from '../../../observable';
 import { FieldsetToggle } from '../../../components/common/fieldsetToggle';
-import { Row } from '../../../components/common/container/container';
 import { clamp } from 'lodash';
 import { Button } from '../../../components/common/button/button';
 import { useEvent } from '../../../common/useEvent';
 import { ImageExporter } from '../../graphics/export/imageExporter';
 import { DownloadAsFile } from '../../../common/downloadHelper';
 import { EditorSceneContext, useEditorSceneContext } from '../../graphics/editorScene';
+import './previewCutter.scss';
 
 type PreviewCutterState = Readonly<{
 	enabled: boolean;
@@ -194,28 +194,28 @@ export function PreviewCutter() {
 			.catch((error) => GetLogger('Editor').error('Error exporting image:', error));
 	});
 	return (
-		<FieldsetToggle legend='Preview Cutter' forceOpen={ state.enabled } onChange={ onChange }>
-			<Row>
+		<FieldsetToggle legend='Preview Cutter' forceOpen={ state.enabled } onChange={ onChange } className='previewCutter'>
+			<div>
 				<label htmlFor='preview-cutter-x'>X</label>
 				<input id='preview-cutter-x' type='number' value={ state.position.x } onChange={ setX } />
-			</Row>
-			<Row>
+			</div>
+			<div>
 				<label htmlFor='preview-cutter-y'>Y</label>
 				<input id='preview-cutter-y' type='number' value={ state.position.y } onChange={ setY } />
-			</Row>
-			<Row>
+			</div>
+			<div>
 				<label htmlFor='preview-cutter-size'>Size</label>
 				<input id='preview-cutter-size' type='number' value={ state.size } onChange={ setSize } />
-			</Row>
-			<Row>
+			</div>
+			<div>
 				<label htmlFor='preview-cutter-centered'>Centered</label>
 				<input id='preview-cutter-centered' type='checkbox' checked={ state.centered } onChange={ setCentered } />
-			</Row>
-			<Row>
+			</div>
+			<div>
 				<Button onClick={ createPreviewImage }>
 					Create Preview Image
 				</Button>
-			</Row>
+			</div>
 		</FieldsetToggle>
 	);
 }

--- a/pandora-client-web/src/editor/components/previewCutter/previewCutter.tsx
+++ b/pandora-client-web/src/editor/components/previewCutter/previewCutter.tsx
@@ -23,12 +23,13 @@ type PreviewCutterState = Readonly<{
 const PREVIEW_CUTTER = new Observable<PreviewCutterState>({
 	enabled: false,
 	lineWidth: 2,
-	size: 100,
+	size: 200,
 	centered: true,
 	position: { x: 0, y: 100 },
 });
 
 const PREVIEW_CUTTER_MIN_SIZE = 50;
+const PREVIEW_CUTTER_MAX_SIZE = CharacterSize.HEIGHT / 3 * 4;
 
 export function PreviewCutterRectangle() {
 	const state = useObservable(PREVIEW_CUTTER);
@@ -56,7 +57,7 @@ function PreviewCutterRectangleInner({
 		g
 			.clear()
 			.lineStyle(lineWidth, color, 1)
-			.drawRect(x, y - lineWidth / 2, size, size);
+			.drawRect(x - lineWidth / 2, y - lineWidth / 2, size + lineWidth, size + lineWidth);
 	}, [lineWidth, dragging, x, y, size]);
 	const onPointerDown = React.useCallback((ev: PIXI.FederatedPointerEvent) => {
 		ev.stopPropagation();
@@ -137,10 +138,7 @@ export function PreviewCutter() {
 		};
 	}, []);
 	const setX = React.useCallback((ev: React.ChangeEvent<HTMLInputElement>) => {
-		const x = parseInt(ev.target.value, 10);
-		if (x < 0 || x > CharacterSize.WIDTH) {
-			return;
-		}
+		const x = clamp(parseInt(ev.target.value, 10), -state.size, CharacterSize.WIDTH + state.size);
 		PREVIEW_CUTTER.value = {
 			...PREVIEW_CUTTER.value,
 			position: {
@@ -148,12 +146,9 @@ export function PreviewCutter() {
 				x,
 			},
 		};
-	}, []);
+	}, [state.size]);
 	const setY = React.useCallback((ev: React.ChangeEvent<HTMLInputElement>) => {
-		const y = parseInt(ev.target.value, 10);
-		if (y < 0 || y > CharacterSize.HEIGHT) {
-			return;
-		}
+		const y = clamp(parseInt(ev.target.value, 10), -state.size, CharacterSize.HEIGHT + state.size);
 		PREVIEW_CUTTER.value = {
 			...PREVIEW_CUTTER.value,
 			position: {
@@ -161,12 +156,9 @@ export function PreviewCutter() {
 				y,
 			},
 		};
-	}, []);
+	}, [state.size]);
 	const setSize = React.useCallback((ev: React.ChangeEvent<HTMLInputElement>) => {
-		const size = parseInt(ev.target.value, 10);
-		if (size < PREVIEW_CUTTER_MIN_SIZE || size > CharacterSize.HEIGHT) {
-			return;
-		}
+		const size = clamp(parseInt(ev.target.value, 10), PREVIEW_CUTTER_MIN_SIZE, PREVIEW_CUTTER_MAX_SIZE);
 		PREVIEW_CUTTER.value = {
 			...PREVIEW_CUTTER.value,
 			size,
@@ -197,15 +189,15 @@ export function PreviewCutter() {
 		<FieldsetToggle legend='Preview Cutter' forceOpen={ state.enabled } onChange={ onChange } className='previewCutter'>
 			<div>
 				<label htmlFor='preview-cutter-x'>X</label>
-				<input id='preview-cutter-x' type='number' value={ state.position.x } onChange={ setX } />
+				<input id='preview-cutter-x' type='number' defaultValue={ state.position.x } onChange={ setX } />
 			</div>
 			<div>
 				<label htmlFor='preview-cutter-y'>Y</label>
-				<input id='preview-cutter-y' type='number' value={ state.position.y } onChange={ setY } />
+				<input id='preview-cutter-y' type='number' defaultValue={ state.position.y } onChange={ setY } />
 			</div>
 			<div>
 				<label htmlFor='preview-cutter-size'>Size</label>
-				<input id='preview-cutter-size' type='number' value={ state.size } onChange={ setSize } />
+				<input id='preview-cutter-size' type='number' defaultValue={ state.size } onChange={ setSize } />
 			</div>
 			<div>
 				<label htmlFor='preview-cutter-centered'>Centered</label>

--- a/pandora-client-web/src/editor/components/previewCutter/previewCutter.tsx
+++ b/pandora-client-web/src/editor/components/previewCutter/previewCutter.tsx
@@ -1,0 +1,192 @@
+import React from 'react';
+import { Graphics } from '@pixi/react';
+import * as PIXI from 'pixi.js';
+import { CharacterSize } from 'pandora-common';
+import { Observable, useObservable } from '../../../observable';
+import { FieldsetToggle } from '../../../components/common/fieldsetToggle';
+import { Row } from '../../../components/common/container/container';
+import { clamp } from 'lodash';
+import { Button } from '../../../components/common/button/button';
+
+type PreviewCutterState = Readonly<{
+	enabled: boolean;
+	lineWidth: number;
+	size: number;
+	centered: boolean;
+	position: Readonly<{ x: number; y: number; }>;
+}>;
+
+const PREVIEW_CUTTER = new Observable<PreviewCutterState>({
+	enabled: false,
+	lineWidth: 2,
+	size: 100,
+	centered: true,
+	position: { x: 0, y: 100 },
+});
+
+const PREVIEW_CUTTER_MIN_SIZE = 50;
+
+export function PreviewCutterRectangle() {
+	const state = useObservable(PREVIEW_CUTTER);
+	if (!state.enabled) {
+		return null;
+	}
+	return <PreviewCutterRectangleInner { ...state } />;
+}
+
+function PreviewCutterRectangleInner({
+	lineWidth,
+	size,
+	centered,
+	position,
+}: PreviewCutterState) {
+	const [dragging, setDragging] = React.useState(false);
+	const graphic = React.useRef<PIXI.Graphics>(null);
+	const x = centered ? ((CharacterSize.WIDTH - size) / 2) : position.x;
+	const y = position.y;
+
+	const draw = React.useCallback((g: PIXI.Graphics) => {
+		const color = dragging ? 0x00ff00 : 0x333333;
+		g
+			.clear()
+			.lineStyle(lineWidth, color, 1)
+			.drawRect(x, y - lineWidth / 2, size, size);
+	}, [lineWidth, dragging, x, y, size]);
+	const onPointerDown = React.useCallback((ev: PIXI.FederatedPointerEvent) => {
+		ev.stopPropagation();
+		setDragging(true);
+	}, []);
+	const onPointerUp = React.useCallback((ev: PIXI.FederatedPointerEvent) => {
+		ev.stopPropagation();
+		setDragging(false);
+	}, []);
+	const onPointerMove = React.useCallback((ev: PIXI.FederatedPointerEvent) => {
+		if (!dragging || !graphic.current) {
+			return;
+		}
+		ev.stopPropagation();
+		const dragPointerEnd = ev.getLocalPosition(graphic.current.parent);
+		PREVIEW_CUTTER.value = {
+			...PREVIEW_CUTTER.value,
+			position: {
+				x: clamp(Math.round(dragPointerEnd.x - (size / 2)), 0, CharacterSize.WIDTH),
+				y: clamp(Math.round(dragPointerEnd.y - (size / 2)), 0, CharacterSize.HEIGHT),
+			},
+		};
+	}, [size, dragging]);
+	React.useEffect(() => {
+		const handler = (ev: KeyboardEvent) => {
+			ev.stopPropagation();
+			const delta = ev.shiftKey ? 10 : 1;
+			switch (ev.key) {
+				case '+':
+					PREVIEW_CUTTER.value = {
+						...PREVIEW_CUTTER.value,
+						size: clamp(size + delta, 10, CharacterSize.HEIGHT),
+					};
+					break;
+				case '-':
+					PREVIEW_CUTTER.value = {
+						...PREVIEW_CUTTER.value,
+						size: clamp(size - delta, 10, CharacterSize.HEIGHT),
+					};
+					break;
+			}
+		};
+		window.addEventListener('keydown', handler);
+		return () => {
+			window.removeEventListener('keydown', handler);
+		};
+	}, [size]);
+
+	return (
+		<Graphics
+			zIndex={ 0 }
+			interactive={ true }
+			hitArea={ new PIXI.Rectangle(x, y - lineWidth / 2, size, size) }
+			draw={ draw }
+			ref={ graphic }
+			onpointerdown={ onPointerDown }
+			onpointerup={ onPointerUp }
+			onpointerupoutside={ onPointerUp }
+			onpointermove={ onPointerMove }
+		/>
+	);
+}
+
+export function PreviewCutter() {
+	const state = useObservable(PREVIEW_CUTTER);
+	const onChange = React.useCallback((enabled: boolean) => {
+		PREVIEW_CUTTER.value = {
+			...PREVIEW_CUTTER.value,
+			enabled,
+		};
+	}, []);
+	const setX = React.useCallback((ev: React.ChangeEvent<HTMLInputElement>) => {
+		const x = parseInt(ev.target.value, 10);
+		if (x < 0 || x > CharacterSize.WIDTH) {
+			return;
+		}
+		PREVIEW_CUTTER.value = {
+			...PREVIEW_CUTTER.value,
+			position: {
+				...PREVIEW_CUTTER.value.position,
+				x,
+			},
+		};
+	}, []);
+	const setY = React.useCallback((ev: React.ChangeEvent<HTMLInputElement>) => {
+		const y = parseInt(ev.target.value, 10);
+		if (y < 0 || y > CharacterSize.HEIGHT) {
+			return;
+		}
+		PREVIEW_CUTTER.value = {
+			...PREVIEW_CUTTER.value,
+			position: {
+				...PREVIEW_CUTTER.value.position,
+				y,
+			},
+		};
+	}, []);
+	const setSize = React.useCallback((ev: React.ChangeEvent<HTMLInputElement>) => {
+		const size = parseInt(ev.target.value, 10);
+		if (size < PREVIEW_CUTTER_MIN_SIZE || size > CharacterSize.HEIGHT) {
+			return;
+		}
+		PREVIEW_CUTTER.value = {
+			...PREVIEW_CUTTER.value,
+			size,
+		};
+	}, []);
+	const setCentered = React.useCallback((ev: React.ChangeEvent<HTMLInputElement>) => {
+		PREVIEW_CUTTER.value = {
+			...PREVIEW_CUTTER.value,
+			centered: ev.target.checked,
+		};
+	}, []);
+	return (
+		<FieldsetToggle legend='Preview Cutter' forceOpen={ state.enabled } onChange={ onChange }>
+			<Row>
+				<label htmlFor='preview-cutter-x'>X</label>
+				<input id='preview-cutter-x' type='number' value={ state.position.x } onChange={ setX } />
+			</Row>
+			<Row>
+				<label htmlFor='preview-cutter-y'>Y</label>
+				<input id='preview-cutter-y' type='number' value={ state.position.y } onChange={ setY } />
+			</Row>
+			<Row>
+				<label htmlFor='preview-cutter-size'>Size</label>
+				<input id='preview-cutter-size' type='number' value={ state.size } onChange={ setSize } />
+			</Row>
+			<Row>
+				<label htmlFor='preview-cutter-centered'>Centered</label>
+				<input id='preview-cutter-centered' type='checkbox' checked={ state.centered } onChange={ setCentered } />
+			</Row>
+			<Row>
+				<Button>
+					Create Preview Image
+				</Button>
+			</Row>
+		</FieldsetToggle>
+	);
+}

--- a/pandora-client-web/src/editor/graphics/character/appearanceEditor.ts
+++ b/pandora-client-web/src/editor/graphics/character/appearanceEditor.ts
@@ -12,6 +12,7 @@ import { ICharacter, CharacterEvents } from '../../../character/character';
 import { Immutable } from 'immer';
 import { useEditorState } from '../../editorContextProvider';
 import { EDITOR_ROOM_CONTEXT } from '../../components/wardrobe/wardrobe';
+import { DownloadAsFile } from '../../../common/downloadHelper';
 
 export interface EditorActionContext {
 	dryRun?: boolean;
@@ -502,14 +503,7 @@ export class EditorAssetGraphics extends AssetGraphics {
 			metadata: files,
 		}).blob();
 
-		// make and click a temporary link to download the Blob
-		const link = document.createElement('a');
-		link.href = URL.createObjectURL(blob);
-		link.download = `${this.id.replace(/^a\//, '').replaceAll('/', '_')}.zip`;
-		link.style.display = 'none';
-		document.body.appendChild(link);
-		link.click();
-		link.remove();
+		DownloadAsFile(blob, `${this.id.replace(/^a\//, '').replaceAll('/', '_')}.zip`);
 	}
 
 	public async exportDefinitionToClipboard(): Promise<void> {

--- a/pandora-client-web/src/editor/graphics/editorScene.tsx
+++ b/pandora-client-web/src/editor/graphics/editorScene.tsx
@@ -13,6 +13,7 @@ import { useObservable } from '../../observable';
 import { EditorContext, useEditor } from '../editorContextProvider';
 import { ResultCharacter, SetupCharacter } from './character';
 import { ImageExporter } from './export/imageExporter';
+import { DownloadAsFile } from '../../common/downloadHelper';
 
 function EditorColorPicker({ throttle }: { throttle: number; }): ReactElement {
 	const editor = useEditor();
@@ -93,17 +94,8 @@ export function EditorScene({
 			height: CharacterSize.HEIGHT,
 			width: CharacterSize.WIDTH,
 		}, 'png')
-			.then((result) => {
-				const link = document.createElement('a');
-				link.href = result;
-				link.download = `export.png`;
-				link.style.display = 'none';
-				document.body.appendChild(link);
-				link.click();
-				link.remove();
-			}, (error) => {
-				GetLogger('Editor').error('Error exporting image:', error);
-			});
+			.then((result) => DownloadAsFile(result, 'export.png'))
+			.catch((error) => GetLogger('Editor').error('Error exporting image:', error));
 	}, []);
 
 	const overlay = (

--- a/pandora-client-web/src/editor/graphics/export/imageExporter.ts
+++ b/pandora-client-web/src/editor/graphics/export/imageExporter.ts
@@ -1,6 +1,7 @@
 import { Size, Rectangle, CharacterSize } from 'pandora-common/dist/assets';
 import { Application, Container, IExtract, Texture, Mesh, MeshGeometry, MeshMaterial, RenderTexture, IRenderableObject, DisplayObject, Shader } from 'pixi.js';
 import Delaunator from 'delaunator';
+import { DataString, AssertDataString } from '../../../common/downloadHelper';
 
 type ImageFormat = 'png' | 'jpg' | 'webp';
 
@@ -19,20 +20,21 @@ export class ImageExporter {
 		});
 	}
 
-	public async export(target: Container, format: ImageFormat): Promise<string> {
+	public async export(target: Container, format: ImageFormat): Promise<DataString> {
 		this._app.renderer.resize(target.width, target.height);
 		const child = this._app.stage.addChild(target);
 		const result = await this._extract.base64(target, `image/${format}`);
 		this._app.stage.removeChild(child);
+		AssertDataString(result);
 		return result;
 	}
 
-	public async textureCut(texture: Texture, size: Size, points: [number, number][], format: ImageFormat): Promise<string> {
+	public async textureCut(texture: Texture, size: Size, points: [number, number][], format: ImageFormat): Promise<DataString> {
 		const cutter = new TextureCutter(texture, size, points);
 		return await this.export(cutter, format);
 	}
 
-	public async imageCut(object: IRenderableObject, rect: Rectangle, format: ImageFormat): Promise<string> {
+	public async imageCut(object: IRenderableObject, rect: Rectangle, format: ImageFormat): Promise<DataString> {
 		const fullSize = { width: CharacterSize.WIDTH, height: CharacterSize.HEIGHT };
 		const renderTexture = RenderTexture.create(fullSize);
 		WithCullingDisabled(object, () => {

--- a/pandora-client-web/src/editor/graphics/layer/resultLayer.tsx
+++ b/pandora-client-web/src/editor/graphics/layer/resultLayer.tsx
@@ -8,6 +8,7 @@ import { useObservable } from '../../../observable';
 import { Container, Graphics, Sprite } from '@pixi/react';
 import { useAppearanceConditionEvaluator } from '../../../graphics/appearanceConditionEvaluator';
 import { useTexture } from '../../../graphics/useTexture';
+import { PreviewCutterRectangle } from '../../components/previewCutter/previewCutter';
 
 export function ResultLayer({
 	layer,
@@ -76,6 +77,7 @@ export function ResultLayer({
 					</Container>
 				)
 			}
+			<PreviewCutterRectangle />
 		</>
 	);
 }

--- a/pandora-common/src/assets/definitions.ts
+++ b/pandora-common/src/assets/definitions.ts
@@ -104,6 +104,14 @@ export interface AssetBaseDefinition<Type extends AssetType, A extends AssetDefi
 	 * If this item is a bodypart, then and **only** then the size **must** be `'bodypart'`
 	 */
 	size: AssetSize;
+
+	/**
+	 * Preview image inside the wardrobe
+	 *  - `<image path>` if this item has a preview
+	 *  - `null` if this item does not have a preview
+	 *  - `undefined` temporarily until all previews are added
+	 */
+	preview?: string | null;
 }
 
 export interface PersonalAssetDefinition<A extends AssetDefinitionExtraArgs = AssetDefinitionExtraArgs> extends AssetProperties<A>, AssetBaseDefinition<'personal', A> {

--- a/pandora-common/src/networking/directory_client.ts
+++ b/pandora-common/src/networking/directory_client.ts
@@ -58,6 +58,14 @@ export const DirectoryAccountSettingsSchema = z.object({
 	 */
 	wardrobeUseRoomBackground: z.boolean().catch(true),
 	/**
+	 * Controls whether to show the attribute icons or preview images in small preview.
+	 */
+	wardrobeSmallPreview: z.enum(['icon', 'image']).default('icon'),
+	/**
+	 * Controls whether to show the attribute icons or preview images in big preview.
+	 */
+	wardrobeBigPreview: z.enum(['icon', 'image']).default('icon'),
+	/**
 	 * Controls how many parts (of 10 total) the chatroom graphics takes inside chatroom, while in horizontal mode
 	 */
 	interfaceChatroomGraphicsRatioHorizontal: z.number().int().min(1).max(9).catch(7),
@@ -86,6 +94,8 @@ export const ACCOUNT_SETTINGS_DEFAULT = Object.freeze<IDirectoryAccountSettings>
 	wardrobeUseRoomBackground: true,
 	wardrobeHoverPreview: true,
 	wardrobeOutfitsPreview: 'small',
+	wardrobeSmallPreview: 'icon',
+	wardrobeBigPreview: 'icon',
 	interfaceChatroomGraphicsRatioHorizontal: 7,
 	interfaceChatroomGraphicsRatioVertical: 4,
 	interfaceChatroomOfflineCharacterFilter: 'ghost',

--- a/pandora-common/src/networking/directory_client.ts
+++ b/pandora-common/src/networking/directory_client.ts
@@ -64,7 +64,7 @@ export const DirectoryAccountSettingsSchema = z.object({
 	/**
 	 * Controls whether to show the attribute icons or preview images in big preview.
 	 */
-	wardrobeBigPreview: z.enum(['icon', 'image']).default('icon'),
+	wardrobeBigPreview: z.enum(['icon', 'image']).default('image'),
 	/**
 	 * Controls how many parts (of 10 total) the chatroom graphics takes inside chatroom, while in horizontal mode
 	 */
@@ -95,7 +95,7 @@ export const ACCOUNT_SETTINGS_DEFAULT = Object.freeze<IDirectoryAccountSettings>
 	wardrobeHoverPreview: true,
 	wardrobeOutfitsPreview: 'small',
 	wardrobeSmallPreview: 'icon',
-	wardrobeBigPreview: 'icon',
+	wardrobeBigPreview: 'image',
 	interfaceChatroomGraphicsRatioHorizontal: 7,
 	interfaceChatroomGraphicsRatioVertical: 4,
 	interfaceChatroomOfflineCharacterFilter: 'ghost',


### PR DESCRIPTION
 - add `preview?: string | null` to asset definition (allow undefined until all assets have this property defined)
 - add preview cutter for the result layer (Preview tab), and controls on Items tab
