### PR TITLE
[CHANGE] space config UI and wiki updates

### DIFF
--- a/pandora-client-web/src/components/wiki/pages/greeting.tsx
+++ b/pandora-client-web/src/components/wiki/pages/greeting.tsx
@@ -36,7 +36,7 @@ export function WikiGreeting(): ReactElement {
 					generally, before anything can happen to you. Moreover, due to the security of restraints in Pandora, stricter ones such as
 					password locks are set to be unavailable to other characters until you change these default item limits.<br />
 					<br />
-					Second important mechanism is for when communication should fail or someone not respecting your safeword. For such a case there are two safe modes,
+					Second important mechanism is for when communication should fail or someone is not respecting your safeword. For such a case there are two safe modes,
 					which you can enter under the "Room"-tab via a button next to your character name: Timeout and safemode.
 					Both modes prevent interactions in both ways while active. Do note, however, that we consider safemode a last-resort option for emergencies.
 					It comes with a cooldown period that simulates stopping the play after a safeword usage to recover and be safe.<br />

--- a/pandora-client-web/src/components/wiki/pages/history.tsx
+++ b/pandora-client-web/src/components/wiki/pages/history.tsx
@@ -27,13 +27,15 @@ export function WikiHistory(): ReactElement {
 			<h4>Does Pandora want to replace BC?</h4>
 
 			<p>
-				Not at all! Pandora has a different vision, wanting to be a secure, consensual roleplaying platform that focuses on text-heavy interactions.
+				Not at all! It is even likely that our vision for Pandora is not attractive enough to a significant part of today's BC community.
+				We want Pandora to be a secure, consensual roleplaying platform that focuses on text-heavy interactions.
 				BC was a bit like that in its first year before more and more game-like features were added that changed the focus of public rooms and the
 				interests of parts of the community slowly. Also the fact that console-usage/scripts/mods/extensions in BC are so all-powerful has certain
 				drawbacks and is exploited quite often.<br />
-				In a way, Pandora will offer an improved "classic" experience, focusing on roleplaying and clear house rules. We will actively remove/hinder
-				ways with which users can cheat or gain feature advantages that others do not have. Instead of embracing inofficial scripts/mods that can pose
-				a security risk to Pandora's users, we encourage developers with feature ideas to get in touch with us about contributing to Pandora directly.
+				In a way, Pandora is offering an improved "classic" experience, focusing on roleplaying and clear house rules. We will actively remove/hinder
+				ways with which users can cheat or gain unexpected feature advantages. Instead of embracing inofficial scripts/mods that can pose
+				a security risk to Pandora's users and will lead to a fragmented user experience, we encourage developers with feature ideas to get in
+				touch with us about contributing to Pandora directly.
 			</p>
 
 			<h4>What issues with BC were seen?</h4>
@@ -42,8 +44,9 @@ export function WikiHistory(): ReactElement {
 				<ul>
 					<li>Technical quality of BC: The source code of BC was not of good quality and while it improved quite a bit over the years (to a large part
 						thanks to the same people who founded Pandora), it is essentially still something held together by many band aids and compromises.
-						Contributing to it is not exactly pleasant and beginner friendly. Starting from scratch seemed like a more sensible decision than
-						trying to improve it further.
+						Since there were unsolvable roadblocks on the way to change that, starting from scratch seemed like the better decision compared to
+						trying to clean up constantly, especially as there are no suitable quality standards and checks for new contributions, making this topic
+						an endless struggle.
 					</li>
 					<li>BC project management: The desire for a different project management approach and development process was strong.</li>
 					<li>BC server architecture: It is singular and cannot scale beyond a certain number of users, where lag and disconnects slowly get worse.

--- a/pandora-client-web/src/components/wiki/pages/intro.tsx
+++ b/pandora-client-web/src/components/wiki/pages/intro.tsx
@@ -8,7 +8,9 @@ export function WikiIntroduction(): ReactElement {
 			<h2>Introduction to Pandora with some quick hints to get you started</h2>
 
 			<p>
-				Pandora's vision is to establish a strict & secure, consensual roleplay platform that focuses on text-heavy interactions.
+				Pandora's vision is to establish a consensual BDSM roleplaying platform that focuses on text-heavy interactions with visual support
+				and meaningfully secure restraining effects. The design focus is to encourage describing scenes textually, with other aspects
+				enhancing the immersion. It is a social chat platform with a focus on kinky roleplaying, rather than a game.
 			</p>
 
 			The following will list some of the existing core features of Pandora.
@@ -162,7 +164,6 @@ export function WikiIntroduction(): ReactElement {
 				<li>Character rules</li>
 				<li>Room templates</li>
 				<li>Key system for locks</li>
-				<li>Movement slowdown effects</li>
 				<li>Visible locks on worn items with different lock designs</li>
 				<li>Reworked UI design with focus on improved usability and design themes</li>
 				<li>More supporting features for roleplaying, for instance a new space role "storyteller" that can orchestrate a prepared roleplay without a physical presence in any room of the space</li>

--- a/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.scss
+++ b/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.scss
@@ -1,11 +1,15 @@
 @import '../../../styles/common';
 
 .spaceConfigurationScreen {
-	width: min(100%, 50em);
+	width: min(100%, 60em);
 	margin: 0 auto;
 
 	&>* {
 		margin-top: 0.5em;
+	}
+
+	.spaceConfigurationScreen-tab {
+		border-top: 2px solid black;
 	}
 
 	.input-container {
@@ -221,7 +225,6 @@
 .permanentInvite {
 	display: block;
 	padding: 10px;
-	font-family: 'Courier New', Courier, monospace;
 
 	.text {
 		display: block;
@@ -230,6 +233,7 @@
 	}
 
 	.invite {
+		font-family: 'Courier New', Courier, monospace;
 		background-color: #ccc;
 		border-radius: 5px;
 		border: 1px solid #ddd;

--- a/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.scss
+++ b/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.scss
@@ -218,8 +218,19 @@
 	}
 }
 
-.spaceInvitesTable td {
-	white-space: nowrap;
+.spaceInvitesTable {
+	&, tr, td, th {
+		border: solid black 1px;
+		border-collapse: collapse;
+	}
+
+	th, td {
+		padding: spacing(small);
+	}
+
+	td {
+		white-space: nowrap;
+	}
 }
 
 .permanentInvite {

--- a/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.tsx
+++ b/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.tsx
@@ -363,7 +363,6 @@ export function SpaceConfiguration({ creation = false }: { creation?: boolean; }
 							</ul>
 						</div>
 						{ canEdit && <Button className='fill-x' onClick={ () => UpdateSpace(directoryConnector, modifiedData, () => navigate('/room')) }>Update space</Button> }
-						{ !canEdit && <Button className='fill-x' onClick={ () => navigate('/room') }>Back</Button> }
 					</div>
 				</Tab>
 				<Tab name='Visitor Management'>
@@ -386,7 +385,6 @@ export function SpaceConfiguration({ creation = false }: { creation?: boolean; }
 						{ canEdit && currentSpaceId != null && <SpaceInvites spaceId={ currentSpaceId } /> }
 						<br />
 						{ canEdit && <Button className='fill-x' onClick={ () => UpdateSpace(directoryConnector, modifiedData, () => navigate('/room')) }>Update space</Button> }
-						{ !canEdit && <Button className='fill-x' onClick={ () => navigate('/room') }>Back</Button> }
 					</div>
 				</Tab>
 				<Tab name='◄ Back' tabClassName='slim' onClick={ () => navigate('/room') } />

--- a/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.tsx
+++ b/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.tsx
@@ -573,7 +573,7 @@ function SpaceInviteExpires({ expires, update }: { expires: number; update: () =
 
 	return (
 		<>
-			{ FormatTimeInterval(expires - now) }
+			{ FormatTimeInterval(expires - now, 'short') }
 		</>
 	);
 }

--- a/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.tsx
+++ b/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.tsx
@@ -51,6 +51,7 @@ import { useCurrentTime } from '../../../common/useCurrentTime';
 import { toast } from 'react-toastify';
 import { CopyToClipboard } from '../../../common/clipboard';
 import { useInputAutofocus } from '../../../common/userInteraction/inputAutofocus';
+import { Tab, TabContainer } from '../../../components/common/tabs/tabs';
 
 const IsValidName = ZodMatcher(SpaceBaseInfoSchema.shape.name);
 const IsValidDescription = ZodMatcher(SpaceBaseInfoSchema.shape.description);
@@ -209,25 +210,13 @@ export function SpaceConfiguration({ creation = false }: { creation?: boolean; }
 					<Button onClick={ () => setModifiedData({ public: !currentConfig.public }) } disabled={ !canEdit } className='fadeDisabled'>{ currentConfig.public ? 'Yes' : 'No' }</Button>
 				</div>
 			</FieldsetToggle>
-			<FieldsetToggle legend='Permissions'>
+			<FieldsetToggle legend='Ownership'>
 				<div className='input-container'>
 					<label>Owners</label>
 					<Row>
 						<NumberListArea className='flex-1' values={ owners } setValues={ () => { /* NOOP */ } } readOnly />
 						{ !creation && currentSpaceInfo != null && currentSpaceId != null && isPlayerOwner ? <SpaceOwnershipRemoval id={ currentSpaceId } name={ currentSpaceInfo.config.name } /> : null }
 					</Row>
-				</div>
-				<div className='input-container'>
-					<label>Admins</label>
-					<NumberListArea values={ currentConfig.admin } setValues={ (admin) => setModifiedData({ admin }) } readOnly={ !canEdit } />
-				</div>
-				<div className='input-container'>
-					<label>Ban list</label>
-					<NumberListArea values={ currentConfig.banned } setValues={ (banned) => setModifiedData({ banned }) } readOnly={ !canEdit } invalid={ invalidBans } />
-				</div>
-				<div className='input-container'>
-					<label>Allow list</label>
-					<NumberListArea values={ currentConfig.allow } setValues={ (allow) => setModifiedData({ allow }) } readOnly={ !canEdit } invalid={ invalidAllow } />
 				</div>
 			</FieldsetToggle>
 			<FieldsetToggle legend='Background'>
@@ -356,30 +345,52 @@ export function SpaceConfiguration({ creation = false }: { creation?: boolean; }
 
 	return (
 		<div className='spaceConfigurationScreen configuration'>
-			<Link to='/room'>◄ Back</Link>
-			{
-				currentSpaceId != null ? (
-					<p>Current space ID: <span className='selectable-all'>{ currentSpaceId }</span></p>
-				) : (
-					<p>Currently in a personal space</p>
-				)
-			}
-			{ configurableElements }
-			<div className='input-container'>
-				<label>Features (cannot be changed after creation)</label>
-				<ul>
-					{
-						SPACE_FEATURES
-							.filter((feature) => currentConfig.features.includes(feature.id))
-							.map((feature) => (
-								<li key={ feature.id }>{ feature.name }</li>
-							))
-					}
-				</ul>
-			</div>
-			{ canEdit && <Button className='fill-x' onClick={ () => UpdateSpace(directoryConnector, modifiedData, () => navigate('/room')) }>Update space</Button> }
-			{ !canEdit && <Button className='fill-x' onClick={ () => navigate('/room') }>Back</Button> }
-			{ canEdit && currentSpaceId != null && <SpaceInvites spaceId={ currentSpaceId } /> }
+			<TabContainer className='flex-1'>
+				<Tab name='General'>
+					<div className='spaceConfigurationScreen-tab'>
+						<br />
+						{ configurableElements }
+						<div className='input-container'>
+							<label>Features (cannot be changed after creation)</label>
+							<ul>
+								{
+									SPACE_FEATURES
+										.filter((feature) => currentConfig.features.includes(feature.id))
+										.map((feature) => (
+											<li key={ feature.id }>{ feature.name }</li>
+										))
+								}
+							</ul>
+						</div>
+						{ canEdit && <Button className='fill-x' onClick={ () => UpdateSpace(directoryConnector, modifiedData, () => navigate('/room')) }>Update space</Button> }
+						{ !canEdit && <Button className='fill-x' onClick={ () => navigate('/room') }>Back</Button> }
+					</div>
+				</Tab>
+				<Tab name='Visitor Management'>
+					<div className='spaceConfigurationScreen-tab'>
+						<br />
+						<FieldsetToggle legend='Permission lists'>
+							<div className='input-container'>
+								<label>Admins</label>
+								<NumberListArea values={ currentConfig.admin } setValues={ (admin) => setModifiedData({ admin }) } readOnly={ !canEdit } />
+							</div>
+							<div className='input-container'>
+								<label>Banned users</label>
+								<NumberListArea values={ currentConfig.banned } setValues={ (banned) => setModifiedData({ banned }) } readOnly={ !canEdit } invalid={ invalidBans } />
+							</div>
+							<div className='input-container'>
+								<label>Allowed users</label>
+								<NumberListArea values={ currentConfig.allow } setValues={ (allow) => setModifiedData({ allow }) } readOnly={ !canEdit } invalid={ invalidAllow } />
+							</div>
+						</FieldsetToggle>
+						{ canEdit && currentSpaceId != null && <SpaceInvites spaceId={ currentSpaceId } /> }
+						<br />
+						{ canEdit && <Button className='fill-x' onClick={ () => UpdateSpace(directoryConnector, modifiedData, () => navigate('/room')) }>Update space</Button> }
+						{ !canEdit && <Button className='fill-x' onClick={ () => navigate('/room') }>Back</Button> }
+					</div>
+				</Tab>
+				<Tab name='◄ Back' tabClassName='slim' onClick={ () => navigate('/room') } />
+			</TabContainer>
 		</div>
 	);
 }
@@ -412,7 +423,7 @@ function SpaceInvites({ spaceId }: { spaceId: SpaceId; }): ReactElement {
 	const addInvite = useCallback((invite: SpaceInvite) => setInvites((inv) => [...inv, invite]), []);
 
 	return (
-		<FieldsetToggle legend='Invites' onChange={ onChange } open={ false }>
+		<FieldsetToggle legend='Invites' onChange={ onChange } open={ true }>
 			<Column gap='medium'>
 				<div onClick={ copyPublic } className='permanentInvite'>
 					<span className='text'>Permanent public invite link:</span>

--- a/pandora-client-web/src/ui/screens/spacesSearch/spacesSearch.tsx
+++ b/pandora-client-web/src/ui/screens/spacesSearch/spacesSearch.tsx
@@ -43,7 +43,7 @@ const TIPS: readonly string[] = [
 	`Every single change in the wardrobe happens instantly and is immediately visible to everyone in the room.`,
 	`Public spaces without an admin online inside are not publicly listed in the spaces search.`,
 	`The character context menu can still be opened from a room item's menu while a character is inside.`,
-	`You do not have to first click into the chat input field to start typing in it.`,
+	`You can start typing a chat message at any time, even without clicking into the text input field first.`,
 ];
 
 export function SpacesSearch(): ReactElement {

--- a/pandora-client-web/src/ui/screens/spacesSearch/spacesSearch.tsx
+++ b/pandora-client-web/src/ui/screens/spacesSearch/spacesSearch.tsx
@@ -43,6 +43,7 @@ const TIPS: readonly string[] = [
 	`Every single change in the wardrobe happens instantly and is immediately visible to everyone in the room.`,
 	`Public spaces without an admin online inside are not publicly listed in the spaces search.`,
 	`The character context menu can still be opened from a room item's menu while a character is inside.`,
+	`You do not have to first click into the chat input field to start typing in it.`,
 ];
 
 export function SpacesSearch(): ReactElement {


### PR DESCRIPTION
Separates the space config view into two tabs:

- General for configuring the space itself
- Visitor Management for for handling permission lists and invites

Also updates the wiki a little bit.