### PR TITLE
[FIX] Fix text input autofocus not working on Firefox

### DIFF
--- a/pandora-client-web/src/common/userInteraction/inputAutofocus.ts
+++ b/pandora-client-web/src/common/userInteraction/inputAutofocus.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+
+/**
+ * Utility to focus a desired input if there is no input focused when user starts writing on the keyboard
+ * @param ref - The input to focus
+ */
+export function useInputAutofocus(ref: React.RefObject<HTMLTextAreaElement | HTMLInputElement>): void {
+	useEffect(() => {
+		const keyPressHandler = (ev: KeyboardEvent) => {
+			if (
+				ref.current &&
+				// Only if no other input is selected
+				(!document.activeElement || !(document.activeElement instanceof HTMLInputElement || document.activeElement instanceof HTMLTextAreaElement)) &&
+				// Only if this isn't a special key or key combo
+				!ev.ctrlKey &&
+				!ev.metaKey &&
+				!ev.altKey &&
+				ev.key.length === 1
+			) {
+				ref.current.focus();
+			}
+		};
+		// Use `keydown` event, because the keyup is important - it needs to have target element focused already when it fires
+		window.addEventListener('keydown', keyPressHandler, { capture: true });
+		return () => {
+			window.removeEventListener('keydown', keyPressHandler, { capture: true });
+		};
+	}, [ref]);
+}

--- a/pandora-client-web/src/components/directMessage/directMessage.tsx
+++ b/pandora-client-web/src/components/directMessage/directMessage.tsx
@@ -24,8 +24,7 @@ export function DirectMessage({ accountId }: { accountId: number; }): ReactEleme
 	const ref = React.useRef<HTMLTextAreaElement>(null);
 	const [autocompleteHint, setAutocompleteHint] = React.useState<AutocompleteDisplayData | null>(null);
 
