### PR TITLE
[FIX] improved CommandSelectorCharacter ID parsing

### DIFF
--- a/pandora-client-web/src/components/chatroom/commandsHelpers.ts
+++ b/pandora-client-web/src/components/chatroom/commandsHelpers.ts
@@ -21,7 +21,13 @@ export const CommandSelectorCharacter = ({ allowSelf }: {
 			};
 		}
 
-		if (/^[0-9]+$/.test(selector)) {
+		let targets = characters.filter((c) => c.data.name === selector);
+		if (targets.length === 0)
+			targets = characters.filter((c) => c.data.name.toLowerCase() === selector.toLowerCase());
+		if (targets.length === 0 && (/^[0-9]+$/.test(selector) || /^c[0-9]+$/.test(selector))) {
+			if (selector[0] === 'c') {
+				selector = selector.substring(1);
+			}
 			const id = Number.parseInt(selector, 10);
 			const target = characters.find((c) => c.data.id === `c${id}`);
 			if (!target) {
@@ -47,10 +53,6 @@ export const CommandSelectorCharacter = ({ allowSelf }: {
 				value: target,
 			};
 		}
-		let targets = characters.filter((c) => c.data.name === selector);
-		if (targets.length === 0)
-			targets = characters.filter((c) => c.data.name.toLowerCase() === selector.toLowerCase());
-
 		if (targets.length === 1) {
 			if (allowSelf !== 'any' && targets[0].isPlayer()) {
 				return {

--- a/pandora-client-web/src/components/chatroom/commandsProcessor.ts
+++ b/pandora-client-web/src/components/chatroom/commandsProcessor.ts
@@ -155,10 +155,12 @@ export function CommandAutocompleteCycle(msg: string, ctx: ICommandInvokeContext
 		};
 	}
 	const best = LongestCommonPrefix(autocompleteLastResult.options.map((i) => i.replaceValue));
-	autocompleteLastQuery = best;
+	// Only use the prefix if it matches with the already entered value
+	const bestReplacement = best.toLocaleLowerCase().startsWith(msg.toLocaleLowerCase()) ? best : msg;
+	autocompleteLastQuery = bestReplacement;
 	autocompleteNextIndex = 0;
 	return {
-		replace: best,
+		replace: bestReplacement,
 		result: autocompleteLastResult,
 		index: null,
 	};


### PR DESCRIPTION
Since we seem to allow full numerical names as character names, ~~there is a bug that makes such characters impossible to whisper to with the according command~~.

While I was there, I also improved the character ID parsing, so that it also allows usage of the actual character ID with a lead "c", as this part could be very confusing to users, that they have to use the character ID without the "c", which would make it look like the account ID.

**By the way, I am not sure it is a good idea to allow numbers in character and display names. It just feels like an invitation to make weird immersion breaking character names. Thoughts?**