### PR TITLE
[FEATURE] Full database migration

### DIFF
--- a/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.tsx
+++ b/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.tsx
@@ -436,7 +436,6 @@ function SpaceInvites({ spaceId }: { spaceId: SpaceId; }): ReactElement {
 							<th>Limited To Account</th>
 							<th>Limited To Character</th>
 							<th>Expires</th>
-							<th>Bypass Password</th>
 							<th>Actions</th>
 						</tr>
 					</thead>

--- a/pandora-common/src/space/space.ts
+++ b/pandora-common/src/space/space.ts
@@ -5,9 +5,9 @@ import { ROOM_INVENTORY_BUNDLE_DEFAULT } from '../assets';
 import { CharacterId, CharacterIdSchema } from '../character';
 import { AccountId, AccountIdSchema } from '../account/account';
 import { RoomInventoryBundleSchema } from '../assets/state/roomState';
-import { ArrayToRecordKeys } from '../utility';
+import { ArrayToRecordKeys, CloneDeepMutable } from '../utility';
 import { LIMIT_SPACE_DESCRIPTION_LENGTH, LIMIT_SPACE_NAME_LENGTH, LIMIT_SPACE_NAME_PATTERN, LIMIT_SPACE_MAX_CHARACTER_NUMBER } from '../inputLimits';
-import { RoomBackgroundDataSchema } from './room';
+import { DEFAULT_BACKGROUND, RoomBackgroundDataSchema } from './room';
 
 // Fix for pnpm resolution weirdness
 import type { } from '../assets/item/base';
@@ -85,7 +85,7 @@ export const SpaceDirectoryConfigSchema = SpaceBaseInfoSchema.extend({
 	/** Account ids that always allow to enter */
 	allow: AccountIdSchema.array().default([]),
 	/** The ID of the background or custom data */
-	background: z.union([z.string(), RoomBackgroundDataSchema.extend({ image: HexColorStringSchema.catch('#1099bb') })]),
+	background: z.union([z.string(), RoomBackgroundDataSchema.extend({ image: HexColorStringSchema.catch('#1099bb') })]).catch(CloneDeepMutable(DEFAULT_BACKGROUND)),
 });
 export type SpaceDirectoryConfig = z.infer<typeof SpaceDirectoryConfigSchema>;
 

--- a/pandora-server-directory/src/config.ts
+++ b/pandora-server-directory/src/config.ts
@@ -62,6 +62,8 @@ export const EnvParser = CreateEnvParser({
 	DATABASE_URL: z.string().default('mongodb://localhost:27017'),
 	/** Name of the db to connect to */
 	DATABASE_NAME: z.string().default('pandora-test'),
+	/** Database migration strategy. Anything but `disable` is costly and should only be used when there is a need for migration. */
+	DATABASE_MIGRATION: z.enum(['disable', 'dry-run', 'migrate']).default('disable'),
 
 	//#endregion
 


### PR DESCRIPTION
Adds a code for full database migration. This code walks through every single document in all collections and runs it through a supplied Zod schema, updating the document to match (both changed and deleted properties, unlike our current on-the-fly migrations).

The migration is disabled by default and can be activated either in dry-run mode (where the changes are not actually committed to the database) or for actual migration.
These are triggered with env configuration `DATABASE_MIGRATION=dry-run` and `DATABASE_MIGRATION=migrate` respectively.

Note that some collections currently don't have a Zod schema. Those are walked through and ignored. (TODOs have been added)