-	const ctx = React.useMemo<IChatInputHandler>(() => ({
-		focus: () => ref.current?.focus(),
+	const ctx = React.useMemo((): IChatInputHandler => ({
 		setValue: (value: string) => {
 			if (ref.current) {
 				ref.current.value = value;

--- a/pandora-client-web/src/components/directMessage/directMessage.tsx
+++ b/pandora-client-web/src/components/directMessage/directMessage.tsx
@@ -19,6 +19,7 @@ import { useShardConnector } from '../gameContext/shardConnectorContextProvider'
 import { useGameStateOptional } from '../gameContext/gameStateContextProvider';
 import { useNavigate } from 'react-router';
 import { AutocompleteDisplayData, COMMAND_KEY, CommandAutocomplete, CommandAutocompleteCycle, ICommandInvokeContext, RunCommand } from '../../ui/components/chat/commandsProcessor';
+import { useInputAutofocus } from '../../common/userInteraction/inputAutofocus';
 
 export function DirectMessage({ accountId }: { accountId: number; }): ReactElement {
 	const ref = React.useRef<HTMLTextAreaElement>(null);
@@ -236,9 +237,7 @@ function DirectChannelInputImpl(_: unknown, ref: React.ForwardedRef<HTMLTextArea
 	});
 
 	const actualRef = useTextFormattingOnKeyboardEvent(ref);
-	React.useEffect(() => {
-		actualRef.current?.focus();
-	}, [actualRef, channel.account]);
+	useInputAutofocus(actualRef);
 
 	if (!channel.account) {
 		return null;

--- a/pandora-client-web/src/components/wardrobe/views/wardrobeAssetView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobeAssetView.tsx
@@ -25,6 +25,7 @@ import { ActionWarning, AttributeButton, InventoryAssetPreview, WardrobeActionBu
 import { useStaggeredAppearanceActionResult } from '../wardrobeCheckQueue';
 import { useCharacterDataOptional } from '../../../character/character';
 import { Immutable } from 'immer';
+import { useInputAutofocus } from '../../../common/userInteraction/inputAutofocus';
 
 export function InventoryAssetView({ className, title, children, assets, container, attributesFilterOptions, spawnStyle }: {
 	className?: string;
@@ -126,28 +127,7 @@ export function WardrobeAssetList({ className, title, children, overlay, assets,
 	}, [attribute, attributesFilterOptions]);
 
 	const filterInput = useRef<HTMLInputElement>(null);
-
-	useEffect(() => {
-		// Handler to autofocus search
-		const keyPressHandler = (ev: KeyboardEvent) => {
-			if (
-				filterInput.current &&
-				// Only if no other input is selected
-				(!document.activeElement || !(document.activeElement instanceof HTMLInputElement)) &&
-				// Only if this isn't a special key or key combo
-				!ev.ctrlKey &&
-				!ev.metaKey &&
-				!ev.altKey &&
-				ev.key.length === 1
-			) {
-				filterInput.current.focus();
-			}
-		};
-		window.addEventListener('keypress', keyPressHandler);
-		return () => {
-			window.removeEventListener('keypress', keyPressHandler);
-		};
-	}, []);
+	useInputAutofocus(filterInput);
 
 	// Clear filter when looking from different focus
 	useEffect(() => {

--- a/pandora-client-web/src/components/wardrobe/wardrobeItemPreferences.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobeItemPreferences.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React, { ReactElement, createContext, useCallback, useContext, useEffect, useId, useMemo, useRef, useState } from 'react';
+import React, { ReactElement, createContext, useCallback, useContext, useId, useMemo, useRef, useState } from 'react';
 import { Tab, TabContainer } from '../common/tabs/tabs';
 import { useAssetManager } from '../../assets/assetManager';
 import { WardrobeAssetList, useAssetPreference, useAssetPreferenceResolver, useAssetPreferences } from './views/wardrobeAssetView';
@@ -16,6 +16,7 @@ import { Column, Row } from '../common/container/container';
 import { Select } from '../common/select/select';
 import { useBrowserStorage } from '../../browserStorage';
 import { z } from 'zod';
+import { useInputAutofocus } from '../../common/userInteraction/inputAutofocus';
 
 type ItemPreferencesFocus = {
 	type: 'none';
@@ -140,28 +141,7 @@ export function WardrobePreferencesAttributePicker({ title }: {
 	), [assetManager, flt]);
 
 	const filterInput = useRef<HTMLInputElement>(null);
-
-	useEffect(() => {
-		// Handler to autofocus search
-		const keyPressHandler = (ev: KeyboardEvent) => {
-			if (
-				filterInput.current &&
-				// Only if no other input is selected
-				(!document.activeElement || !(document.activeElement instanceof HTMLInputElement)) &&
-				// Only if this isn't a special key or key combo
-				!ev.ctrlKey &&
-				!ev.metaKey &&
-				!ev.altKey &&
-				ev.key.length === 1
-			) {
-				filterInput.current.focus();
-			}
-		};
-		window.addEventListener('keypress', keyPressHandler);
-		return () => {
-			window.removeEventListener('keypress', keyPressHandler);
-		};
-	}, []);
+	useInputAutofocus(filterInput);
 
 	return (
 		<div className='inventoryView'>

--- a/pandora-client-web/src/ui/components/chat/chatInput.tsx
+++ b/pandora-client-web/src/ui/components/chat/chatInput.tsx
@@ -22,6 +22,7 @@ import { useNavigate } from 'react-router';
 import { useNullableObservable } from '../../../observable';
 import { useTextFormattingOnKeyboardEvent } from '../../../common/useTextFormattingOnKeyboardEvent';
 import { Scrollable } from '../../../components/common/scrollbar/scrollbar';
+import { useInputAutofocus } from '../../../common/userInteraction/inputAutofocus';
 
 type Editing = {
 	target: number;
@@ -29,7 +30,6 @@ type Editing = {
 };
 
 export type IChatInputHandler = {
-	focus: () => void;
 	setValue: (value: string) => void;
 	target: Character | null;
 	setTarget: (target: CharacterId | null) => void;
@@ -115,28 +115,9 @@ export function ChatInputContextProvider({ children }: { children: React.ReactNo
 	});
 
 	// Handler to autofocus chat input
-	useEffect(() => {
-		const keyPressHandler = (ev: KeyboardEvent) => {
-			if (
-				ref.current &&
-				// Only if no other input is selected
-				(!document.activeElement || !(document.activeElement instanceof HTMLInputElement || document.activeElement instanceof HTMLTextAreaElement)) &&
-				// Only if this isn't a special key or key combo
-				!ev.ctrlKey &&
-				!ev.metaKey &&
-				!ev.altKey &&
-				ev.key.length === 1
-			) {
-				ref.current.focus();
-			}
-		};
-		window.addEventListener('keypress', keyPressHandler);
-		return () => {
-			window.removeEventListener('keypress', keyPressHandler);
-		};
-	}, []);
+	useInputAutofocus(ref);
 
-	const context = useMemo<IChatInputHandler>(() => {
+	const context = useMemo((): IChatInputHandler => {
 		const newSetTarget = (t: CharacterId | null) => {
 			if (t === playerId) {
 				return;
@@ -144,7 +125,6 @@ export function ChatInputContextProvider({ children }: { children: React.ReactNo
 			setTarget(!t ? null : characters?.find((c) => c.data.id === t) ?? null);
 		};
 		return {
-			focus: () => ref.current?.focus(),
 			setValue: (value: string) => {
 				if (ref.current) {
 					ref.current.value = value;

--- a/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.tsx
+++ b/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.tsx
@@ -50,6 +50,7 @@ import { useAsyncEvent } from '../../../common/useEvent';
 import { useCurrentTime } from '../../../common/useCurrentTime';
 import { toast } from 'react-toastify';
 import { CopyToClipboard } from '../../../common/clipboard';
+import { useInputAutofocus } from '../../../common/userInteraction/inputAutofocus';
 
 const IsValidName = ZodMatcher(SpaceBaseInfoSchema.shape.name);
 const IsValidDescription = ZodMatcher(SpaceBaseInfoSchema.shape.description);
@@ -743,29 +744,9 @@ function BackgroundSelectDialog({ hide, current, select }: {
 			.filter((b) => filterParts.every((f) => b.name.toLowerCase().includes(f)))
 			.sort(backgroundSortOrder);
 	}, [selection, nameFilter, backgroundSortOrder]);
-	const nameFilterInput = useRef<HTMLInputElement>(null);
 
-	useEffect(() => {
-		// Handler to autofocus search
-		const keyPressHandler = (ev: KeyboardEvent) => {
-			if (
-				nameFilterInput.current &&
-				// Only if no other input is selected
-				(!document.activeElement || !(document.activeElement instanceof HTMLInputElement)) &&
-				// Only if this isn't a special key or key combo
-				!ev.ctrlKey &&
-				!ev.metaKey &&
-				!ev.altKey &&
-				ev.key.length === 1
-			) {
-				nameFilterInput.current.focus();
-			}
-		};
-		window.addEventListener('keypress', keyPressHandler);
-		return () => {
-			window.removeEventListener('keypress', keyPressHandler);
-		};
-	}, []);
+	const nameFilterInput = useRef<HTMLInputElement>(null);
+	useInputAutofocus(nameFilterInput);
 
 	return (
 		<ModalDialog position='top'>


### PR DESCRIPTION
Firefox needs the input to be focused before `keypress` fires. This PR mainly changes the hook to work on `keydown` and unifies the behavior for all such inputs.