### PR TITLE
[FIX] Fixes and improvements for graphics suspense and editor

### DIFF
--- a/pandora-client-web/src/components/gameContext/directoryConnectorContextProvider.tsx
+++ b/pandora-client-web/src/components/gameContext/directoryConnectorContextProvider.tsx
@@ -104,7 +104,7 @@ export function useCurrentAccount(): IDirectoryAccountInfo | null {
 }
 
 export function useCurrentAccountSettings(): Immutable<IDirectoryAccountSettings> {
-	// Get account manually to avoid assets in the editor
+	// Get account manually to avoid error in the editor
 	const account = useNullableObservable(useDirectoryConnectorOptional()?.currentAccount);
 	// It is safe to return it simply like this, as when settings change, the whole account object is updated (it is immutable)
 	return account?.settings ?? ACCOUNT_SETTINGS_DEFAULT;

--- a/pandora-client-web/src/graphics/graphicsCharacter.tsx
+++ b/pandora-client-web/src/graphics/graphicsCharacter.tsx
@@ -202,7 +202,7 @@ function GraphicsCharacterWithManagerImpl({
 			pointermove={ onPointerMove }
 			cursor='pointer'
 		>
-			<GraphicsSuspense loadingCirclePosition={ { x: 500, y: 750 } }>
+			<GraphicsSuspense loadingCirclePosition={ { x: 500, y: 750 } } sortableChildren>
 				<SwapCullingDirection uniqueKey='filter' swap={ filters != null && filters.length > 0 }>
 					<SwapCullingDirection swap={ (scale.x >= 0) !== (scale.y >= 0) }>
 						{

--- a/pandora-client-web/src/graphics/graphicsSceneRenderer.tsx
+++ b/pandora-client-web/src/graphics/graphicsSceneRenderer.tsx
@@ -1,6 +1,7 @@
 import React, { Context, ReactElement, ReactNode, useMemo } from 'react';
+import * as PIXI from 'pixi.js';
 import { Application, Container, IApplicationOptions, Ticker } from 'pixi.js';
-import { Assert, AssertNotNullable, GetLogger, Rectangle } from 'pandora-common';
+import { Assert, AssertNotNullable, GetLogger, IsObject, Rectangle } from 'pandora-common';
 import { AppProvider, createRoot, ReactPixiRoot, Stage } from '@pixi/react';
 import { cloneDeep } from 'lodash';
 import { ChildrenProps } from '../common/reactTypes';
@@ -481,4 +482,19 @@ export function ContextBridge({ children, contexts, render }: {
 			) }
 		</Consumer>
 	);
+}
+
+export function PixiElementRequestUpdate(element: PIXI.Container): void {
+	const unknownCastElement: unknown = element;
+
+	if (
+		!IsObject(unknownCastElement) ||
+		!IsObject(unknownCastElement.__reactpixi) ||
+		!IsObject(unknownCastElement.__reactpixi.root) ||
+		!(unknownCastElement.__reactpixi.root instanceof PIXI.Container)
+	) {
+		throw new Error('Attempt to request update on a PIXI container outside of @pixi/react tree');
+	}
+
+	unknownCastElement.__reactpixi.root.emit(`__REACT_PIXI_REQUEST_RENDER__`);
 }


### PR DESCRIPTION
Fixes several crashes in editor.
Improves graphics suspense:
- Both container updates and loading progress updates happen synchronously and outside React now
- This avoids previous error in editor / when using custom texture getter
- Adds a grace period before showing progress again after being ready