### PR TITLE
[FIX] Properly override `Observable`'s `value` for `RateLimitedObservable`

### DIFF
--- a/pandora-client-web/src/observable.ts
+++ b/pandora-client-web/src/observable.ts
@@ -63,6 +63,10 @@ class RateLimitedObservable<T> extends NormalObservable<T> {
 		super(defaultValue);
 	}
 
+	public override get value(): T {
+		return super.value;
+	}
+
 	public override set value(value: T) {
 		const actualSet = () => {
 			super.value = value;


### PR DESCRIPTION
Seems final version of #515 was not tested, because it completely breaks development and userdebug builds.
This is because in ECMAScript spec overriding getter/setter sets a new property on the current prototype. This property, however, overrides both set and get actions from the parent prototype. This means that to get the expected results both need to be overridden at the same time.