### PR TITLE
[FIX] Do not remove room device link unless revalidating

### DIFF
--- a/pandora-common/src/assets/item.ts
+++ b/pandora-common/src/assets/item.ts
@@ -874,7 +874,15 @@ export class ItemRoomDeviceWearablePart extends ItemBase<'roomDeviceWearablePart
 			};
 
 		const device = context.roomState?.items.find((item) => item.isType('roomDevice') && item.id === this.roomDeviceLink?.device);
-		if (device == null || device !== this.roomDevice) {
+		if (
+			// Target device must exist
+			(device == null || device !== this.roomDevice) ||
+			// The device must have a matching slot
+			(device.asset.definition.slots[this.roomDeviceLink.slot]?.wearableAsset !== this.asset.id) ||
+			// The device must be deployed with this character in target slot
+			// TODO: We have no way to check that the character in the slot is us, because we don't have the character ID at this point
+			(!device.deployment || !device.slotOccupancy.has(this.roomDeviceLink.slot))
+		) {
 			return {
 				success: false,
 				error: {
@@ -917,8 +925,8 @@ export class ItemRoomDeviceWearablePart extends ItemBase<'roomDeviceWearablePart
 		});
 	}
 
-	public updateRoomStateLink(roomDevice: ItemRoomDevice): ItemRoomDeviceWearablePart {
-		Assert(this.roomDeviceLink?.device === roomDevice.id);
+	public updateRoomStateLink(roomDevice: ItemRoomDevice | null): ItemRoomDeviceWearablePart {
+		Assert(roomDevice == null || this.roomDeviceLink?.device === roomDevice.id);
 		return this.withProps({
 			roomDevice,
 		});

--- a/pandora-common/src/assets/state/characterState.ts
+++ b/pandora-common/src/assets/state/characterState.ts
@@ -191,20 +191,12 @@ export class AssetFrameworkCharacterState implements AssetFrameworkCharacterStat
 			if (item.isType('roomDeviceWearablePart')) {
 				const link = item.roomDeviceLink;
 				if (!roomInventory || !link)
-					return null;
+					return item.updateRoomStateLink(null);
 
 				// Target device must exist
 				const device = roomInventory.items.find((roomItem) => roomItem.id === link.device);
-				if (!device || !device.isType('roomDevice'))
-					return null;
-
-				// The device must have a matching slot
-				if (device.asset.definition.slots[item.roomDeviceLink.slot]?.wearableAsset !== item.asset.id)
-					return null;
-
-				// The device must be deployed with this character in target slot
-				if (!device.deployment || device.slotOccupancy.get(item.roomDeviceLink.slot) !== this.id)
-					return null;
+				if (!device || !device.isType('roomDevice') || device.slotOccupancy.get(item.roomDeviceLink.slot) !== this.id)
+					return item.updateRoomStateLink(null);
 
 				return item.updateRoomStateLink(device);
 			}


### PR DESCRIPTION
Puts the room device link into an invalid state instead of deleting it when it is not valid.
This is important because during some actions the link can become temporarily invalid and later restored. After this change it will effectively be no change for the link instead of being deleted during that.