### PR TITLE
[FEATURE] Localized error boundaries for client

### DIFF
--- a/pandora-client-web/src/common/clipboard.ts
+++ b/pandora-client-web/src/common/clipboard.ts
@@ -1,0 +1,57 @@
+import { GetLogger } from 'pandora-common';
+import { toast } from 'react-toastify';
+import { TOAST_OPTIONS_ERROR } from '../persistentToast';
+
+const logger = GetLogger('Clipboard');
+
+export function CopyToClipboard(text: string, onSuccess?: () => void, onError?: () => void): void {
+	function copyFallback() {
+		const textArea = document.createElement('textarea');
+		textArea.value = text;
+
+		// Avoid scrolling to bottom
+		textArea.style.top = '0';
+		textArea.style.left = '0';
+		textArea.style.position = 'fixed';
+
+		document.body.appendChild(textArea);
+		textArea.focus();
+		textArea.select();
+
+		let successful = false;
+
+		try {
+			// eslint-disable-next-line deprecation/deprecation
+			successful = document.execCommand('copy');
+			if (!successful) {
+				logger.warning(`Failed to copy text with returned error by execCommand`);
+			}
+		} catch (err) {
+			logger.warning(`Failed to copy text with error:`, err);
+		}
+
+		document.body.removeChild(textArea);
+
+		if (successful) {
+			onSuccess?.();
+		} else {
+			toast(`Failed to copy the text, please copy it manually.`, TOAST_OPTIONS_ERROR);
+			onError?.();
+		}
+	}
+
+	if (!navigator.clipboard) {
+		copyFallback();
+		return;
+	}
+
+	navigator.clipboard.writeText(text)
+		.then(() => {
+			onSuccess?.();
+		})
+		.catch((err) => {
+			logger.warning(`Failed to write text with error:`, err);
+			// Try fallback
+			copyFallback();
+		});
+}

--- a/pandora-client-web/src/components/common/tabs/tabs.tsx
+++ b/pandora-client-web/src/components/common/tabs/tabs.tsx
@@ -4,6 +4,7 @@ import { ChildrenProps } from '../../../common/reactTypes';
 import './tabs.scss';
 import { Column } from '../container/container';
 import { Navigate, Route, Routes, matchPath, resolvePath, useLocation, useNavigate, useResolvedPath } from 'react-router';
