### PR TITLE
[FIX] Fix room deletion (last owner abandoning ownership)

### DIFF
--- a/pandora-server-directory/src/account/character.ts
+++ b/pandora-server-directory/src/account/character.ts
@@ -723,13 +723,8 @@ export class Character {
 		// Actually remove the character from the room
 		await oldRoom.removeCharacter(this, 'leave', this.baseInfo);
 
-		// Cleanup the assignment
-		Assert(this.assignment?.type === 'room-tracking' && this.assignment.room === oldRoom);
-		oldRoom.trackingCharacters.delete(this);
-		this.assignment = {
-			type: 'shard',
-			shard,
-		};
+		Assert(this.room == null);
+		Assert(this.assignment == null || this.assignment.type === 'shard');
 
 		// Check if room can be cleaned up
 		await oldRoom.cleanupIfEmpty();

--- a/pandora-server-directory/src/networking/manager_client.ts
+++ b/pandora-server-directory/src/networking/manager_client.ts
@@ -476,7 +476,7 @@ export const ConnectionManagerClient = new class ConnectionManagerClient impleme
 
 		const room = await RoomManager.loadRoom(id);
 
-		if (room == null || !room.owners.has(connection.account.id)) {
+		if (room == null) {
 			return { result: 'notAnOwner' };
 		}
 

--- a/pandora-server-directory/src/room/roomManager.ts
+++ b/pandora-server-directory/src/room/roomManager.ts
@@ -158,19 +158,6 @@ export const RoomManager = new class RoomManagerClass implements Service {
 		return room;
 	}
 
-	/**
-	 * Destroy a room
-	 * @param room - The room to destroy
-	 */
-	public async destroyRoom(room: Room): Promise<void> {
-		await GetDatabase().deleteChatRoom(room.id);
-		await room.onDestroy();
-		this._unloadRoom(room);
-		logger.verbose(`Destroyed room ${room.id}`);
-
-		ConnectionManagerClient.onRoomListChange();
-	}
-
 	/** Create room from received data, adding it to loaded rooms */
 
 	@AsyncSynchronized()

--- a/pandora-server-directory/test/room/roomManager.test.ts
+++ b/pandora-server-directory/test/room/roomManager.test.ts
@@ -5,6 +5,7 @@ import { RoomManager } from '../../src/room/roomManager';
 import { ShardManager } from '../../src/shard/shardManager';
 import { TEST_ROOM, TEST_ROOM2, TEST_ROOM_DEV, TEST_ROOM_PANDORA_OWNED } from './testData';
 import { TestMockAccount, TestMockDb } from '../utils';
+import { GetDatabase } from '../../src/database/databaseProvider';
 
 describe('RoomManager', () => {
 	let shard: Shard;
@@ -27,6 +28,8 @@ describe('RoomManager', () => {
 			Assert(room instanceof Room);
 			expect(room.getConfig()).toEqual(data);
 			expect(room.assignedShard).toBeNull();
+
+			await expect(GetDatabase().getChatRoomById(room.id, null)).resolves.not.toBeNull();
 
 			if (!testRoomId) {
 				testRoomId = room.id;
@@ -93,25 +96,6 @@ describe('RoomManager', () => {
 			const rooms = RoomManager.listLoadedRooms();
 
 			expect(rooms.map((r) => r.id)).toContain(testRoomId);
-		});
-	});
-
-	describe('destroyRoom()', () => {
-		it('Deletes room by instance', async () => {
-			const room = await RoomManager.loadRoom(testRoomId);
-			expect(room).toBeInstanceOf(Room);
-			Assert(room instanceof Room);
-
-			const roomonDestroySpy = jest.spyOn(room, 'onDestroy');
-
-			await RoomManager.destroyRoom(room);
-
-			// Not gettable
-			expect(RoomManager.getLoadedRoom(testRoomId)).toBe(null);
-			expect(RoomManager.listLoadedRooms()).not.toContain(room);
-			await expect(RoomManager.loadRoom(testRoomId)).resolves.toBe(null);
-			// Destructor called
-			expect(roomonDestroySpy).toHaveBeenCalledTimes(1);
 		});
 	});
 });


### PR DESCRIPTION
This reworks how deletion works from being eager to delete the room, to simply marking it as "pending deletion".
This kicks everyone inside, unloads it from the current shard and then deletes it from the database. The room is however then not immediately unloaded to allow any lingering references to be removed (such as characters pending join during that time) before unloading the room cleanly.