### PR TITLE
[DEV] Contributor license agreement

### DIFF
--- a/contributor-licence-agreement.md
+++ b/contributor-licence-agreement.md
@@ -1,0 +1,105 @@
+## Contributor Agreement
+
+Thank you for your interest in contributing to Project Pandora ("We" or "Us").
+
+The purpose of this contributor agreement ("Agreement") is to clarify and document the rights granted by contributors to Us.
+
+### 1. Definitions
+
+**"You"** (or "Your") shall mean the copyright owner or legal entity
+authorized by the copyright owner that is making this Agreement
+with Us. For legal entities, the entity making a
+Contribution and all other entities that control, are controlled
+by, or are under common control with that entity are considered to
+be a single Contributor. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+**"Contribution"** shall mean any original work of authorship,
+including any modifications or additions to an existing work, that
+is intentionally submitted by You to Us for inclusion
+in, or documentation of, any of the products owned or managed by
+Us (the "Work"). For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written
+communication sent to Us or our representatives,
+including but not limited to communication on electronic mailing
+lists, source code control systems, and issue tracking systems that
+are managed by, or on behalf of, Us for the purpose of
+discussing and improving the Work, but excluding communication that
+is conspicuously marked or otherwise designated in writing by You
+as "Not a Contribution."
+
+### 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement,
+You hereby grant Us a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable copyright license to reproduce,
+prepare derivative works of, publicly display, publicly perform,
+sublicense, and distribute Your Contributions and such derivative works.
+
+### 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement,
+You hereby grant Us a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license
+to make, have made, use, offer to sell, sell, import, and otherwise transfer
+the Work, where such license applies only to those patent claims
+licensable by You that are necessarily infringed by Your
+Contribution(s) alone or by combination of Your Contribution(s)
+with the Work to which such Contribution(s) was submitted. If any
+entity institutes patent litigation against You or any other entity
+(including a cross-claim or counterclaim in a lawsuit) alleging
+that your Contribution, or the Work to which you have contributed,
+constitutes direct or contributory patent infringement, then any
+patent licenses granted to that entity under this Agreement for
+that Contribution or Work shall terminate as of the date such
+litigation is filed.
+
+### 4. You represent that you are legally entitled to grant the above license
+
+You represent that you are legally entitled to grant the above license.
+If your employer(s) has rights to intellectual property
+that you create that includes your Contributions, you represent
+that you have received permission to make Contributions on behalf
+of that employer, that your employer has waived such rights for
+your Contributions to Us, or that your employer has
+executed a separate Corporate CLA with Us.
+
+### 5. You represent that each of Your Contributions is Your original creation
+
+You represent that each of Your Contributions is Your original
+creation (see section 7 for submissions on behalf of others). You
+represent that Your Contribution submissions include complete
+details of any third-party license or other restriction (including,
+but not limited to, related patents and trademarks) of which you
+are personally aware and which are associated with any part of Your
+Contributions.
+
+### 6. Support and damage waiver
+
+You are not expected to provide support for Your Contributions,
+except to the extent You desire to provide support. You may provide
+support for free, for a fee, or not at all. Unless required by
+applicable law or agreed to in writing, You provide Your
+Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+OF ANY KIND, either express or implied, including, without
+limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+### 7. Submissions on behalf of others
+
+Should You wish to submit work that is not Your original creation,
+You may submit it to Us separately from any Contribution,
+identifying the complete details of its source and of
+any license or other restriction (including, but not limited to,
+related patents, trademarks, and license agreements) of which you
+are personally aware, and conspicuously marking the work as
+"Submitted on behalf of a third-party: [named here]".
+
+### 8. Miscellaneous
+
+You agree to notify Us of any facts or circumstances of
+which you become aware that would make these representations
+inaccurate in any respect.


### PR DESCRIPTION
This PR adds a CLA - Contributor License Agreement, which applies to any contribution made via GitHub (I will be making a PR template later that also states this explicitly).

The proposed CLA is based on the Apache Foundation individuals CLA; rewritten into markdown from the original PDF:
[https://apache.org/licenses/icla.pdf](https://apache.org/licenses/icla.pdf)

The reason for adding the CLA is the following: We already encountered a situation where it is beneficial for us to change the license on our code. So far it isn't much of a problem as we have few past contributors, but once outside people contribute it might become problematic to get agreement to update the license if necessary in the future.

At the moment of addition of the CLA the repository contains code from the following contributors:
- [Jomshir98](https://github.com/Jomshir98) - me **(implicit approval by opening the PR)**
- [Sekkmer](https://github.com/Sekkmer) **(approved the PR)**
- [ClaudiaMia](https://github.com/ClaudiaMia) **(approved the PR)**
- [Ellie](https://github.com/elliesec) **(approved the PR)**
- [Tech](https://github.com/ttax00) **(approved the PR)**
- [Sandrine](https://github.com/SandrinePDR) **(approved the PR)**
- [Nina](https://github.com/Nina-1474) **(approved the PR)**
- [zorgjbe](https://github.com/zorgjbe) **(approved the PR)**

By approving this PR the existing contributors agree with licensing their past contributions under the proposed CLA.