### PR TITLE
[CHANGE] crypto key should not be changed directly

### DIFF
--- a/pandora-client-web/src/components/directMessage/directMessage.tsx
+++ b/pandora-client-web/src/components/directMessage/directMessage.tsx
@@ -45,18 +45,17 @@ function DirectMessageList(): ReactElement | null {
 }
 
 function DirectMessageElement({ message, channel, account }: { message: DirectMessage; channel: Readonly<IDirectoryDirectMessageAccount>; account: IDirectoryAccountInfo; }): ReactElement {
-	const { color, name } = useMemo(() => {
-		if (message.sent) {
-			return {
-				color: account.settings.labelColor,
-				name: account.username,
-			};
-		} else {
-			return {
-				color: channel.labelColor,
-				name: channel.name,
-			};
-		}
+	const displayNameElement = useMemo(() => {
+		const { labelColor, displayName } = !message.sent ? channel : {
+			labelColor: account.settings.labelColor,
+			displayName: account.displayName,
+		};
+
+		return (
+			<span style={ { color: labelColor } } className='direct-message-entry__name'>
+				{ displayName }
+			</span>
+		);
 	}, [message, account, channel]);
 	const time = useMemo(() => new Date(message.time), [message.time]);
 
@@ -69,9 +68,7 @@ function DirectMessageElement({ message, channel, account }: { message: DirectMe
 				{ message.edited ? <span> [edited]</span> : null }
 				{ /* Space so copied text looks nicer */ ' ' }
 			</span>
-			<span style={ { color } } className='direct-message-entry__name'>
-				{ name }
-			</span>
+			{ displayNameElement }
 			{ ': ' }
 			<span className='direct-message-entry__content'>
 				{ ...message.message.map((c, i) => RenderChatPart(c, i, true)) }
@@ -112,7 +109,7 @@ function DirectChannelInput(): ReactElement | null {
 			ref={ actualRef }
 			onKeyDown={ onKeyDown }
 			maxLength={ LIMIT_DIRECT_MESSAGE_LENGTH }
-			placeholder={ `Send message to ${channel.account.name} (${channel.account.id})` }
+			placeholder={ `Send message to ${channel.account.displayName} (${channel.account.id})` }
 		/>
 	);
 }

--- a/pandora-client-web/src/components/directMessages/directMessages.tsx
+++ b/pandora-client-web/src/components/directMessages/directMessages.tsx
@@ -17,8 +17,8 @@ export function DirectMessages(): React.ReactElement {
 	const filtered = React.useMemo(() => {
 		const arr = flt.split(/\s+/).filter((s) => s.length > 0);
 		return info
-			.filter(({ account, id }) => {
-				const name = `${account} (${id})`.toLowerCase();
+			.filter(({ displayName, id }) => {
+				const name = `${displayName} (${id})`.toLowerCase();
 				return arr.every((s) => name.includes(s));
 			})
 			.sort((a, b) => b.time - a.time);
@@ -58,19 +58,19 @@ function DirectMessageTempInfo({ selected, filtered }: { selected: AccountId; fi
 
 	return (
 		<li className='temp'>
-			{ chat.account.name } ({ selected })
+			{ chat.account.displayName } ({ selected })
 		</li>
 	);
 }
 
 function DirectMessageInfo({ info, selected }: { info: Readonly<IDirectoryDirectMessageInfo>; selected: boolean; }): React.ReactElement {
 	const directory = useDirectoryConnector();
-	const { id, account, hasUnread } = info;
+	const { id, displayName, hasUnread } = info;
 	const show = React.useCallback(() => directory.directMessageHandler.setSelected(id), [directory.directMessageHandler, id]);
 
 	return (
 		<li onClick={ show } className={ selected ? 'selected' : '' }>
-			{ account } ({ id })
+			{ displayName } ({ id })
 			{ hasUnread && <span>!</span> }
 		</li>
 	);

--- a/pandora-client-web/src/networking/directMessageManager.ts
+++ b/pandora-client-web/src/networking/directMessageManager.ts
@@ -64,7 +64,10 @@ export class DirectMessageManager extends TypedEventEmitter<{ newMessage: Direct
 		} else {
 			this.#crypto = await KeyExchange.generate();
 			this._lastCryptoKey = await this.#crypto.export(cryptoPassword);
-			this.connector.sendMessage('setCryptoKey', { cryptoKey: this._lastCryptoKey });
+			const { result } = await this.connector.awaitResponse('setInitialCryptoKey', { cryptoKey: this._lastCryptoKey });
+			if (result !== 'ok') {
+				throw new Error(`Failed to set crypto key: ${result}`);
+			}
 		}
 		await this._loadInfo();
 	}

--- a/pandora-client-web/src/networking/directMessageManager.ts
+++ b/pandora-client-web/src/networking/directMessageManager.ts
@@ -248,7 +248,7 @@ export class DirectMessageChannel {
 		const id = this._account.id;
 		let info = infos.value.find((i) => i.id === id);
 		if (!info) {
-			info = { id, time, account: this._account.name };
+			info = { id, time, displayName: this._account.displayName };
 			infos.value = [...infos.value, info];
 		}
 		if (data.edited === undefined) {

--- a/pandora-client-web/test/mocks/networking/mockDirectoryConnector.ts
+++ b/pandora-client-web/test/mocks/networking/mockDirectoryConnector.ts
@@ -60,6 +60,7 @@ export function MockAccountInfo(overrides?: Partial<IDirectoryAccountInfo>): IDi
 		id: 1234567890,
 		created: 0,
 		username: 'test-user',
+		displayName: 'Test User',
 		roles: {},
 		roomOwnershipLimit: 5,
 		settings: cloneDeep(ACCOUNT_SETTINGS_DEFAULT),

--- a/pandora-common/src/networking/client_directory.ts
+++ b/pandora-common/src/networking/client_directory.ts
@@ -175,11 +175,11 @@ export const ClientDirectorySchema = {
 		request: DirectoryAccountSettingsSchema.partial(),
 		response: null,
 	},
-	setCryptoKey: {
+	setInitialCryptoKey: {
 		request: z.object({
 			cryptoKey: AccountCryptoKeySchema,
 		}),
-		response: null,
+		response: ZodCast<{ result: 'ok' | 'invalid' | 'keyAlreadySet'; }>(),
 	},
 	//#endregion
 

--- a/pandora-common/src/networking/directory_client.ts
+++ b/pandora-common/src/networking/directory_client.ts
@@ -113,6 +113,7 @@ export type IAccountCryptoKey = z.infer<typeof AccountCryptoKeySchema>;
 export type IDirectoryAccountInfo = {
 	id: number;
 	username: string;
+	displayName: string;
 	created: number;
 	github?: { id: number; login: string; };
 	roles?: IAccountRoleInfo;
@@ -153,8 +154,8 @@ export type IDirectoryDirectMessage = {
 export type IDirectoryDirectMessageAccount = {
 	/** Id of the account */
 	id: AccountId;
-	/** Name of the account */
-	name: string;
+	/** Display name of the account */
+	displayName: string;
 	/** Label color of the account */
 	labelColor: string;
 	/** Public key of the account */
@@ -165,8 +166,8 @@ export type IDirectoryDirectMessageAccount = {
 export type IDirectoryDirectMessageInfo = {
 	/** Id of the other account */
 	id: AccountId;
-	/** Name of the other account */
-	account: string;
+	/** Display ame of the other account */
+	displayName: string;
 	/** Flag to indicate that there are unread messages */
 	hasUnread?: true;
 	/** Last message time */

--- a/pandora-server-directory/src/account/account.ts
+++ b/pandora-server-directory/src/account/account.ts
@@ -36,6 +36,11 @@ export class Account {
 		return this.data.username;
 	}
 
+	/** TODO: Allow choosing custom display name instead of always showing a username */
+	public get displayName(): string {
+		return this.data.username;
+	}
+
 	constructor(data: DatabaseAccountWithSecure) {
 		this.lastActivity = Date.now();
 		// Shallow copy to preserve received data when cleaning up secure
@@ -76,6 +81,7 @@ export class Account {
 		return {
 			id: this.data.id,
 			username: this.data.username,
+			displayName: this.displayName,
 			created: this.data.created,
 			github: this.secure.getGitHubStatus(),
 			roles: this.roles.getSelfInfo(),
@@ -89,8 +95,7 @@ export class Account {
 	public getAccountPublicInfo(): AccountPublicInfo {
 		return {
 			id: this.data.id,
-			// TODO: Allow choosing custom display name instead of always showing a username
-			displayName: this.data.username,
+			displayName: this.displayName,
 			labelColor: this.data.settings.labelColor,
 			created: this.data.created,
 			visibleRoles: uniq(this.data.settings.visibleRoles.filter((role) => this.roles.isAuthorized(role))),

--- a/pandora-server-directory/src/account/accountDirectMessages.ts
+++ b/pandora-server-directory/src/account/accountDirectMessages.ts
@@ -45,7 +45,7 @@ export class AccountDirectMessages {
 			}
 			dm = {
 				id,
-				account: account.username,
+				displayName: account.displayName,
 				time,
 			};
 			this._dms.push(dm);
@@ -135,7 +135,7 @@ export class AccountDirectMessages {
 		const account = this._account;
 		return {
 			id: account.id,
-			name: account.username,
+			displayName: account.displayName,
 			labelColor: account.data.settings.labelColor,
 			publicKeyData: account.directMessages._publicKey,
 		};

--- a/pandora-server-directory/src/account/accountSecure.ts
+++ b/pandora-server-directory/src/account/accountSecure.ts
@@ -170,19 +170,19 @@ export default class AccountSecure {
 		return this.#secure.cryptoKey?.publicKey;
 	}
 
-	public async setCryptoKey(key: IAccountCryptoKey): Promise<boolean> {
+	public async setInitialCryptoKey(key: IAccountCryptoKey): Promise<'ok' | 'invalid' | 'keyAlreadySet'> {
+		if (this.#secure.cryptoKey != null)
+			return 'keyAlreadySet';
+
 		if (!await this.#validateCryptoKey(key))
-			return false;
+			return 'invalid';
 
 		this.#secure.cryptoKey = _.cloneDeep(key);
 		await this.#updateDatabase();
-		return true;
+		return 'ok';
 	}
 
-	async #validateCryptoKey({ publicKey }: IAccountCryptoKey, previous?: IAccountCryptoKey): Promise<boolean> {
-		if (previous?.publicKey === publicKey)
-			return true;
-
+	async #validateCryptoKey({ publicKey }: IAccountCryptoKey): Promise<boolean> {
 		return await IsPublicKey(publicKey);
 	}
 

--- a/pandora-server-directory/src/networking/manager_client.ts
+++ b/pandora-server-directory/src/networking/manager_client.ts
@@ -86,7 +86,7 @@ export const ConnectionManagerClient = new class ConnectionManagerClient impleme
 			gitHubBind: this.handleGitHubBind.bind(this),
 			gitHubUnbind: this.handleGitHubUnbind.bind(this),
 			changeSettings: this.handleChangeSettings.bind(this),
-			setCryptoKey: this.handleSetCryptoKey.bind(this),
+			setInitialCryptoKey: this.handleSetInitialCryptoKey.bind(this),
 
 			getRelationships: this.handleGetRelationships.bind(this),
 			getAccountInfo: this.handleGetAccountInfo.bind(this),
@@ -625,11 +625,13 @@ export const ConnectionManagerClient = new class ConnectionManagerClient impleme
 
 	//#region Direct Messages
 
-	private async handleSetCryptoKey({ cryptoKey }: IClientDirectoryArgument['setCryptoKey'], connection: ClientConnection): IClientDirectoryPromiseResult['setCryptoKey'] {
+	private async handleSetInitialCryptoKey({ cryptoKey }: IClientDirectoryArgument['setInitialCryptoKey'], connection: ClientConnection): IClientDirectoryPromiseResult['setInitialCryptoKey'] {
 		if (!connection.account)
 			throw new BadMessageError();
 
-		await connection.account.secure.setCryptoKey(cryptoKey);
+		const result = await connection.account.secure.setInitialCryptoKey(cryptoKey);
+
+		return { result };
 	}
 
 	private async handleGetDirectMessages({ id, until }: IClientDirectoryArgument['getDirectMessages'], connection: ClientConnection): IClientDirectoryPromiseResult['getDirectMessages'] {


### PR DESCRIPTION
prevent direct update of the crypto key after its first creation, as it was never an intended behavior

change DMs to refer to the upcoming `displayName` of the account instead of the username