### PR TITLE
[CHANGE] Room devices setup rework

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,9 +27,8 @@
 	"typescript.format.insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces": true,
 	"typescript.preferences.quoteStyle": "single",
 	"editor.codeActionsOnSave": {
-		"source.fixAll.eslint": true
+		"source.fixAll.eslint": "explicit"
 	},
-	"eslint.packageManager": "pnpm",
 	"eslint.workingDirectories": [
 		"pandora-client-web",
 		"pandora-common",

--- a/pandora-client-web/src/assets/appearanceValidation.ts
+++ b/pandora-client-web/src/assets/appearanceValidation.ts
@@ -76,6 +76,14 @@ export function RenderAppearanceActionProblem(assetManager: AssetManagerClient, 
 				return `You cannot touch others while either you or they are in safemode.`;
 			case 'modifyBodyRoom':
 				return `You cannot modify body in this room.`;
+			case 'modifyRoomRestriction':
+				switch (e.reason) {
+					case 'notAdmin':
+						return `You must be a room admin or a room owner to do this.`;
+					case 'missingConstructionTools':
+						return `You must be holding 'Room Construction Tools' to do this.`;
+				}
+				break;
 			case 'invalid':
 				return '';
 		}

--- a/pandora-client-web/src/components/chatroom/chatroomControls.tsx
+++ b/pandora-client-web/src/components/chatroom/chatroomControls.tsx
@@ -11,9 +11,10 @@ import { ChatroomDebugConfigView } from './chatroomDebug';
 import { Column, Row } from '../common/container/container';
 import { Character, useCharacterData } from '../../character/character';
 import { CharacterSafemodeWarningContent, useSafemodeDialogContext } from '../characterSafemode/characterSafemode';
-import { DeviceOverlayToggle } from './chatRoomDevice';
+import { DeviceOverlaySetting, DeviceOverlaySettingSchema } from './chatRoomDevice';
 import { useObservable } from '../../observable';
 import { ICharacterRoomData } from 'pandora-common';
+import { Select } from '../common/select/select';
 
 export function ChatroomControls(): ReactElement | null {
 	const roomInfo = useChatRoomInfo();
@@ -21,7 +22,7 @@ export function ChatroomControls(): ReactElement | null {
 	const navigate = useNavigate();
 	const player = usePlayer();
 
-	const deviceOverlayToggle = useObservable(DeviceOverlayToggle);
+	const deviceOverlaySetting = useObservable(DeviceOverlaySetting);
 
 	if (!roomInfo || !roomCharacters || !player) {
 		return null;
@@ -48,12 +49,22 @@ export function ChatroomControls(): ReactElement | null {
 			<br />
 			<div>
 				<label htmlFor='chatroom-device-overlay'>Show device movement area overlay</label>
-				<input
-					id='chatroom-device-overlay'
-					type='checkbox'
-					checked={ deviceOverlayToggle }
-					onChange={ (e) => DeviceOverlayToggle.value = e.target.checked }
-				/>
+				<Select
+					value={ deviceOverlaySetting }
+					onChange={ (e) => {
+						DeviceOverlaySetting.value = DeviceOverlaySettingSchema.parse(e.target.value);
+					} }
+				>
+					<option value='never'>
+						Never (enterable devices can still be interacted with)
+					</option>
+					<option value='interactable'>
+						For enterable devices only
+					</option>
+					<option value='always'>
+						For all devices
+					</option>
+				</Select>
 			</div>
 			<br />
 			{ USER_DEBUG ? <ChatroomDebugConfigView /> : null }

--- a/pandora-client-web/src/components/chatroom/contextMenus/deviceContextMenu.tsx
+++ b/pandora-client-web/src/components/chatroom/contextMenus/deviceContextMenu.tsx
@@ -1,5 +1,5 @@
 import { nanoid } from 'nanoid';
-import { ItemRoomDevice, AppearanceAction, ItemId, ICharacterRoomData } from 'pandora-common';
+import { ItemRoomDevice, AppearanceAction, ItemId, ICharacterRoomData, CloneDeepMutable } from 'pandora-common';
 import React, { useMemo, useState, ReactElement, useEffect, useCallback } from 'react';
 import { Character, ICharacter, useCharacterData } from '../../../character/character';
 import { ChildrenProps } from '../../../common/reactTypes';
@@ -11,6 +11,11 @@ import { useStaggeredAppearanceActionResult } from '../../wardrobe/wardrobeCheck
 import { useWardrobeContext, useWardrobeExecuteChecked, WardrobeContextProvider } from '../../wardrobe/wardrobeContext';
 import { EvalItemPath } from 'pandora-common/dist/assets/appearanceHelpers';
 import { CharacterContextMenu } from './characterContextMenu';
+import { Immutable } from 'immer';
+import { IChatRoomMode } from '../chatRoomScene';
+import { toast } from 'react-toastify';
+import { ActionWarningContent } from '../../wardrobe/wardrobeComponents';
+import { TOAST_OPTIONS_WARNING } from '../../../persistentToast';
 
 function StoreDeviceMenu({ device, close }: {
 	device: ItemRoomDevice;
@@ -32,6 +37,41 @@ function StoreDeviceMenu({ device, close }: {
 	return (
 		<button onClick={ execute } disabled={ processing } className={ available ? '' : 'text-strikethrough' }>
 			Store the device
+		</button>
+	);
+}
+
+function MoveDeviceMenu({ device, setChatRoomMode, close }: {
+	device: ItemRoomDevice;
+	setChatRoomMode: (newMode: Immutable<IChatRoomMode>) => void;
+	close: () => void;
+}) {
+	const action = useMemo<AppearanceAction>(() => ({
+		type: 'roomDeviceDeploy',
+		item: {
+			container: [],
+			itemId: device.id,
+		},
+		target: { type: 'roomInventory' },
+		deployment: CloneDeepMutable(device.deployment),
+	}), [device]);
+	const checkResult = useStaggeredAppearanceActionResult(action, { immediate: true });
+	const available = checkResult != null && checkResult.problems.length === 0;
+
+	return (
+		<button
+			onClick={ () => {
+				if (checkResult != null && (!checkResult.valid || checkResult.problems.length > 0)) {
+					toast(<ActionWarningContent problems={ checkResult.problems } />, TOAST_OPTIONS_WARNING);
+					return;
+				}
+
+				setChatRoomMode({ mode: 'moveDevice', deviceItemId: device.id });
+				close();
+			} }
+			className={ available ? '' : 'text-strikethrough' }
+		>
+			Move
 		</button>
 	);
 }
@@ -199,9 +239,11 @@ function DeviceSlotsMenu({ device, position, close }: {
 	);
 }
 
-function DeviceContextMenuCurrent({ device, position, onClose }: {
+function DeviceContextMenuCurrent({ device, position, setChatRoomMode, onClose }: {
 	device: ItemRoomDevice;
 	position: Readonly<PointLike>;
+	chatRoomMode: Immutable<IChatRoomMode>;
+	setChatRoomMode: (newMode: Immutable<IChatRoomMode>) => void;
 	onClose: () => void;
 }): ReactElement | null {
 	const ref = useContextMenuPosition(position);
@@ -225,6 +267,7 @@ function DeviceContextMenuCurrent({ device, position, onClose }: {
 						<button onClick={ () => setMenu('slots') }>
 							Slots
 						</button>
+						<MoveDeviceMenu device={ device } setChatRoomMode={ setChatRoomMode } close={ onClose } />
 						<StoreDeviceMenu device={ device } close={ onClose } />
 					</>
 				) }
@@ -244,9 +287,11 @@ function DeviceContextMenuCurrent({ device, position, onClose }: {
 	);
 }
 
-export function DeviceContextMenu({ deviceItemId, position, onClose }: {
+export function DeviceContextMenu({ deviceItemId, position, chatRoomMode, setChatRoomMode, onClose }: {
 	deviceItemId: ItemId;
 	position: Readonly<PointLike>;
+	chatRoomMode: Immutable<IChatRoomMode>;
+	setChatRoomMode: (newMode: Immutable<IChatRoomMode>) => void;
 	onClose: () => void;
 }): ReactElement | null {
 	const globalState = useRoomState(useChatroomRequired());
@@ -270,6 +315,12 @@ export function DeviceContextMenu({ deviceItemId, position, onClose }: {
 		return null;
 
 	return (
-		<DeviceContextMenuCurrent device={ item } position={ position } onClose={ onClose } />
+		<DeviceContextMenuCurrent
+			device={ item }
+			position={ position }
+			chatRoomMode={ chatRoomMode }
+			setChatRoomMode={ setChatRoomMode }
+			onClose={ onClose }
+		/>
 	);
 }

--- a/pandora-client-web/src/components/chatroom/contextMenus/deviceContextMenu.tsx
+++ b/pandora-client-web/src/components/chatroom/contextMenus/deviceContextMenu.tsx
@@ -11,7 +11,6 @@ import { useStaggeredAppearanceActionResult } from '../../wardrobe/wardrobeCheck
 import { useWardrobeContext, useWardrobeExecuteChecked, WardrobeContextProvider } from '../../wardrobe/wardrobeContext';
 import { EvalItemPath } from 'pandora-common/dist/assets/appearanceHelpers';
 import { CharacterContextMenu } from './characterContextMenu';
-import { useConfirmDialog } from '../../dialog/dialog';
 
 function StoreDeviceMenu({ device, close }: {
 	device: ItemRoomDevice;
@@ -29,19 +28,9 @@ function StoreDeviceMenu({ device, close }: {
 	const checkResult = useStaggeredAppearanceActionResult(action, { immediate: true });
 	const available = checkResult != null && checkResult.problems.length === 0;
 	const [execute, processing] = useWardrobeExecuteChecked(action, checkResult, { onSuccess: close });
-	const confirm = useConfirmDialog();
-
-	const onClick = useCallback(() => {
-		confirm('Confirm storing device', 'Are you sure you want to store the device in the room inventory?')
-			.then((result) => {
-				if (result) {
-					execute();
-				}
-			}).catch(() => { /* NOOP */});
-	}, [confirm, execute]);
 
 	return (
-		<button onClick={ onClick } disabled={ processing } className={ available ? '' : 'text-strikethrough' }>
+		<button onClick={ execute } disabled={ processing } className={ available ? '' : 'text-strikethrough' }>
 			Store the device
 		</button>
 	);

--- a/pandora-client-web/src/components/gameContext/chatRoomContextProvider.tsx
+++ b/pandora-client-web/src/components/gameContext/chatRoomContextProvider.tsx
@@ -12,6 +12,7 @@ import { useShardConnector } from './shardConnectorContextProvider';
 import { GetCurrentAssetManager } from '../../assets/assetManager';
 import { z } from 'zod';
 import { IChatroomMessageProcessed } from '../chatroom/chatroomMessages';
+import { useCurrentAccount } from './directoryConnectorContextProvider';
 
 const logger = GetLogger('ChatRoom');
 
@@ -485,9 +486,16 @@ export function useChatRoomFeatures(): ChatRoomFeature[] | null {
 
 export function useActionRoomContext(): ActionRoomContext | null {
 	const info = useChatRoomInfo();
-	return useMemo(() => info ? ({
+	const playerAccount = useCurrentAccount();
+	return useMemo((): ActionRoomContext | null => info ? ({
 		features: info.features,
-	}) : null, [info]);
+		isAdmin: (accountId) => {
+			if (accountId === playerAccount?.id) {
+				return IsChatroomAdmin(info, playerAccount);
+			}
+			return IsChatroomAdmin(info, { id: accountId });
+		},
+	}) : null, [info, playerAccount]);
 }
 
 export function useCharacterRestrictionsManager<T>(characterState: AssetFrameworkCharacterState, character: Character, use: (manager: CharacterRestrictionsManager) => T): T {

--- a/pandora-client-web/src/components/wardrobe/itemDetail/wardrobeItemRoomDevice.tsx
+++ b/pandora-client-web/src/components/wardrobe/itemDetail/wardrobeItemRoomDevice.tsx
@@ -26,6 +26,9 @@ export function WardrobeRoomDeviceDeployment({ roomDevice, item }: {
 }): ReactElement | null {
 	const { targetSelector } = useWardrobeContext();
 
+	// Generate random X position for the device that is not directly on the edge of the room
+	const randomDeploymentPositionX = useMemo(() => Math.floor(200 + Math.random() * 800), []);
+
 	let contents: ReactElement | undefined;
 
 	if (roomDevice.deployment != null) {
@@ -49,7 +52,7 @@ export function WardrobeRoomDeviceDeployment({ roomDevice, item }: {
 				target: targetSelector,
 				item,
 				deployment: {
-					x: 0,
+					x: randomDeploymentPositionX,
 					y: 0,
 					yOffset: 0,
 				},

--- a/pandora-client-web/src/components/wardrobe/wardrobeContext.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobeContext.tsx
@@ -185,11 +185,11 @@ export function useWardrobeExecuteChecked(action: Nullable<AppearanceAction>, re
 			}
 
 			// Detect need for confirmation
-			const warnings = WardrobeCheckResultForConfirmationWarnings(player, roomContext, result);
+			const warnings = WardrobeCheckResultForConfirmationWarnings(player, roomContext, action, result);
 
 			if (warnings.length > 0) {
 				confirm(
-					`You might not be able to undo this action without help. Continue?`,
+					`You might not be able to undo this action easily. Continue?`,
 					(
 						<ul>
 							{

--- a/pandora-client-web/src/editor/components/wardrobe/wardrobe.tsx
+++ b/pandora-client-web/src/editor/components/wardrobe/wardrobe.tsx
@@ -20,6 +20,7 @@ import { WardrobeActionButton } from '../../../components/wardrobe/wardrobeCompo
 
 export const EDITOR_ROOM_CONTEXT = {
 	features: ChatRoomFeatureSchema.options,
+	isAdmin: () => true,
 } as const satisfies ActionRoomContext;
 
 export function EditorWardrobeContextProvider({ children }: { children: ReactNode; }): ReactElement {

--- a/pandora-client-web/src/graphics/movementHelper.tsx
+++ b/pandora-client-web/src/graphics/movementHelper.tsx
@@ -1,0 +1,88 @@
+import { Graphics, _ReactPixi } from '@pixi/react';
+import * as PIXI from 'pixi.js';
+import React, { ReactElement, useCallback } from 'react';
+
+export interface MovementHelperGraphicsProps extends Omit<_ReactPixi.IGraphics, 'draw'> {
+	radius: number;
+	colorUpDown?: number;
+	colorLeftRight?: number;
+}
+
+export function MovementHelperGraphics({
+	radius,
+	colorUpDown,
+	colorLeftRight,
+	...props
+}: MovementHelperGraphicsProps): ReactElement | null {
+	const arrowBodyLength = 15;
+	const arrowWidthInner = 4;
+	const arrowWidth = 16;
+	const centerOffset = 5;
+
+	const graphicsDraw = useCallback((g: PIXI.Graphics) => {
+		g.clear()
+			.lineStyle(4, 0xffffff, 1)
+			.drawEllipse(0, 0, radius, radius)
+			.lineStyle(0);
+
+		if (colorLeftRight != null) {
+			g.beginFill(colorLeftRight, 1)
+				.drawPolygon([
+					centerOffset, -arrowWidthInner,
+					centerOffset + arrowBodyLength, -arrowWidthInner,
+					centerOffset + arrowBodyLength, -arrowWidth,
+					radius, 0,
+					centerOffset + arrowBodyLength, arrowWidth,
+					centerOffset + arrowBodyLength, arrowWidthInner,
+					centerOffset, arrowWidthInner,
+				])
+				.endFill()
+				.beginFill(colorLeftRight, 1)
+				.drawPolygon([
+					- centerOffset, arrowWidthInner,
+					- centerOffset - arrowBodyLength, arrowWidthInner,
+					- centerOffset - arrowBodyLength, arrowWidth,
+					-radius, 0,
+					- centerOffset - arrowBodyLength, -arrowWidth,
+					- centerOffset - arrowBodyLength, -arrowWidthInner,
+					- centerOffset, -arrowWidthInner,
+				])
+				.endFill();
+		}
+
+		if (colorUpDown != null) {
+			g.beginFill(colorUpDown, 1)
+				.drawPolygon([
+					- arrowWidthInner, -centerOffset,
+					- arrowWidthInner, -centerOffset - arrowBodyLength,
+					- arrowWidth, -centerOffset - arrowBodyLength,
+					0, -radius,
+					arrowWidth, - centerOffset - arrowBodyLength,
+					arrowWidthInner, - centerOffset - arrowBodyLength,
+					arrowWidthInner, - centerOffset,
+				])
+				.endFill()
+				.beginFill(colorUpDown, 1)
+				.drawPolygon([
+					- arrowWidthInner, centerOffset,
+					- arrowWidthInner, centerOffset + arrowBodyLength,
+					- arrowWidth, centerOffset + arrowBodyLength,
+					0, radius,
+					arrowWidth, centerOffset + arrowBodyLength,
+					arrowWidthInner, centerOffset + arrowBodyLength,
+					arrowWidthInner, centerOffset,
+				])
+				.endFill();
+		}
+		g.beginFill(0xffffff, 1)
+			.drawEllipse(0, 0, centerOffset, centerOffset)
+			.endFill();
+	}, [radius, colorLeftRight, colorUpDown]);
+
+	return (
+		<Graphics
+			{ ...props }
+			draw={ graphicsDraw }
+		/>
+	);
+}

--- a/pandora-common/src/assets/appearanceActions.ts
+++ b/pandora-common/src/assets/appearanceActions.ts
@@ -498,6 +498,26 @@ export function DoAppearanceAction(
 					restriction: r.restriction,
 				});
 			}
+			// To manipulate room devices, player must be an admin
+			if (!playerRestrictionManager.isCurrentRoomAdmin()) {
+				processingContext.addProblem({
+					result: 'restrictionError',
+					restriction: {
+						type: 'modifyRoomRestriction',
+						reason: 'notAdmin',
+					},
+				});
+			}
+			// To manipulate room devices, player must be holding room construction tools
+			if (!playerRestrictionManager.getEffects().toolRoomConstruction) {
+				processingContext.addProblem({
+					result: 'restrictionError',
+					restriction: {
+						type: 'modifyRoomRestriction',
+						reason: 'missingConstructionTools',
+					},
+				});
+			}
 
 			const targetManipulator = processingContext.manipulator.getManipulatorFor(action.target);
 			if (!ActionRoomDeviceDeploy(processingContext, targetManipulator, action.item, action.deployment))

--- a/pandora-common/src/assets/effects.ts
+++ b/pandora-common/src/assets/effects.ts
@@ -32,6 +32,11 @@ export type EffectsDefinition = MuffleSettings & {
 	 * - 10 = completely blind
 	 */
 	blind: number;
+
+	/**
+	 * Allows this item to work as a room construction tool - enabling admins to edit room and room devices while holding it.
+	 */
+	toolRoomConstruction: boolean;
 };
 
 export const EFFECTS_DEFAULT: EffectsDefault = {
@@ -50,6 +55,7 @@ export const EFFECTS_DEFAULT: EffectsDefault = {
 	blockRoomMovement: false,
 	blockRoomLeave: false,
 	blind: 0,
+	toolRoomConstruction: false,
 };
 
 //#endregion

--- a/pandora-common/src/character/restrictionsManager.ts
+++ b/pandora-common/src/character/restrictionsManager.ts
@@ -107,6 +107,10 @@ export type Restriction =
 	| {
 		type: 'modifyBodyRoom';
 	}
+	| {
+		type: 'modifyRoomRestriction';
+		reason: 'notAdmin' | 'missingConstructionTools';
+	}
 	// Generic catch-all problem, supposed to be used when something simply went wrong (like bad data, target not found, and so on...)
 	| {
 		type: 'invalid';
@@ -216,6 +220,17 @@ export class CharacterRestrictionsManager {
 
 	public isInSafemode(): boolean {
 		return this.appearance.getSafemode() != null;
+	}
+
+	public isCurrentRoomAdmin(): boolean {
+		// If not in a room, shortcircuit to yes
+		if (this.room == null)
+			return true;
+
+		if (this.room.isAdmin(this.character.accountId))
+			return true;
+
+		return false;
 	}
 
 	public canInteractWithTarget(context: AppearanceActionProcessingContext, target: RoomActionTarget): RestrictionResult {

--- a/pandora-common/src/chatroom/room.ts
+++ b/pandora-common/src/chatroom/room.ts
@@ -29,6 +29,7 @@ export type ChatRoomFeature = z.infer<typeof ChatRoomFeatureSchema>;
 
 export type ActionRoomContext = {
 	features: readonly ChatRoomFeature[];
+	isAdmin(account: AccountId): boolean;
 };
 
 export const ChatRoomBaseInfoSchema = z.object({

--- a/pandora-server-shard/src/room/room.ts
+++ b/pandora-server-shard/src/room/room.ts
@@ -193,6 +193,7 @@ export class Room extends ServerRoom<IShardClient> {
 	public getActionRoomContext(): ActionRoomContext {
 		return {
 			features: this.data.config.features,
+			isAdmin: (account) => Array.from(this.characters).some((character) => character.accountId === account && this.isAdmin(character)),
 		};
 	}
 


### PR DESCRIPTION
This PR introduces following changes:
- Room device deployment and movement now requires being an admin
- Room device deployment and movement now requires holding room construction tools (item provided in asset repo PR)
- The confirmation prompt for storing a device is now using the standardized action confirmation dialog
- Reworked how moving device works
- Reworked the interaction helper overlay