### PR TITLE
[ADD] coloring permission of devices and minimum account password length

### DIFF
--- a/pandora-client-web/src/components/login/forms/registrationForm.tsx
+++ b/pandora-client-web/src/components/login/forms/registrationForm.tsx
@@ -101,7 +101,7 @@ export function RegistrationForm(): ReactElement {
 		<Form className='RegistrationForm' dirty={ submitCount > 0 } onSubmit={ onSubmit }>
 			<h1>Sign up</h1>
 			<FormField>
-				<label htmlFor='registration-username'>Username</label>
+				<label htmlFor='registration-username'>Username (will be visible to other users)</label>
 				<input
 					type='text'
 					id='registration-username'

--- a/pandora-client-web/src/components/login/forms/registrationForm.tsx
+++ b/pandora-client-web/src/components/login/forms/registrationForm.tsx
@@ -1,4 +1,4 @@
-import { AssertNever, EmailAddressSchema, PasswordSha512Schema, UserNameSchema } from 'pandora-common';
+import { AssertNever, EmailAddressSchema, PasswordSchema, UserNameSchema } from 'pandora-common';
 import React, { ReactElement, useCallback, useEffect, useState } from 'react';
 import { useForm, Validate } from 'react-hook-form';
 import { useNavigate } from 'react-router';
@@ -134,7 +134,7 @@ export function RegistrationForm(): ReactElement {
 					autoComplete='new-password'
 					{ ...register('password', {
 						required: 'Password is required',
-						validate: FormCreateStringValidator(PasswordSha512Schema, 'password'),
+						validate: FormCreateStringValidator(PasswordSchema, 'password'),
 					}) }
 				/>
 				<FormFieldError error={ errors.password } />

--- a/pandora-client-web/src/components/login/forms/registrationForm.tsx
+++ b/pandora-client-web/src/components/login/forms/registrationForm.tsx
@@ -101,7 +101,7 @@ export function RegistrationForm(): ReactElement {
 		<Form className='RegistrationForm' dirty={ submitCount > 0 } onSubmit={ onSubmit }>
 			<h1>Sign up</h1>
 			<FormField>
-				<label htmlFor='registration-username'>Username (will be visible to other users)</label>
+				<label htmlFor='registration-username'>Username</label>
 				<input
 					type='text'
 					id='registration-username'

--- a/pandora-client-web/src/components/login/forms/registrationForm.tsx
+++ b/pandora-client-web/src/components/login/forms/registrationForm.tsx
@@ -1,4 +1,4 @@
-import { AssertNever, EmailAddressSchema, UserNameSchema } from 'pandora-common';
+import { AssertNever, EmailAddressSchema, PasswordSha512Schema, UserNameSchema } from 'pandora-common';
 import React, { ReactElement, useCallback, useEffect, useState } from 'react';
 import { useForm, Validate } from 'react-hook-form';
 import { useNavigate } from 'react-router';
@@ -134,6 +134,7 @@ export function RegistrationForm(): ReactElement {
 					autoComplete='new-password'
 					{ ...register('password', {
 						required: 'Password is required',
+						validate: FormCreateStringValidator(PasswordSha512Schema, 'password'),
 					}) }
 				/>
 				<FormFieldError error={ errors.password } />

--- a/pandora-client-web/src/components/login/forms/resetPasswordForm.tsx
+++ b/pandora-client-web/src/components/login/forms/resetPasswordForm.tsx
@@ -1,4 +1,4 @@
-import { AssertNever, IsSimpleToken, PasswordSha512Schema, SIMPLE_TOKEN_LENGTH, UserNameSchema } from 'pandora-common';
+import { AssertNever, IsSimpleToken, PasswordSchema, SIMPLE_TOKEN_LENGTH, UserNameSchema } from 'pandora-common';
 import React, { ReactElement, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router';
@@ -92,7 +92,7 @@ export function ResetPasswordForm(): ReactElement {
 					autoComplete='new-password'
 					{ ...register('password', {
 						required: 'Password is required',
-						validate: FormCreateStringValidator(PasswordSha512Schema, 'password'),
+						validate: FormCreateStringValidator(PasswordSchema, 'password'),
 					}) }
 				/>
 				<FormFieldError error={ errors.password } />

--- a/pandora-client-web/src/components/login/forms/resetPasswordForm.tsx
+++ b/pandora-client-web/src/components/login/forms/resetPasswordForm.tsx
@@ -1,4 +1,4 @@
-import { AssertNever, IsSimpleToken, SIMPLE_TOKEN_LENGTH, UserNameSchema } from 'pandora-common';
+import { AssertNever, IsSimpleToken, PasswordSha512Schema, SIMPLE_TOKEN_LENGTH, UserNameSchema } from 'pandora-common';
 import React, { ReactElement, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router';
@@ -92,6 +92,7 @@ export function ResetPasswordForm(): ReactElement {
 					autoComplete='new-password'
 					{ ...register('password', {
 						required: 'Password is required',
+						validate: FormCreateStringValidator(PasswordSha512Schema, 'password'),
 					}) }
 				/>
 				<FormFieldError error={ errors.password } />

--- a/pandora-client-web/test/components/login/forms/registrationForm.test.tsx
+++ b/pandora-client-web/test/components/login/forms/registrationForm.test.tsx
@@ -24,7 +24,7 @@ describe('Registration Form', () => {
 		});
 	});
 
-	TestFieldIsRendered('username', 'Username (will be visible to other users)', 'text', 'username');
+	TestFieldIsRendered('username', 'Username', 'text', 'username');
 	TestFieldIsRendered('email', 'Email', 'email', 'email');
 	TestFieldIsRendered('password', 'Password', 'password', 'new-password');
 	TestFieldIsRendered('password confirmation', 'Confirm password', 'password', 'new-password');
@@ -39,7 +39,7 @@ describe('Registration Form', () => {
 		await user.type(screen.getByLabelText('Confirm password'), defaultPassword);
 		await user.click(screen.getByRole('button'));
 
-		await ExpectFieldToBeInvalid('Username (will be visible to other users)');
+		await ExpectFieldToBeInvalid('Username');
 		// Error is caught by native validation, so the message is not displayed
 		// await ExpectFieldToBeInvalid('Username', 'Username is required');
 	});
@@ -48,7 +48,7 @@ describe('Registration Form', () => {
 		// TODO: Expand this to actually check that a WS message hasn't been sent
 		expect(screen.queryByText('Email is required')).not.toBeInTheDocument();
 
-		await user.type(screen.getByLabelText('Username (will be visible to other users)'), defaultUsername);
+		await user.type(screen.getByLabelText('Username'), defaultUsername);
 		await user.type(screen.getByLabelText('Password'), defaultPassword);
 		await user.type(screen.getByLabelText('Confirm password'), defaultPassword);
 		await user.click(screen.getByRole('button'));
@@ -62,7 +62,7 @@ describe('Registration Form', () => {
 		// TODO: Expand this to actually check that a WS message hasn't been sent
 		expect(screen.queryByText('Password is required')).not.toBeInTheDocument();
 
-		await user.type(screen.getByLabelText('Username (will be visible to other users)'), defaultUsername);
+		await user.type(screen.getByLabelText('Username'), defaultUsername);
 		await user.type(screen.getByLabelText('Email'), defaultEmail);
 		await user.type(screen.getByLabelText('Confirm password'), defaultPassword);
 		await user.click(screen.getByRole('button'));
@@ -76,7 +76,7 @@ describe('Registration Form', () => {
 		// TODO: Expand this to actually check that a WS message hasn't been sent
 		expect(screen.queryByText('Please confirm your password')).not.toBeInTheDocument();
 
-		await user.type(screen.getByLabelText('Username (will be visible to other users)'), defaultUsername);
+		await user.type(screen.getByLabelText('Username'), defaultUsername);
 		await user.type(screen.getByLabelText('Email'), defaultEmail);
 		await user.type(screen.getByLabelText('Password'), defaultPassword);
 		await user.click(screen.getByRole('button'));
@@ -92,7 +92,7 @@ describe('Registration Form', () => {
 
 		await fillInAndSubmitForm(invalidUsername, defaultEmail, defaultPassword, defaultPassword);
 
-		await ExpectFieldToBeInvalid('Username (will be visible to other users)');
+		await ExpectFieldToBeInvalid('Username');
 	});
 
 	it.each(INVALID_EMAILS)('should not permit the invalid email %p to be submitted', async (invalidEmail) => {
@@ -141,7 +141,7 @@ describe('Registration Form', () => {
 		password: string,
 		passwordConfirm: string,
 	): Promise<void> {
-		await user.type(screen.getByLabelText('Username (will be visible to other users)'), username);
+		await user.type(screen.getByLabelText('Username'), username);
 		await user.type(screen.getByLabelText('Email'), email);
 		await user.type(screen.getByLabelText('Password'), password);
 		await user.type(screen.getByLabelText('Confirm password'), passwordConfirm);

--- a/pandora-client-web/test/components/login/forms/registrationForm.test.tsx
+++ b/pandora-client-web/test/components/login/forms/registrationForm.test.tsx
@@ -24,7 +24,7 @@ describe('Registration Form', () => {
 		});
 	});
 
-	TestFieldIsRendered('username', 'Username', 'text', 'username');
+	TestFieldIsRendered('username', 'Username (will be visible to other users)', 'text', 'username');
 	TestFieldIsRendered('email', 'Email', 'email', 'email');
 	TestFieldIsRendered('password', 'Password', 'password', 'new-password');
 	TestFieldIsRendered('password confirmation', 'Confirm password', 'password', 'new-password');
@@ -39,7 +39,7 @@ describe('Registration Form', () => {
 		await user.type(screen.getByLabelText('Confirm password'), defaultPassword);
 		await user.click(screen.getByRole('button'));
 
-		await ExpectFieldToBeInvalid('Username');
+		await ExpectFieldToBeInvalid('Username (will be visible to other users)');
 		// Error is caught by native validation, so the message is not displayed
 		// await ExpectFieldToBeInvalid('Username', 'Username is required');
 	});
@@ -48,7 +48,7 @@ describe('Registration Form', () => {
 		// TODO: Expand this to actually check that a WS message hasn't been sent
 		expect(screen.queryByText('Email is required')).not.toBeInTheDocument();
 
-		await user.type(screen.getByLabelText('Username'), defaultUsername);
+		await user.type(screen.getByLabelText('Username (will be visible to other users)'), defaultUsername);
 		await user.type(screen.getByLabelText('Password'), defaultPassword);
 		await user.type(screen.getByLabelText('Confirm password'), defaultPassword);
 		await user.click(screen.getByRole('button'));
@@ -62,7 +62,7 @@ describe('Registration Form', () => {
 		// TODO: Expand this to actually check that a WS message hasn't been sent
 		expect(screen.queryByText('Password is required')).not.toBeInTheDocument();
 
-		await user.type(screen.getByLabelText('Username'), defaultUsername);
+		await user.type(screen.getByLabelText('Username (will be visible to other users)'), defaultUsername);
 		await user.type(screen.getByLabelText('Email'), defaultEmail);
 		await user.type(screen.getByLabelText('Confirm password'), defaultPassword);
 		await user.click(screen.getByRole('button'));
@@ -76,7 +76,7 @@ describe('Registration Form', () => {
 		// TODO: Expand this to actually check that a WS message hasn't been sent
 		expect(screen.queryByText('Please confirm your password')).not.toBeInTheDocument();
 
-		await user.type(screen.getByLabelText('Username'), defaultUsername);
+		await user.type(screen.getByLabelText('Username (will be visible to other users)'), defaultUsername);
 		await user.type(screen.getByLabelText('Email'), defaultEmail);
 		await user.type(screen.getByLabelText('Password'), defaultPassword);
 		await user.click(screen.getByRole('button'));
@@ -92,7 +92,7 @@ describe('Registration Form', () => {
 
 		await fillInAndSubmitForm(invalidUsername, defaultEmail, defaultPassword, defaultPassword);
 
-		await ExpectFieldToBeInvalid('Username');
+		await ExpectFieldToBeInvalid('Username (will be visible to other users)');
 	});
 
 	it.each(INVALID_EMAILS)('should not permit the invalid email %p to be submitted', async (invalidEmail) => {
@@ -141,7 +141,7 @@ describe('Registration Form', () => {
 		password: string,
 		passwordConfirm: string,
 	): Promise<void> {
-		await user.type(screen.getByLabelText('Username'), username);
+		await user.type(screen.getByLabelText('Username (will be visible to other users)'), username);
 		await user.type(screen.getByLabelText('Email'), email);
 		await user.type(screen.getByLabelText('Password'), password);
 		await user.type(screen.getByLabelText('Confirm password'), passwordConfirm);

--- a/pandora-common/src/assets/appearanceActions.ts
+++ b/pandora-common/src/assets/appearanceActions.ts
@@ -364,6 +364,17 @@ export function DoAppearanceAction(
 			const target = processingContext.getTarget(action.target);
 			if (!target)
 				return processingContext.invalid();
+			const item = target.getItem(action.item);
+			// To manipulate the color of room devices, player must be an admin
+			if (item?.isType('roomDevice') && !playerRestrictionManager.isCurrentRoomAdmin()) {
+				processingContext.addProblem({
+					result: 'restrictionError',
+					restriction: {
+						type: 'modifyRoomRestriction',
+						reason: 'notAdmin',
+					},
+				});
+			}
 			// Player coloring the item must be able to interact with the item
 			const r = playerRestrictionManager.canUseItem(processingContext, target, action.item, ItemInteractionType.STYLING);
 			if (!r.allowed) {

--- a/pandora-common/src/validation.ts
+++ b/pandora-common/src/validation.ts
@@ -178,4 +178,5 @@ export const SIMPLE_TOKEN_LENGTH = 6;
 export const SimpleTokenSchema = z.string().length(SIMPLE_TOKEN_LENGTH).regex(/^[0-9]+$/);
 export const IsSimpleToken = ZodMatcher(SimpleTokenSchema);
 
+// TODO: set minimum password length to maybe 8 characters?
 export const PasswordSha512Schema = z.string().regex(/^[a-zA-Z0-9+/]{86}==$/);

--- a/pandora-common/src/validation.ts
+++ b/pandora-common/src/validation.ts
@@ -178,4 +178,5 @@ export const SIMPLE_TOKEN_LENGTH = 6;
 export const SimpleTokenSchema = z.string().length(SIMPLE_TOKEN_LENGTH).regex(/^[0-9]+$/);
 export const IsSimpleToken = ZodMatcher(SimpleTokenSchema);
 
-export const PasswordSha512Schema = z.string().min(8).regex(/^[a-zA-Z0-9+/]{86}==$/);
+export const PasswordSchema = z.string().min(8);
+export const PasswordSha512Schema = z.string().regex(/^[a-zA-Z0-9+/]{86}==$/);

--- a/pandora-common/src/validation.ts
+++ b/pandora-common/src/validation.ts
@@ -178,5 +178,4 @@ export const SIMPLE_TOKEN_LENGTH = 6;
 export const SimpleTokenSchema = z.string().length(SIMPLE_TOKEN_LENGTH).regex(/^[0-9]+$/);
 export const IsSimpleToken = ZodMatcher(SimpleTokenSchema);
 
-// TODO: set minimum password length to maybe 8 characters?
-export const PasswordSha512Schema = z.string().regex(/^[a-zA-Z0-9+/]{86}==$/);
+export const PasswordSha512Schema = z.string().min(8).regex(/^[a-zA-Z0-9+/]{86}==$/);


### PR DESCRIPTION
Reasoning:

~~Change 1. Give warning to users to not use a sensitive username since they think it is hidden~~ EDIT: seems with the activities around using `displayName` everywhere, this is no longer needed, so I reverted this change again
Change 2. Prevent bad actors from undoing lots of work by changing room device colors randomly without leaving a trace even in the chat
Change 3. We still should force users to select a strong enough password, despite our account security measures. Yes, this will lead to serious bad actors focusing on trying passwords with a length of 8-10 characters mainly, but overall it still improves the security situation on average, I think.