### PR TITLE
[REFACTOR] Simplify character autoconnect logic

### DIFF
--- a/pandora-client-web/src/networking/directoryConnector.ts
+++ b/pandora-client-web/src/networking/directoryConnector.ts
@@ -47,16 +47,8 @@ export interface DirectoryConnector extends IConnectionBase<IClientDirectory> {
 	/** Current auth token or undefined if not logged in */
 	readonly authToken: ReadonlyObservable<AuthToken | undefined>;
 
-	/**
-	 * Character auto connection state
-	 *
-	 * - `none`: no character will be auto connected
-	 * - `initial`: auto connection may be attempted
-	 * - `loading`: loading character infos
-	 * - `connecting`: attempting to connect to character
-	 * - `connected`: connected to character
-	 *  */
-	readonly characterAutoConnectState: ReadonlyObservable<'none' | 'initial' | 'loading' | 'connecting' | 'connected'>;
+	/** The Id of the last selected character for this session. On reconnect this character will be re-selected. */
+	readonly lastSelectedCharacter: ReadonlyObservable<CharacterId | undefined>;
 
 	/** Event emitter for directory change events */
 	readonly changeEventEmitter: TypedEventEmitter<Record<IDirectoryClientChangeEvents, true>>;

--- a/pandora-client-web/test/mocks/networking/mockDirectoryConnector.ts
+++ b/pandora-client-web/test/mocks/networking/mockDirectoryConnector.ts
@@ -24,10 +24,10 @@ export class TestEventEmitter<T extends TypedEvent> extends TypedEventEmitter<T>
 /** Mock directory connector implementation for testing */
 export class MockDirectoryConnector implements DirectoryConnector {
 	public readonly authToken = new Observable<AuthToken | undefined>(undefined);
+	public readonly lastSelectedCharacter = new Observable<CharacterId | undefined>(undefined);
 	public readonly currentAccount = new Observable<IDirectoryAccountInfo | null>(null);
 	public readonly directoryStatus = new Observable<IDirectoryStatus>(CreateDefaultDirectoryStatus());
 	public readonly state = new Observable<DirectoryConnectionState>(DirectoryConnectionState.NONE);
-	public readonly characterAutoConnectState = new Observable<'initial'>('initial');
 
 	public readonly changeEventEmitter = new TestEventEmitter<Record<IDirectoryClientChangeEvents, true>>();
 	public readonly connectionStateEventEmitter = new TestEventEmitter<Pick<IDirectoryClientArgument, 'connectionState'>>();

--- a/pandora-server-directory/src/account/character.ts
+++ b/pandora-server-directory/src/account/character.ts
@@ -310,9 +310,14 @@ export class Character {
 			await this.currentShard?.update('characters');
 		}
 
-		connection.setCharacter(this);
-		connection.sendConnectionStateUpdate();
-		Assert(this.assignedClient === connection);
+		// Race-condition check - check that the connection is still valid and logged in
+		if (connection.isConnected() && connection.account === this.baseInfo.account) {
+			// If yes, assign this character to the connection
+			// If no, then continue anyway (the character will later timeout on shard and disconnect automatically)
+			connection.setCharacter(this);
+			connection.sendConnectionStateUpdate();
+			Assert(this.assignedClient === connection);
+		}
 
 		// Perform action specific to the current assignment
 		if (this.assignment == null) {

--- a/pandora-server-directory/src/networking/manager_client.ts
+++ b/pandora-server-directory/src/networking/manager_client.ts
@@ -359,8 +359,6 @@ export const ConnectionManagerClient = new class ConnectionManagerClient impleme
 			throw new BadMessageError();
 
 		await connection.character?.disconnect();
-		connection.setCharacter(null);
-		connection.sendConnectionStateUpdate();
 	}
 
 	private handleShardInfo(_: IClientDirectoryArgument['shardInfo'], _connection: ClientConnection): IClientDirectoryResult['shardInfo'] {


### PR DESCRIPTION
This PR:
- Fixes problem that the screen could get stuck randomly
- Fixes problem that the screen would get stuck if another client took over the character
- Fixes problem that the first client would try to take back character taken over by different client on refresh
- Fixes a race condition in the directory server around client disconnecting in the middle of character connection

To do that it:
- Removes the explicit connection state; the dialog instead uses state collected from directory and shard connectors to display it
- Removes listing of characters; the id is simply used to try to connect. This removes the behavior of auto-selecting a character in-creation if it is the only character the player has, but I don't think that is a problem.
- Clears the last character id if the connect request would fail