+import { LocalErrorBoundary } from '../../error/localErrorBoundary';
 
 interface TabProps extends ChildrenProps {
 	name: ReactNode;
@@ -93,7 +94,9 @@ export function TabContainer({
 
 	return (
 		<Tabulation tabs={ tabs } className={ className } collapsable={ collapsable } tabsPosition={ tabsPosition }>
-			{ currentTab < children.length ? children[currentTab] : null }
+			<React.Fragment key={ currentTab }>
+				{ currentTab < children.length ? children[currentTab] : null }
+			</React.Fragment>
 		</Tabulation>
 	);
 }
@@ -167,7 +170,11 @@ export function UrlTabContainer({
 }
 
 export function Tab({ children }: TabProps): ReactElement {
-	return <Column className='flex-1 tab-content overflow-hidden'>{ children }</Column>;
+	return (
+		<LocalErrorBoundary errorOverlayClassName='flex-1 tab-content overflow-hidden'>
+			<Column className='flex-1 tab-content overflow-hidden'>{ children }</Column>
+		</LocalErrorBoundary>
+	);
 }
 
 export function UrlTab(props: UrlTabProps): ReactElement {

--- a/pandora-client-web/src/components/error/errorReport.ts
+++ b/pandora-client-web/src/components/error/errorReport.ts
@@ -5,6 +5,7 @@ import { ShardConnectionState } from '../../networking/shardConnector';
 import { DebugData } from './debugContextProvider';
 import { utils } from 'pixi.js';
 import bowser from 'bowser';
+import { IsNotNullable } from 'pandora-common';
 
 interface ReportSection {
 	heading: string;
@@ -13,16 +14,17 @@ interface ReportSection {
 
 export const MAX_ERROR_STACK_LINES = 20;
 
-export function BuildErrorReport(error: unknown, errorInfo: ErrorInfo | undefined, debugData: DebugData): string {
+export function BuildErrorReport(error: unknown, errorInfo: ErrorInfo | undefined, debugData: DebugData | undefined): string {
 	try {
 		const report = [
 			BuildStackTraceSection(error),
 			BuildComponentStackSection(errorInfo),
-			BuildDirectoryDataSection(debugData),
-			BuildShardDataSection(debugData),
+			debugData != null ? BuildDirectoryDataSection(debugData) : null,
+			debugData != null ? BuildShardDataSection(debugData) : null,
 			BuildDiagnosticsSection(),
 			BuildDeviceSection(),
 		]
+			.filter(IsNotNullable)
 			.map(DisplayReportSection)
 			.join('\n\n');
 		return '```\n' + report + '\n```';

--- a/pandora-client-web/src/components/error/forwardingErrorBoundary.tsx
+++ b/pandora-client-web/src/components/error/forwardingErrorBoundary.tsx
@@ -1,0 +1,45 @@
+import { GetLogger } from 'pandora-common';
+import React, { Component, ErrorInfo, ReactElement } from 'react';
+import { ChildrenProps } from '../../common/reactTypes';
+import './localErrorBoundary.scss';
+
+export interface ForwardingErrorBoundaryProps extends ChildrenProps {
+	errorHandler: (error: unknown) => void;
+}
+
+export interface ForwardingErrorBoundaryState {
+	hadError: boolean;
+}
+
+const logger = GetLogger('ForwardingErrorBoundary');
+
+export class ForwardingErrorBoundary extends Component<ForwardingErrorBoundaryProps, ForwardingErrorBoundaryState> {
+	public override state: ForwardingErrorBoundaryState = {
+		hadError: false,
+	};
+
+	public override render(): ReactElement | null {
+		const { children } = this.props;
+		const { hadError } = this.state;
+
+		if (hadError) {
+			return null;
+		}
+
+		return <>{ children }</>;
+	}
+
+	public static getDerivedStateFromError(_error: unknown): Partial<ForwardingErrorBoundaryState> {
+		return {
+			hadError: true,
+		};
+	}
+
+	public override componentDidCatch(error: Error, errorInfo?: ErrorInfo) {
+		logger.alert('Caught error:', error, errorInfo);
+
+		const { errorHandler } = this.props;
+
+		errorHandler(error);
+	}
+}

--- a/pandora-client-web/src/components/error/localErrorBoundary.scss
+++ b/pandora-client-web/src/components/error/localErrorBoundary.scss
@@ -1,0 +1,61 @@
+@import '../../styles/common';
+
+.localErrorBoundaryOverlay {
+	color: white;
+	background-color: darkred;
+	text-decoration: none;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+
+	>.localErrorBoundaryContent {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5em;
+		margin: auto;
+		width: fit-content;
+
+		>h1 {
+			margin: 0;
+		}
+	}
+}
+
+.localErrorBoundaryDialog {
+	width: 95vw;
+	max-width: 72em;
+	max-height: 90vh;
+	overflow: hidden;
+
+	h1 {
+		align-self: center;
+		margin-top: 0;
+	}
+
+	pre {
+		position: relative;
+		flex: 1;
+		margin: 0 0 1em;
+		border: 1px solid;
+		padding: 1em;
+		overflow: auto;
+		background-color: $grey-lighter;
+		border-radius: 0.25em;
+
+		.button-wrapper {
+			position: absolute;
+			top: 0;
+			right: 0;
+		}
+
+		.Button {
+			position: fixed;
+			border-radius: 0 0 0 0.2em;
+			transform: translateX(-100%);
+		}
+
+		.report-content {
+			user-select: all;
+		}
+	}
+}

--- a/pandora-client-web/src/components/error/localErrorBoundary.tsx
+++ b/pandora-client-web/src/components/error/localErrorBoundary.tsx
@@ -22,6 +22,7 @@ export interface LocalErrorBoundaryProps extends ChildrenProps {
 
 export interface LocalErrorBoundaryState {
 	report?: string;
+	isTemporaryReport: boolean;
 	showReport: boolean;
 	copyState: ReportCopyState;
 }
@@ -34,6 +35,7 @@ export class LocalErrorBoundary extends Component<LocalErrorBoundaryProps, Local
 	public override state: LocalErrorBoundaryState = {
 		showReport: false,
 		copyState: ReportCopyState.NONE,
+		isTemporaryReport: false,
 	};
 
 	public override render(): ReactElement {
@@ -50,17 +52,19 @@ export class LocalErrorBoundary extends Component<LocalErrorBoundaryProps, Local
 	public static getDerivedStateFromError(error: unknown): Partial<LocalErrorBoundaryState> {
 		return {
 			report: BuildErrorReport(error, undefined, undefined),
+			isTemporaryReport: true,
 		};
 	}
 
 	public override componentDidCatch(error: Error, errorInfo?: ErrorInfo) {
 		logger.alert('Caught error:', error, errorInfo);
 
-		const { report } = this.state;
-		if (!report) {
+		const { report, isTemporaryReport } = this.state;
+		if (!report || isTemporaryReport) {
 			const { debugData } = this.context as DebugContext;
 			this.setState({
 				report: BuildErrorReport(error, errorInfo, debugData),
+				isTemporaryReport: false,
 			});
 		}
 	}

--- a/pandora-client-web/src/components/error/localErrorBoundary.tsx
+++ b/pandora-client-web/src/components/error/localErrorBoundary.tsx
@@ -1,0 +1,161 @@
+import { GetLogger } from 'pandora-common';
+import React, { Component, ErrorInfo, ReactElement } from 'react';
+import { ChildrenProps } from '../../common/reactTypes';
+import { Button } from '../common/button/button';
+import { DebugContext, debugContext } from './debugContextProvider';
+import { BuildErrorReport } from './errorReport';
+import { Column, Row } from '../common/container/container';
+import { CopyToClipboard } from '../../common/clipboard';
+import './localErrorBoundary.scss';
+import classNames from 'classnames';
+import { ModalDialog } from '../dialog/dialog';
+
+export enum ReportCopyState {
+	NONE = 'Copy to clipboard',
+	SUCCESS = 'Copied!',
+	FAILED = 'Failed',
+}
+
+export interface LocalErrorBoundaryProps extends ChildrenProps {
+	errorOverlayClassName?: string;
+}
+
+export interface LocalErrorBoundaryState {
+	report?: string;
+	showReport: boolean;
+	copyState: ReportCopyState;
+}
+
+const logger = GetLogger('LocalErrorBoundary');
+
+export class LocalErrorBoundary extends Component<LocalErrorBoundaryProps, LocalErrorBoundaryState> {
+	private timeout: number | null = null;
+
+	public override state: LocalErrorBoundaryState = {
+		showReport: false,
+		copyState: ReportCopyState.NONE,
+	};
+
+	public override render(): ReactElement {
+		const { children } = this.props;
+		const { report } = this.state;
+
+		if (report != null) {
+			return this.renderErrorContent();
+		}
+
+		return <>{ children }</>;
+	}
+
+	public static getDerivedStateFromError(error: unknown): Partial<LocalErrorBoundaryState> {
+		return {
+			report: BuildErrorReport(error, undefined, undefined),
+		};
+	}
+
+	public override componentDidCatch(error: Error, errorInfo?: ErrorInfo) {
+		logger.alert('Caught error:', error, errorInfo);
+
+		const { report } = this.state;
+		if (!report) {
+			const { debugData } = this.context as DebugContext;
+			this.setState({
+				report: BuildErrorReport(error, errorInfo, debugData),
+			});
+		}
+	}
+
+	public override componentWillUnmount(): void {
+		if (this.timeout) {
+			clearTimeout(this.timeout);
+			this.timeout = null;
+		}
+	}
+
+	private renderErrorContent(): ReactElement {
+		const { copyState, showReport, report } = this.state;
+		const {
+			errorOverlayClassName = 'flex-1 fill',
+		} = this.props;
+
+		return (
+			<div className={ classNames('localErrorBoundaryOverlay', errorOverlayClassName) }>
+				<div className='localErrorBoundaryContent'>
+					<h1>Something went wrong...</h1>
+					<span>... which resulted in this component crashing</span>
+					<Button
+						onClick={ () => {
+							this.setState({ showReport: true });
+						} }
+					>
+						Show error report
+					</Button>
+					<Button
+						onClick={ () => {
+							this.setState({
+								report: undefined,
+								showReport: false,
+							});
+						} }
+					>
+						Reload the component
+					</Button>
+				</div>
+				{
+					showReport && report != null ? (
+						<ModalDialog>
+							<Column className='localErrorBoundaryDialog'>
+								<h1>Something went wrong</h1>
+								<p>
+									Pandora has run into an error - this is likely a problem with the game.<br />
+									Please report this error, providing the following information:
+								</p>
+
+								<pre>
+									<span className='button-wrapper'>
+										<Button onClick={ () => this.copyToClipboard() }>{ copyState }</Button>
+									</span>
+									<span className='report-content'>
+										{ report }
+									</span>
+								</pre>
+
+								<Row alignX='center' padding='medium'>
+									<Button
+										onClick={ () => {
+											this.setState({ showReport: false });
+										} }
+									>
+										Close
+									</Button>
+								</Row>
+							</Column>
+						</ModalDialog>
+					) : null
+				}
+			</div>
+		);
+	}
+
+	private copyToClipboard(): void {
+		const { report } = this.state;
+
+		CopyToClipboard(
+			report ?? '',
+			() => {
+				this.setState({ copyState: ReportCopyState.SUCCESS });
+				this.timeout = window.setTimeout(() => {
+					this.setState({ copyState: ReportCopyState.NONE });
+				}, 5000);
+			},
+			() => {
+				this.setState({ copyState: ReportCopyState.FAILED });
+				this.timeout = window.setTimeout(() => {
+					this.setState({ copyState: ReportCopyState.NONE });
+				}, 5000);
+			},
+		);
+	}
+}
+
+LocalErrorBoundary.contextType = debugContext;

--- a/pandora-client-web/src/components/error/localErrorBoundary.tsx
+++ b/pandora-client-web/src/components/error/localErrorBoundary.tsx
@@ -57,7 +57,7 @@ export class LocalErrorBoundary extends Component<LocalErrorBoundaryProps, Local
 	}
 
 	public override componentDidCatch(error: Error, errorInfo?: ErrorInfo) {
-		logger.alert('Caught error:', error, errorInfo);
+		logger.error('Caught error:', error, errorInfo);
 
 		const { report, isTemporaryReport } = this.state;
 		if (!report || isTemporaryReport) {

--- a/pandora-client-web/src/components/error/rootErrorBoundary.tsx
+++ b/pandora-client-web/src/components/error/rootErrorBoundary.tsx
@@ -16,6 +16,7 @@ export enum ReportCopyState {
 
 export interface RootErrorBoundaryState {
 	report?: string;
+	isTemporaryReport: boolean;
 	copyState: ReportCopyState;
 }
 
@@ -27,6 +28,7 @@ export class RootErrorBoundary extends PureComponent<ChildrenProps, RootErrorBou
 
 	public override state: RootErrorBoundaryState = {
 		copyState: ReportCopyState.NONE,
+		isTemporaryReport: false,
 	};
 
 	public override render(): ReactElement {
@@ -43,15 +45,17 @@ export class RootErrorBoundary extends PureComponent<ChildrenProps, RootErrorBou
 	public static getDerivedStateFromError(error: unknown): Partial<RootErrorBoundaryState> {
 		return {
 			report: BuildErrorReport(error, undefined, undefined),
+			isTemporaryReport: true,
 		};
 	}
 
 	public override componentDidCatch(error: Error, errorInfo?: ErrorInfo) {
-		const { report } = this.state;
-		if (!report) {
+		const { report, isTemporaryReport } = this.state;
+		if (!report || isTemporaryReport) {
 			const { debugData } = this.context as DebugContext;
 			this.setState({
 				report: BuildErrorReport(error, errorInfo, debugData),
+				isTemporaryReport: false,
 			});
 		}
 	}

--- a/pandora-client-web/src/components/error/rootErrorBoundary.tsx
+++ b/pandora-client-web/src/components/error/rootErrorBoundary.tsx
@@ -6,6 +6,7 @@ import { DebugContext, debugContext } from './debugContextProvider';
 import { BuildErrorReport } from './errorReport';
 import './rootErrorBoundary.scss';
 import { Row } from '../common/container/container';
+import { CopyToClipboard } from '../../common/clipboard';
 
 export enum ReportCopyState {
 	NONE = 'Copy to clipboard',
@@ -107,7 +108,7 @@ export class RootErrorBoundary extends PureComponent<ChildrenProps, RootErrorBou
 
 				<pre>
 					<span className='button-wrapper'>
-						<Button onClick={ () => void this.copyToClipboard() }>{ copyState }</Button>
+						<Button onClick={ () => this.copyToClipboard() }>{ copyState }</Button>
 					</span>
 					<span data-testid='report-content' className='report-content' ref={ this.reportRef }>
 						{ report }
@@ -127,48 +128,24 @@ export class RootErrorBoundary extends PureComponent<ChildrenProps, RootErrorBou
 		);
 	}
 
-	private async copyToClipboard(): Promise<void> {
-		let copied = await this.copyUsingClipboardApi();
-
-		if (!copied) {
-			copied = this.copyUsingCommand();
-		}
-
-		if (copied) {
-			this.setState({ copyState: ReportCopyState.SUCCESS });
-		} else {
-			this.setState({ copyState: ReportCopyState.FAILED });
-		}
-		this.timeout = window.setTimeout(() => {
-			this.setState({ copyState: ReportCopyState.NONE });
-		}, 5000);
-	}
-
-	private async copyUsingClipboardApi(): Promise<boolean> {
+	private copyToClipboard(): void {
 		const { report } = this.state;
-		try {
-			await navigator.clipboard.writeText(report ?? '');
-			return true;
-		} catch (_) {
-			return false;
-		}
-	}
 
-	private copyUsingCommand(): boolean {
-		try {
-			const reportElement = this.reportRef.current;
-			if (!reportElement) {
-				return false;
-			}
-			const range = document.createRange();
-			range.selectNode(reportElement);
-			window.getSelection()?.removeAllRanges();
-			window.getSelection()?.addRange(range);
-			// eslint-disable-next-line deprecation/deprecation
-			return document.execCommand('copy');
-		} catch (_) {
-			return false;
-		}
+		CopyToClipboard(
+			report ?? '',
+			() => {
+				this.setState({ copyState: ReportCopyState.SUCCESS });
+				this.timeout = window.setTimeout(() => {
+					this.setState({ copyState: ReportCopyState.NONE });
+				}, 5000);
+			},
+			() => {
+				this.setState({ copyState: ReportCopyState.FAILED });
+				this.timeout = window.setTimeout(() => {
+					this.setState({ copyState: ReportCopyState.NONE });
+				}, 5000);
+			},
+		);
 	}
 }
 

--- a/pandora-client-web/src/components/error/rootErrorBoundary.tsx
+++ b/pandora-client-web/src/components/error/rootErrorBoundary.tsx
@@ -50,6 +50,8 @@ export class RootErrorBoundary extends PureComponent<ChildrenProps, RootErrorBou
 	}
 
 	public override componentDidCatch(error: Error, errorInfo?: ErrorInfo) {
+		logger.error('Caught error:', error, errorInfo);
+
 		const { report, isTemporaryReport } = this.state;
 		if (!report || isTemporaryReport) {
 			const { debugData } = this.context as DebugContext;

--- a/pandora-client-web/src/components/error/rootErrorBoundary.tsx
+++ b/pandora-client-web/src/components/error/rootErrorBoundary.tsx
@@ -40,6 +40,12 @@ export class RootErrorBoundary extends PureComponent<ChildrenProps, RootErrorBou
 		return <>{ children }</>;
 	}
 
+	public static getDerivedStateFromError(error: unknown): Partial<RootErrorBoundaryState> {
+		return {
+			report: BuildErrorReport(error, undefined, undefined),
+		};
+	}
+
 	public override componentDidCatch(error: Error, errorInfo?: ErrorInfo) {
 		const { report } = this.state;
 		if (!report) {

--- a/pandora-client-web/src/graphics/graphicsScene.tsx
+++ b/pandora-client-web/src/graphics/graphicsScene.tsx
@@ -9,6 +9,7 @@ import { GraphicsSceneRendererDirect, GraphicsSceneRendererShared } from './grap
 import classNames from 'classnames';
 import { useGraphicsSettings } from './graphicsSettings';
 import { useTexture } from './useTexture';
+import { LocalErrorBoundary } from '../components/error/localErrorBoundary';
 
 export type GraphicsSceneProps = {
 	viewportConfig?: PixiViewportSetupCallback;
@@ -206,21 +207,22 @@ export function GraphicsScene({
 	sceneOptions?: GraphicsSceneProps;
 	divChildren?: ReactNode;
 } & React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>): ReactElement {
-
 	const { resolution } = useGraphicsSettings();
 
 	const [div, setDiv] = useState<HTMLDivElement | null>(null);
 
 	return (
-		<div className={ classNames({ disabled: resolution <= 0 }, className) } { ...divProps } ref={ setDiv }>
-			{
-				div && resolution > 0 ? (
-					<GraphicsSceneCore { ...sceneOptions } div={ div } resolution={ resolution / 100 }>
-						{ children }
-					</GraphicsSceneCore>
-				) : null
-			}
-			{ divChildren }
-		</div>
+		<LocalErrorBoundary errorOverlayClassName={ className }>
+			<div className={ classNames({ disabled: resolution <= 0 }, className) } { ...divProps } ref={ setDiv }>
+				{
+					div && resolution > 0 ? (
+						<GraphicsSceneCore { ...sceneOptions } div={ div } resolution={ resolution / 100 }>
+							{ children }
+						</GraphicsSceneCore>
+					) : null
+				}
+				{ divChildren }
+			</div>
+		</LocalErrorBoundary>
 	);
 }

--- a/pandora-client-web/src/graphics/graphicsSceneRenderer.tsx
+++ b/pandora-client-web/src/graphics/graphicsSceneRenderer.tsx
@@ -8,6 +8,7 @@ import { ChildrenProps } from '../common/reactTypes';
 import { USER_DEBUG } from '../config/Environment';
 import { DEFAULT_BACKGROUND_COLOR } from './graphicsScene';
 import { CalculationQueue } from '../common/calculationQueue';
+import { LocalErrorBoundary } from '../components/error/localErrorBoundary';
 
 const SHARED_APP_MAX_COUNT = 2;
 
@@ -430,7 +431,7 @@ class GraphicsSceneBackgroundRendererImpl extends React.Component<Omit<GraphicsS
 	}
 }
 
-export function GraphicsSceneBackgroundRenderer({
+function GraphicsSceneBackgroundRendererUnsafe({
 	children,
 	renderArea,
 	resolution,
@@ -457,6 +458,14 @@ export function GraphicsSceneBackgroundRenderer({
 				{ children }
 			</React.StrictMode>
 		</ContextBridge>
+	);
+}
+
+export function GraphicsSceneBackgroundRenderer(props: GraphicsSceneBackgroundRendererProps): ReactElement {
+	return (
+		<LocalErrorBoundary>
+			<GraphicsSceneBackgroundRendererUnsafe { ...props } />
+		</LocalErrorBoundary>
 	);
 }
 

--- a/pandora-client-web/src/graphics/graphicsSceneRenderer.tsx
+++ b/pandora-client-web/src/graphics/graphicsSceneRenderer.tsx
@@ -8,6 +8,8 @@ import { ChildrenProps } from '../common/reactTypes';
 import { USER_DEBUG } from '../config/Environment';
 import { DEFAULT_BACKGROUND_COLOR } from './graphicsScene';
 import { CalculationQueue } from '../common/calculationQueue';
+import { ForwardingErrorBoundary } from '../components/error/forwardingErrorBoundary';
+import { useErrorHandler } from '../common/useErrorHandler';
 import { LocalErrorBoundary } from '../components/error/localErrorBoundary';
 
 const SHARED_APP_MAX_COUNT = 2;
@@ -48,6 +50,8 @@ export function GraphicsSceneRendererDirect({
 		resolution,
 	}), [resolution]);
 
+	const errorHandler = useErrorHandler();
+
 	return (
 		<ContextBridge contexts={ forwardContexts } render={ (c) => (
 			<Stage
@@ -57,7 +61,9 @@ export function GraphicsSceneRendererDirect({
 				raf={ false }
 				renderOnComponentChange={ true }
 			>
-				{ c }
+				<ForwardingErrorBoundary errorHandler={ errorHandler }>
+					{ c }
+				</ForwardingErrorBoundary>
 			</Stage>
 		) }>
 			<React.StrictMode>
@@ -223,6 +229,8 @@ export function GraphicsSceneRendererShared({
 	container,
 	forwardContexts = [],
 }: GraphicsSceneRendererProps): ReactElement {
+	const errorHandler = useErrorHandler();
+
 	return (
 		<ContextBridge contexts={ forwardContexts } render={ (c) => (
 			<GraphicsSceneRendererSharedImpl
@@ -231,7 +239,9 @@ export function GraphicsSceneRendererShared({
 				onUnmount={ onUnmount }
 				container={ container }
 			>
-				{ c }
+				<ForwardingErrorBoundary errorHandler={ errorHandler }>
+					{ c }
+				</ForwardingErrorBoundary>
 			</GraphicsSceneRendererSharedImpl>
 		) }>
 			<React.StrictMode>
@@ -441,6 +451,8 @@ function GraphicsSceneBackgroundRendererUnsafe({
 	onUnmount,
 	forwardContexts = [],
 }: GraphicsSceneBackgroundRendererProps): ReactElement {
+	const errorHandler = useErrorHandler();
+
 	return (
 		<ContextBridge contexts={ forwardContexts } render={ (c) => (
 			<GraphicsSceneBackgroundRendererImpl
@@ -451,7 +463,9 @@ function GraphicsSceneBackgroundRendererUnsafe({
 				onMount={ onMount }
 				onUnmount={ onUnmount }
 			>
-				{ c }
+				<ForwardingErrorBoundary errorHandler={ errorHandler }>
+					{ c }
+				</ForwardingErrorBoundary>
 			</GraphicsSceneBackgroundRendererImpl>
 		) }>
 			<React.StrictMode>


### PR DESCRIPTION
This PR adds various error handling to the client so not all errors make it go nuclear anymore, namely:
- Adds "local" error boundary that shows placeholder element with ability to open the error report
- Adds "forwarding" error boundary that shows nothing and calls a callback when error happens (used to get errors out of Pixi's fiber into DOM context)
- Wraps all tabs in a local error boundary automatically
- Wraps all graphic scenes in a local error boundary
- Forwards errors from Pixi's fiber into the outer one