### PR TITLE
[FIX] Actually fail if worn item validation fails

### DIFF
--- a/pandora-common/src/assets/appearanceValidation.ts
+++ b/pandora-common/src/assets/appearanceValidation.ts
@@ -129,24 +129,13 @@ export function ValidateAppearanceItemsPrefix(assetManager: AssetManager, items:
 	}
 
 	{
-		let hasDevicePart = false;
-		const r = ValidateItemsPrefix(assetManager, items, roomState, 'character', (item) => {
-			// Check that character is in at most once device
-			if (item.isType('roomDeviceWearablePart')) {
-				if (hasDevicePart) {
-					return {
-						problem: 'canOnlyBeInOneDevice',
-					};
-				}
-				hasDevicePart = true;
-			}
-			return null;
-		});
+		const r = ValidateItemsPrefix(assetManager, items, roomState, 'character');
 		if (!r.success)
 			return r;
 	}
 
 	// Check requirements are met, and check asset count limits
+	let hasDevicePart = false;
 	const assetCounts = new Map<AssetId, number>();
 	let globalProperties = CreateAssetPropertiesResult();
 	for (const item of items) {
@@ -162,6 +151,19 @@ export function ValidateAppearanceItemsPrefix(assetManager: AssetManager, items:
 					limit,
 				},
 			};
+		}
+
+		// Check that character is in at most once device
+		if (item.isType('roomDeviceWearablePart')) {
+			if (hasDevicePart) {
+				return {
+					success: false,
+					error: {
+						problem: 'canOnlyBeInOneDevice',
+					},
+				};
+			}
+			hasDevicePart = true;
 		}
 
 		const properties = item.getProperties();

--- a/pandora-common/src/assets/appearanceValidation.ts
+++ b/pandora-common/src/assets/appearanceValidation.ts
@@ -128,19 +128,23 @@ export function ValidateAppearanceItemsPrefix(assetManager: AssetManager, items:
 			};
 	}
 
-	let hasDevicePart = false;
-	ValidateItemsPrefix(assetManager, items, roomState, 'character', (item) => {
-		// Check that character is in at most once device
-		if (item.isType('roomDeviceWearablePart')) {
-			if (hasDevicePart) {
-				return {
-					problem: 'canOnlyBeInOneDevice',
-				};
+	{
+		let hasDevicePart = false;
+		const r = ValidateItemsPrefix(assetManager, items, roomState, 'character', (item) => {
+			// Check that character is in at most once device
+			if (item.isType('roomDeviceWearablePart')) {
+				if (hasDevicePart) {
+					return {
+						problem: 'canOnlyBeInOneDevice',
+					};
+				}
+				hasDevicePart = true;
 			}
-			hasDevicePart = true;
-		}
-		return null;
-	});
+			return null;
+		});
+		if (!r.success)
+			return r;
+	}
 
 	// Check requirements are met, and check asset count limits
 	const assetCounts = new Map<AssetId, number>();

--- a/pandora-common/src/assets/validation.ts
+++ b/pandora-common/src/assets/validation.ts
@@ -1,7 +1,7 @@
 import type { ItemId } from './appearanceTypes';
-import type { AppearanceItems, AppearanceValidationError, AppearanceValidationResult } from './appearanceValidation';
+import type { AppearanceItems, AppearanceValidationResult } from './appearanceValidation';
 import type { AssetManager } from './assetManager';
-import type { IItemLocationDescriptor, Item } from './item';
+import type { IItemLocationDescriptor } from './item';
 import type { AssetFrameworkRoomState } from './state/roomState';
 import { ITEM_LIMIT_CHARACTER_WORN, ITEM_LIMIT_ROOM_INVENTORY } from './itemLimits';
 
@@ -24,7 +24,6 @@ export function ValidateItemsPrefix(
 	items: AppearanceItems,
 	roomState: AssetFrameworkRoomState | null,
 	type: keyof typeof VALIDATIONS,
-	extraChecks?: (item: Item) => AppearanceValidationError | null,
 ): AppearanceValidationResult {
 	const { location, limit } = VALIDATIONS[type];
 
@@ -46,10 +45,6 @@ export function ValidateItemsPrefix(
 		const r = item.validate({ location, roomState });
 		if (!r.success)
 			return r;
-
-		const error = extraChecks?.(item);
-		if (error)
-			return { success: false, error };
 	}
 
 	if (AppearanceItemsCalculateTotalCount(items) > limit) {


### PR DESCRIPTION
Fixes regression from #533.

After said PR `validate` calls from items are ignored for worn items. This allows attempting to do things such as storing more items than possible in a storage, or getting into some kinds of invalid states that are not validated across multiple items.