### PR TITLE
[FEATURE] Allow specifying multiple URLs for server connection

### DIFF
--- a/pandora-client-web/src/assets/assetManager.ts
+++ b/pandora-client-web/src/assets/assetManager.ts
@@ -3,6 +3,7 @@ import { GraphicsManagerInstance, GraphicsManager } from './graphicsManager';
 import { URLGraphicsLoader } from './graphicsLoader';
 import { Observable, useObservable } from '../observable';
 import { Immutable } from 'immer';
+import { ConfigServerIndex } from '../config/searchArgs';
 
 const logger = GetLogger('AssetManager');
 
@@ -47,7 +48,8 @@ export function LoadAssetDefinitions(definitionsHash: string, data: Immutable<As
 		return;
 
 	lastGraphicsHash = data.graphicsId;
-	assetsSource = source;
+	const assetsSourceOptions = source.split(';').map((a) => a.trim());
+	assetsSource = assetsSourceOptions[ConfigServerIndex % assetsSourceOptions.length];
 
 	loader ??= new URLGraphicsLoader(source);
 	loader.loadTextFile(`graphics_${lastGraphicsHash}.json`).then((json) => {

--- a/pandora-client-web/src/assets/assetManager.ts
+++ b/pandora-client-web/src/assets/assetManager.ts
@@ -49,7 +49,7 @@ export function LoadAssetDefinitions(definitionsHash: string, data: Immutable<As
 
 	lastGraphicsHash = data.graphicsId;
 	const assetsSourceOptions = source.split(';').map((a) => a.trim());
-	assetsSource = assetsSourceOptions[ConfigServerIndex % assetsSourceOptions.length];
+	assetsSource = assetsSourceOptions[ConfigServerIndex.value % assetsSourceOptions.length];
 
 	loader ??= new URLGraphicsLoader(source);
 	loader.loadTextFile(`graphics_${lastGraphicsHash}.json`).then((json) => {

--- a/pandora-client-web/src/components/gameContext/directoryConnectorContextProvider.tsx
+++ b/pandora-client-web/src/components/gameContext/directoryConnectorContextProvider.tsx
@@ -18,7 +18,7 @@ let connectionPromise: Promise<DirectoryConnector> | undefined;
 /** Factory function responsible for providing the concrete directory connector implementation to the application */
 function CreateDirectoryConnector(): DirectoryConnector {
 	const directoryAddressOptions = DIRECTORY_ADDRESS.split(';').map((a) => a.trim());
-	const directoryAddress = directoryAddressOptions[ConfigServerIndex];
+	const directoryAddress = directoryAddressOptions[ConfigServerIndex.value];
 
 	if (!directoryAddress) {
 		throw new Error('Unable to create directory connector: missing DIRECTORY_ADDRESS');

--- a/pandora-client-web/src/config/searchArgs.ts
+++ b/pandora-client-web/src/config/searchArgs.ts
@@ -1,8 +1,13 @@
-import { LogLevel } from 'pandora-common';
+import { GetLogger, LogLevel } from 'pandora-common';
 import { USER_DEBUG } from './Environment';
 
 /** Log level to use for logging to console, set by combination of build mode and URL arguments */
 export let ConfigLogLevel: LogLevel = USER_DEBUG ? LogLevel.VERBOSE : LogLevel.WARNING;
+
+/** Server index to use, set by URL arguments */
+export let ConfigServerIndex: number = 0;
+
+const logger = GetLogger('SearchArgs');
 
 export function LoadSearchArgs(): void {
 	const search = new URLSearchParams(window.location.search);
@@ -34,10 +39,22 @@ export function LoadSearchArgs(): void {
 			default: {
 				const parsed = parseInt(logLevel);
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
-				if (parsed >= LogLevel.FATAL && parsed <= LogLevel.DEBUG)
+				if (parsed >= LogLevel.FATAL && parsed <= LogLevel.DEBUG) {
 					ConfigLogLevel = parsed;
+				} else {
+					logger.warning('Log level has invalid value', logLevel);
+				}
 				break;
 			}
+		}
+	}
+
+	if (search.has('serverindex')) {
+		const serverIndex = search.get('serverindex')?.trim() || '';
+		if (/^[0-9]+$/.test(serverIndex)) {
+			ConfigServerIndex = parseInt(serverIndex, 10);
+		} else {
+			logger.warning('Server index has invalid value', serverIndex);
 		}
 	}
 }

--- a/pandora-client-web/src/config/searchArgs.ts
+++ b/pandora-client-web/src/config/searchArgs.ts
@@ -1,0 +1,43 @@
+import { LogLevel } from 'pandora-common';
+import { USER_DEBUG } from './Environment';
+
+/** Log level to use for logging to console, set by combination of build mode and URL arguments */
+export let ConfigLogLevel: LogLevel = USER_DEBUG ? LogLevel.VERBOSE : LogLevel.WARNING;
+
+export function LoadSearchArgs(): void {
+	const search = new URLSearchParams(window.location.search);
+
+	if (search.has('loglevel')) {
+		const logLevel = search.get('loglevel')?.trim() || '';
+		switch (logLevel.toLowerCase()) {
+			case 'debug':
+				ConfigLogLevel = LogLevel.DEBUG;
+				break;
+			case 'verbose':
+				ConfigLogLevel = LogLevel.VERBOSE;
+				break;
+			case 'info':
+				ConfigLogLevel = LogLevel.INFO;
+				break;
+			case 'alert':
+				ConfigLogLevel = LogLevel.ALERT;
+				break;
+			case 'warning':
+				ConfigLogLevel = LogLevel.WARNING;
+				break;
+			case 'error':
+				ConfigLogLevel = LogLevel.ERROR;
+				break;
+			case 'fatal':
+				ConfigLogLevel = LogLevel.FATAL;
+				break;
+			default: {
+				const parsed = parseInt(logLevel);
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
+				if (parsed >= LogLevel.FATAL && parsed <= LogLevel.DEBUG)
+					ConfigLogLevel = parsed;
+				break;
+			}
+		}
+	}
+}

--- a/pandora-client-web/src/editor/index.tsx
+++ b/pandora-client-web/src/editor/index.tsx
@@ -16,6 +16,7 @@ import { EulaGate } from '../components/Eula';
 import { EditorWardrobeContextProvider } from './components/wardrobe/wardrobe';
 import { AssetManagerEditor } from './assets/assetManager';
 import { ConfigurePixiSettings } from '../graphics/pixiSettings';
+import { LoadSearchArgs } from '../config/searchArgs';
 
 const logger = GetLogger('init');
 
@@ -27,6 +28,7 @@ Start().catch((error) => {
  * Starts the application.
  */
 async function Start(): Promise<void> {
+	LoadSearchArgs();
 	SetupLogging();
 	ConfigurePixiSettings();
 	logger.info('Starting...');

--- a/pandora-client-web/src/index.tsx
+++ b/pandora-client-web/src/index.tsx
@@ -64,5 +64,5 @@ function Start(): void {
  * Configures logging for the application.
  */
 function SetupLogging(): void {
-	SetConsoleOutput(ConfigLogLevel);
+	SetConsoleOutput(ConfigLogLevel.value);
 }

--- a/pandora-client-web/src/index.tsx
+++ b/pandora-client-web/src/index.tsx
@@ -1,4 +1,4 @@
-import { GetLogger, LogLevel, SetConsoleOutput } from 'pandora-common';
+import { GetLogger, SetConsoleOutput } from 'pandora-common';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
@@ -14,6 +14,7 @@ import { PandoraRoutes } from './routing/Routes';
 import { Dialogs } from './components/dialog/dialog';
 import { HoverElementsPortal } from './components/hoverElement/hoverElement';
 import { ConfigurePixiSettings } from './graphics/pixiSettings';
+import { ConfigLogLevel, LoadSearchArgs } from './config/searchArgs';
 
 const logger = GetLogger('init');
 
@@ -27,6 +28,7 @@ try {
  * Starts the application.
  */
 function Start(): void {
+	LoadSearchArgs();
 	SetupLogging();
 	ConfigurePixiSettings();
 	logger.info('Starting...');
@@ -62,40 +64,5 @@ function Start(): void {
  * Configures logging for the application.
  */
 function SetupLogging(): void {
-	let level = USER_DEBUG ? LogLevel.VERBOSE : LogLevel.WARNING;
-	const search = new URLSearchParams(window.location.search);
-	if (search.has('loglevel')) {
-		const logLevel = search.get('loglevel') || '';
-		switch (logLevel.toLowerCase()) {
-			case 'debug':
-				level = LogLevel.DEBUG;
-				break;
-			case 'verbose':
-				level = LogLevel.VERBOSE;
-				break;
-			case 'info':
-				level = LogLevel.INFO;
-				break;
-			case 'alert':
-				level = LogLevel.ALERT;
-				break;
-			case 'warning':
-				level = LogLevel.WARNING;
-				break;
-			case 'error':
-				level = LogLevel.ERROR;
-				break;
-			case 'fatal':
-				level = LogLevel.FATAL;
-				break;
-			default: {
-				const parsed = parseInt(logLevel);
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
-				if (parsed >= LogLevel.FATAL && parsed <= LogLevel.DEBUG)
-					level = parsed;
-				break;
-			}
-		}
-	}
-	SetConsoleOutput(level);
+	SetConsoleOutput(ConfigLogLevel);
 }

--- a/pandora-client-web/src/networking/socketio_shard_connector.ts
+++ b/pandora-client-web/src/networking/socketio_shard_connector.ts
@@ -38,7 +38,7 @@ export const LastSelectedCharacter = BrowserStorage.createSession<CharacterId | 
 function CreateConnection({ publicURL, secret, characterId }: IDirectoryCharacterConnectionInfo): Socket {
 	// Find which public URL we should actually use
 	const publicURLOptions = publicURL.split(';').map((a) => a.trim());
-	publicURL = publicURLOptions[ConfigServerIndex % publicURLOptions.length];
+	publicURL = publicURLOptions[ConfigServerIndex.value % publicURLOptions.length];
 
 	// Create the connection without connecting
 	return connect(publicURL, {

--- a/pandora-client-web/src/networking/socketio_shard_connector.ts
+++ b/pandora-client-web/src/networking/socketio_shard_connector.ts
@@ -22,6 +22,7 @@ import { GameState } from '../components/gameContext/gameStateContextProvider';
 import { Observable, ReadonlyObservable } from '../observable';
 import { PersistentToast } from '../persistentToast';
 import { ShardConnector, ShardConnectionState } from './shardConnector';
+import { ConfigServerIndex } from '../config/searchArgs';
 
 const logger = GetLogger('ShardConn');
 
@@ -35,6 +36,10 @@ export class ShardChangeEventEmitter extends TypedEventEmitter<Record<IShardClie
 export const LastSelectedCharacter = BrowserStorage.createSession<CharacterId | undefined>('lastSelectedCharacter', undefined, CharacterIdSchema.optional());
 
 function CreateConnection({ publicURL, secret, characterId }: IDirectoryCharacterConnectionInfo): Socket {
+	// Find which public URL we should actually use
+	const publicURLOptions = publicURL.split(';').map((a) => a.trim());
+	publicURL = publicURLOptions[ConfigServerIndex % publicURLOptions.length];
+
 	// Create the connection without connecting
 	return connect(publicURL, {
 		autoConnect: false,

--- a/pandora-server-shard/src/networking/connection_client.ts
+++ b/pandora-server-shard/src/networking/connection_client.ts
@@ -63,7 +63,7 @@ export class ClientConnection extends IncomingConnection<IShardClient, IClientSh
 			space: this.character.getOrLoadSpace().getLoadData(),
 			assetsDefinition: assetManager.rawData,
 			assetsDefinitionHash: assetManager.definitionsHash,
-			assetsSource: ASSETS_SOURCE || (SERVER_PUBLIC_ADDRESS + '/assets/'),
+			assetsSource: ASSETS_SOURCE || (SERVER_PUBLIC_ADDRESS.split(';').map((addr) => addr.trim() + '/assets/').join(';')),
 		});
 	}
 


### PR DESCRIPTION
Adds ability to specify multiple URLs for server connections or asset sources. This is to support fallback URLs if Cloudflare is having a bad day (which seems to be fairly often recently). There is no automatic failover mechanism - the index of server/assets url needs to be specified via URL search argument, such as:
```
https://fallback.project-pandora.com/?serverindex=1
```
The argument is remembered in session storage so it is not accidentally lost on F5 or similar actions.