### PR TITLE
[FIX] Update spaces search progress even after unmount

### DIFF
--- a/pandora-client-web/src/ui/screens/spacesSearch/spacesSearch.tsx
+++ b/pandora-client-web/src/ui/screens/spacesSearch/spacesSearch.tsx
@@ -265,6 +265,7 @@ export function SpaceDetails({ info, hide, invite, redirectBeforeLeave, closeTex
 			}
 		},
 		{
+			updateAfterUnmount: true,
 			errorHandler: (error) => {
 				GetLogger('JoinSpace').warning('Error during space join', error);
 				SpaceJoinProgress.show('error',


### PR DESCRIPTION
This prevents the "Joining space" toast from getting stuck.