### PR TITLE
[FEATURE] Sparse settings

### DIFF
--- a/pandora-client-web/src/components/directMessage/directMessage.tsx
+++ b/pandora-client-web/src/components/directMessage/directMessage.tsx
@@ -9,7 +9,7 @@ import { TOAST_OPTIONS_ERROR } from '../../persistentToast';
 import { RenderChatPart } from '../../ui/components/chat/chatMessages';
 import { Scrollbar } from '../common/scrollbar/scrollbar';
 import { DirectMessageChannelProvider, useDirectMessageChannel } from '../gameContext/directMessageChannelProvieder';
-import { useCurrentAccount, useCurrentAccountSettings, useDirectoryConnector } from '../gameContext/directoryConnectorContextProvider';
+import { useCurrentAccount, useDirectoryConnector, useEffectiveAccountSettings } from '../gameContext/directoryConnectorContextProvider';
 import './directMessage.scss';
 import { useTextFormattingOnKeyboardEvent } from '../../common/useTextFormattingOnKeyboardEvent';
 import classNames from 'classnames';
@@ -59,7 +59,7 @@ export function DirectMessage({ accountId }: { accountId: number; }): ReactEleme
 }
 
 function DirectMessageList(): ReactElement | null {
-	const { interfaceChatroomChatFontSize } = useCurrentAccountSettings();
+	const { interfaceChatroomChatFontSize } = useEffectiveAccountSettings();
 	const channel = useDirectMessageChannel();
 	const channelAccount = channel.account;
 	const messages = useObservable(channel.messages);

--- a/pandora-client-web/src/components/directMessage/directMessage.tsx
+++ b/pandora-client-web/src/components/directMessage/directMessage.tsx
@@ -9,7 +9,7 @@ import { TOAST_OPTIONS_ERROR } from '../../persistentToast';
 import { RenderChatPart } from '../../ui/components/chat/chatMessages';
 import { Scrollbar } from '../common/scrollbar/scrollbar';
 import { DirectMessageChannelProvider, useDirectMessageChannel } from '../gameContext/directMessageChannelProvieder';
-import { useCurrentAccount, useDirectoryConnector, useEffectiveAccountSettings } from '../gameContext/directoryConnectorContextProvider';
+import { useCurrentAccount, useDirectoryConnector, useAccountSettings } from '../gameContext/directoryConnectorContextProvider';
 import './directMessage.scss';
 import { useTextFormattingOnKeyboardEvent } from '../../common/useTextFormattingOnKeyboardEvent';
 import classNames from 'classnames';
@@ -59,7 +59,7 @@ export function DirectMessage({ accountId }: { accountId: number; }): ReactEleme
 }
 
 function DirectMessageList(): ReactElement | null {
-	const { interfaceChatroomChatFontSize } = useEffectiveAccountSettings();
+	const { interfaceChatroomChatFontSize } = useAccountSettings();
 	const channel = useDirectMessageChannel();
 	const channelAccount = channel.account;
 	const messages = useObservable(channel.messages);

--- a/pandora-client-web/src/components/gameContext/directoryConnectorContextProvider.tsx
+++ b/pandora-client-web/src/components/gameContext/directoryConnectorContextProvider.tsx
@@ -1,18 +1,28 @@
+import { Immutable } from 'immer';
 import { noop } from 'lodash';
-import { ACCOUNT_SETTINGS_DEFAULT, AssertNever, GetLogger, IDirectoryAccountInfo, IDirectoryAccountSettings, IDirectoryClientChangeEvents, SecondFactorData, SecondFactorResponse, SecondFactorType } from 'pandora-common';
-import React, { createContext, ReactElement, useContext, useEffect, useRef } from 'react';
+import {
+	ACCOUNT_SETTINGS_DEFAULT,
+	AssertNever,
+	GetLogger,
+	IDirectoryAccountInfo,
+	IDirectoryClientChangeEvents,
+	SecondFactorData,
+	SecondFactorResponse,
+	SecondFactorType,
+	type AccountSettings,
+} from 'pandora-common';
+import React, { ReactElement, createContext, useContext, useEffect, useMemo, useRef } from 'react';
 import { ChildrenProps } from '../../common/reactTypes';
 import { useDebugExpose } from '../../common/useDebugExpose';
 import { useErrorHandler } from '../../common/useErrorHandler';
 import { DIRECTORY_ADDRESS } from '../../config/Environment';
+import { ConfigServerIndex } from '../../config/searchArgs';
 import { AuthToken, DirectoryConnector } from '../../networking/directoryConnector';
 import { SocketIODirectoryConnector } from '../../networking/socketio_directory_connector';
 import { Observable, useNullableObservable, useObservable } from '../../observable';
-import { Immutable } from 'immer';
-import { ConfigServerIndex } from '../../config/searchArgs';
-import { Form, FormFieldCaptcha } from '../common/form/form';
 import { Button } from '../common/button/button';
 import { Row } from '../common/container/container';
+import { Form, FormFieldCaptcha } from '../common/form/form';
 import { ModalDialog } from '../dialog/dialog';
 
 const DirectoryConnector = new Observable<DirectoryConnector | undefined>(undefined);
@@ -111,11 +121,25 @@ export function useCurrentAccount(): IDirectoryAccountInfo | null {
 	return useObservable(directoryConnector.currentAccount);
 }
 
-export function useCurrentAccountSettings(): Immutable<IDirectoryAccountSettings> {
+/**
+ * Gets modified settings for the current account.
+ * @returns The partial settings object, or `undefined` if no account is loaded.
+ */
+export function useModifiedAccountSettings(): Immutable<Partial<AccountSettings>> | undefined {
 	// Get account manually to avoid error in the editor
-	const account = useNullableObservable(useDirectoryConnectorOptional()?.currentAccount);
-	// It is safe to return it simply like this, as when settings change, the whole account object is updated (it is immutable)
-	return account?.settings ?? ACCOUNT_SETTINGS_DEFAULT;
+	return useNullableObservable(useDirectoryConnectorOptional()?.currentAccount)?.settings;
+}
+
+/**
+ * Resolves full account settings to their effective values.
+ * @returns The settings that apply to this account.
+ */
+export function useEffectiveAccountSettings(): Immutable<AccountSettings> {
+	const modifiedSettings = useModifiedAccountSettings();
+	return useMemo((): Immutable<AccountSettings> => ({
+		...modifiedSettings,
+		...ACCOUNT_SETTINGS_DEFAULT,
+	}), [modifiedSettings]);
 }
 
 export function useAuthToken(): AuthToken | undefined {

--- a/pandora-client-web/src/components/gameContext/directoryConnectorContextProvider.tsx
+++ b/pandora-client-web/src/components/gameContext/directoryConnectorContextProvider.tsx
@@ -137,8 +137,8 @@ export function useModifiedAccountSettings(): Immutable<Partial<AccountSettings>
 export function useEffectiveAccountSettings(): Immutable<AccountSettings> {
 	const modifiedSettings = useModifiedAccountSettings();
 	return useMemo((): Immutable<AccountSettings> => ({
-		...modifiedSettings,
 		...ACCOUNT_SETTINGS_DEFAULT,
+		...modifiedSettings,
 	}), [modifiedSettings]);
 }
 

--- a/pandora-client-web/src/components/gameContext/directoryConnectorContextProvider.tsx
+++ b/pandora-client-web/src/components/gameContext/directoryConnectorContextProvider.tsx
@@ -134,7 +134,7 @@ export function useModifiedAccountSettings(): Immutable<Partial<AccountSettings>
  * Resolves full account settings to their effective values.
  * @returns The settings that apply to this account.
  */
-export function useEffectiveAccountSettings(): Immutable<AccountSettings> {
+export function useAccountSettings(): Immutable<AccountSettings> {
 	const modifiedSettings = useModifiedAccountSettings();
 	return useMemo((): Immutable<AccountSettings> => ({
 		...ACCOUNT_SETTINGS_DEFAULT,

--- a/pandora-client-web/src/components/settings/accountSettings.tsx
+++ b/pandora-client-web/src/components/settings/accountSettings.tsx
@@ -158,15 +158,21 @@ function AccountRoleList({ account }: { account: IDirectoryAccountInfo; }): Reac
 }
 
 function AccountRole({ role, data }: { role: AccountRole; data?: { expires?: number; }; }): ReactElement {
-	const connector = useDirectoryConnector();
+	const directory = useDirectoryConnector();
 	const visibleRoles = useCurrentAccount()?.settings.visibleRoles || [];
 	const visible = visibleRoles.includes(role);
 
 	const onSetVisible = (e: React.ChangeEvent<HTMLInputElement>) => {
 		if (e.target.checked) {
-			connector.sendMessage('changeSettings', { visibleRoles: uniq([...visibleRoles, role]) });
+			directory.sendMessage('changeSettings', {
+				type: 'set',
+				settings: { visibleRoles: uniq([...visibleRoles, role]) },
+			});
 		} else {
-			connector.sendMessage('changeSettings', { visibleRoles: visibleRoles.filter((r) => r !== role) });
+			directory.sendMessage('changeSettings', {
+				type: 'set',
+				settings: { visibleRoles: visibleRoles.filter((r) => r !== role) },
+			});
 		}
 	};
 
@@ -193,7 +199,12 @@ function LabelColor({ account }: { account: IDirectoryAccountInfo; }): ReactElem
 				<ColorInput initialValue={ color } onChange={ setColor } />
 				<Button
 					className='slim fadeDisabled'
-					onClick={ () => directory?.sendMessage('changeSettings', { labelColor: color }) }
+					onClick={ () => {
+						directory.sendMessage('changeSettings', {
+							type: 'set',
+							settings: { labelColor: color },
+						});
+					} }
 					disabled={ color === account.settings.labelColor?.toUpperCase() }>
 					Save
 				</Button>
@@ -216,7 +227,10 @@ function DisplayName({ account }: { account: IDirectoryAccountInfo; }): ReactEle
 			return;
 		}
 		const displayName = account.username === name ? null : name;
-		directory.sendMessage('changeSettings', { displayName });
+		directory.sendMessage('changeSettings', {
+			type: 'set',
+			settings: { displayName },
+		});
 	});
 
 	const now = useCurrentTime(TimeSpanMs(1, 'seconds'));

--- a/pandora-client-web/src/components/settings/helpers/accountSettings.tsx
+++ b/pandora-client-web/src/components/settings/helpers/accountSettings.tsx
@@ -1,8 +1,9 @@
-import { ACCOUNT_SETTINGS_DEFAULT, type AccountSettings } from 'pandora-common';
+import { ACCOUNT_SETTINGS_DEFAULT, AccountSettingsSchema, type AccountSettings } from 'pandora-common';
 import React, { type ReactElement } from 'react';
 import type { ConditionalKeys } from 'type-fest';
 import { useDirectoryConnector, useModifiedAccountSettings } from '../../gameContext/directoryConnectorContextProvider';
-import { ToggleSettingInput } from './settingsInputs';
+import { SelectSettingInput, ToggleSettingInput } from './settingsInputs';
+import type { ZodType } from 'zod';
 
 type BooleanSettings = ConditionalKeys<AccountSettings, boolean>;
 export function ToggleAccountSetting<const Setting extends BooleanSettings>({ setting, label }: {
@@ -31,6 +32,46 @@ export function ToggleAccountSetting<const Setting extends BooleanSettings>({ se
 			label={ label }
 			currentValue={ modifiedSettings?.[setting] }
 			defaultValue={ ACCOUNT_SETTINGS_DEFAULT[setting] }
+			onChange={ onChange }
+			onReset={ onReset }
+		/>
+	);
+}
+
+type StringSettings = ConditionalKeys<AccountSettings, string>;
+export function SelectAccountSettings<const Setting extends StringSettings>({ setting, label, stringify }: {
+	setting: Setting;
+	label: string;
+	stringify: Readonly<Record<AccountSettings[Setting], string>>;
+}): ReactElement {
+	const modifiedSettings = useModifiedAccountSettings();
+	const directory = useDirectoryConnector();
+
+	const onChange = (value: AccountSettings[Setting]) => {
+		directory.sendMessage('changeSettings', {
+			type: 'set',
+			settings: { [setting]: value },
+		});
+	};
+
+	const onReset = () => {
+		directory.sendMessage('changeSettings', {
+			type: 'reset',
+			settings: [setting],
+		});
+	};
+
+	const currentValue: string | undefined = modifiedSettings?.[setting];
+	// @ts-expect-error: Type specialized manually
+	const schema: ZodType<AccountSettings[Setting]> = AccountSettingsSchema.shape[setting];
+
+	return (
+		<SelectSettingInput<AccountSettings[Setting]>
+			currentValue={ schema.optional().parse(currentValue) }
+			defaultValue={ ACCOUNT_SETTINGS_DEFAULT[setting] }
+			label={ label }
+			stringify={ stringify }
+			schema={ schema }
 			onChange={ onChange }
 			onReset={ onReset }
 		/>

--- a/pandora-client-web/src/components/settings/helpers/accountSettings.tsx
+++ b/pandora-client-web/src/components/settings/helpers/accountSettings.tsx
@@ -1,0 +1,38 @@
+import { ACCOUNT_SETTINGS_DEFAULT, type AccountSettings } from 'pandora-common';
+import React, { type ReactElement } from 'react';
+import type { ConditionalKeys } from 'type-fest';
+import { useDirectoryConnector, useModifiedAccountSettings } from '../../gameContext/directoryConnectorContextProvider';
+import { ToggleSettingInput } from './settingsInputs';
+
+type BooleanSettings = ConditionalKeys<AccountSettings, boolean>;
+export function ToggleAccountSetting<const Setting extends BooleanSettings>({ setting, label }: {
+	setting: Setting;
+	label: string;
+}): ReactElement {
+	const modifiedSettings = useModifiedAccountSettings();
+	const directory = useDirectoryConnector();
+
+	const onChange = (value: boolean) => {
+		directory.sendMessage('changeSettings', {
+			type: 'set',
+			settings: { [setting]: value },
+		});
+	};
+
+	const onReset = () => {
+		directory.sendMessage('changeSettings', {
+			type: 'reset',
+			settings: [setting],
+		});
+	};
+
+	return (
+		<ToggleSettingInput
+			label={ label }
+			currentValue={ modifiedSettings?.[setting] }
+			defaultValue={ ACCOUNT_SETTINGS_DEFAULT[setting] }
+			onChange={ onChange }
+			onReset={ onReset }
+		/>
+	);
+}

--- a/pandora-client-web/src/components/settings/helpers/settingsInputs.tsx
+++ b/pandora-client-web/src/components/settings/helpers/settingsInputs.tsx
@@ -1,0 +1,58 @@
+import React, { useId, type DependencyList, type ReactElement } from 'react';
+import { useRemotelyUpdatedUserInput } from '../../../common/useRemotelyUpdatedUserInput';
+import { EMPTY_ARRAY } from 'pandora-common';
+import { Button } from '../../common/button/button';
+
+export function ToggleSettingInput({ currentValue, defaultValue, label, onChange, onReset, deps = EMPTY_ARRAY }: {
+	currentValue: boolean | undefined;
+	defaultValue: boolean;
+	label: string;
+	onChange: (newValue: boolean) => void;
+	onReset?: () => void;
+	deps?: DependencyList;
+}): ReactElement {
+	const [value, setValue] = useRemotelyUpdatedUserInput(currentValue, deps, {
+		updateCallback(newValue) {
+			if (newValue === undefined) {
+				if (onReset) {
+					onReset();
+				} else {
+					onChange(defaultValue);
+				}
+			} else {
+				onChange(newValue);
+			}
+		},
+	});
+
+	const onInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const newValue = e.target.checked;
+		setValue(newValue);
+	};
+
+	const id = `setting-${useId()}`;
+
+	return (
+		<div className='input-row'>
+			<input
+				id={ id }
+				type='checkbox'
+				checked={ value ?? defaultValue }
+				onChange={ onInputChange }
+			/>
+			<label
+				htmlFor={ id }
+				className='flex-1'
+			>
+				{ label }
+			</label>
+			<Button
+				className='slim fadeDisabled'
+				onClick={ () => setValue(undefined) }
+				disabled={ value === undefined }
+			>
+				↺
+			</Button>
+		</div>
+	);
+}

--- a/pandora-client-web/src/components/settings/helpers/settingsInputs.tsx
+++ b/pandora-client-web/src/components/settings/helpers/settingsInputs.tsx
@@ -1,7 +1,10 @@
-import React, { useId, type DependencyList, type ReactElement } from 'react';
+import React, { useId, type DependencyList, type ReactElement, useCallback, useMemo } from 'react';
 import { useRemotelyUpdatedUserInput } from '../../../common/useRemotelyUpdatedUserInput';
-import { EMPTY_ARRAY } from 'pandora-common';
+import { EMPTY_ARRAY, KnownObject } from 'pandora-common';
 import { Button } from '../../common/button/button';
+import type { ZodSchema, ZodTypeDef } from 'zod';
+import { Select } from '../../common/select/select';
+import { Row } from '../../common/container/container';
 
 export function ToggleSettingInput({ currentValue, defaultValue, label, onChange, onReset, deps = EMPTY_ARRAY }: {
 	currentValue: boolean | undefined;
@@ -53,6 +56,71 @@ export function ToggleSettingInput({ currentValue, defaultValue, label, onChange
 			>
 				↺
 			</Button>
+		</div>
+	);
+}
+
+export function SelectSettingInput<TValue extends string>({ currentValue, defaultValue, label, stringify, schema, onChange, onReset, deps }: {
+	currentValue: TValue | undefined;
+	defaultValue: TValue;
+	label: string;
+	stringify: Readonly<Record<TValue, string>>;
+	schema: ZodSchema<TValue, ZodTypeDef, unknown>;
+	onChange: (newValue: TValue) => void;
+	onReset?: () => void;
+	deps?: DependencyList;
+}): ReactElement {
+	const [value, setValue] = useRemotelyUpdatedUserInput<TValue | undefined>(currentValue, deps, {
+		updateCallback(newValue) {
+			if (newValue === undefined) {
+				if (onReset) {
+					onReset();
+				} else {
+					onChange(defaultValue);
+				}
+			} else {
+				onChange(newValue);
+			}
+		},
+	});
+
+	const id = `setting-${useId()}`;
+
+	const onInputChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+		const newValue = schema.parse(e.target.value);
+		setValue(newValue);
+	}, [schema, setValue]);
+
+	const options = useMemo(() => (
+		KnownObject
+			.entries(stringify)
+			.map(([k, v]) => (
+				<option key={ k } value={ k }>
+					{ v }
+				</option>
+			))
+	), [stringify]);
+
+	return (
+		<div className='input-section'>
+			<label htmlFor={ id }>{ label }</label>
+			<Row alignY='center'>
+				<Select
+					id={ id }
+					className='flex-1'
+					value={ value ?? defaultValue }
+					onChange={ onInputChange }
+				>
+					{ options }
+				</Select>
+				<Button
+					className='slim fadeDisabled'
+					onClick={ () => setValue(undefined) }
+					disabled={ value === undefined }
+				>
+					↺
+				</Button>
+			</Row>
 		</div>
 	);
 }

--- a/pandora-client-web/src/components/settings/interfaceSettings.tsx
+++ b/pandora-client-web/src/components/settings/interfaceSettings.tsx
@@ -1,15 +1,14 @@
 import type { Immutable } from 'immer';
 import { range } from 'lodash';
-import { AccountSettings, AccountSettingsSchema, KnownObject } from 'pandora-common';
-import React, { ReactElement, useCallback, useMemo, useState } from 'react';
+import { AccountSettings, AccountSettingsSchema } from 'pandora-common';
+import React, { ReactElement, useMemo } from 'react';
 import { useColorInput } from '../../common/useColorInput';
-import { useRemotelyUpdatedUserInput } from '../../common/useRemotelyUpdatedUserInput';
 import { useUpdatedUserInput } from '../../common/useSyncUserInput';
 import { Button } from '../common/button/button';
 import { ColorInput } from '../common/colorInput/colorInput';
-import { Select, SelectProps } from '../common/select/select';
+import { Select } from '../common/select/select';
 import { useCurrentAccount, useDirectoryConnector, useEffectiveAccountSettings } from '../gameContext/directoryConnectorContextProvider';
-import { ToggleAccountSetting } from './helpers/accountSettings';
+import { SelectAccountSettings, ToggleAccountSetting } from './helpers/accountSettings';
 
 export function InterfaceSettings(): ReactElement | null {
 	const account = useCurrentAccount();
@@ -31,8 +30,8 @@ function ChatroomSettings({ currentSettings }: { currentSettings: Immutable<Acco
 		<fieldset>
 			<legend>Chatroom UI</legend>
 			<ChatroomGraphicsRatio currentSettings={ currentSettings } />
-			<ChatroomChatFontSize currentSettings={ currentSettings } />
-			<ChatroomOfflineCharacters currentSettings={ currentSettings } />
+			<ChatroomChatFontSize />
+			<ChatroomOfflineCharacters />
 		</fieldset>
 	);
 }
@@ -88,73 +87,27 @@ function ChatroomGraphicsRatio({ currentSettings }: { currentSettings: Immutable
 	);
 }
 
-function ChatroomChatFontSize({ currentSettings }: { currentSettings: Immutable<AccountSettings>; }): ReactElement {
-	const directory = useDirectoryConnector();
-	const [size, setSize] = useState(currentSettings.interfaceChatroomChatFontSize);
-
-	const onChange = useCallback<NonNullable<SelectProps['onChange']>>(({ target }) => {
-		const newValue = AccountSettingsSchema.shape.interfaceChatroomChatFontSize.parse(target.value);
-
-		setSize(newValue);
-		directory.sendMessage('changeSettings', {
-			type: 'set',
-			settings: { interfaceChatroomChatFontSize: newValue },
-		});
-	}, [directory]);
-
-	const SELECTION_DESCRIPTIONS: Record<AccountSettings['interfaceChatroomChatFontSize'], string> = {
+function ChatroomChatFontSize(): ReactElement {
+	const SELECTION_DESCRIPTIONS = useMemo((): Record<AccountSettings['interfaceChatroomChatFontSize'], string> => ({
 		xs: 'Extra small',
 		s: 'Small',
 		m: 'Medium (default)',
 		l: 'Large',
 		xl: 'Extra large',
-	};
+	}), []);
 
-	return (
-		<div className='input-section'>
-			<label>Font size of main chat and direct messages</label>
-			<Select value={ size } onChange={ onChange }>
-				{
-					KnownObject.keys(SELECTION_DESCRIPTIONS)
-						.map((v) => <option key={ v } value={ v }>{ SELECTION_DESCRIPTIONS[v] }</option>)
-				}
-			</Select>
-		</div>
-	);
+	return <SelectAccountSettings setting='interfaceChatroomChatFontSize' label='Font size of main chat and direct messages' stringify={ SELECTION_DESCRIPTIONS } />;
 }
 
-function ChatroomOfflineCharacters({ currentSettings }: { currentSettings: Immutable<AccountSettings>; }): ReactElement {
-	const directory = useDirectoryConnector();
-	const [selection, setSelection] = useState(currentSettings.interfaceChatroomOfflineCharacterFilter);
-
-	const onChange = useCallback<NonNullable<SelectProps['onChange']>>(({ target }) => {
-		const newValue = AccountSettingsSchema.shape.interfaceChatroomOfflineCharacterFilter.parse(target.value);
-
-		setSelection(newValue);
-		directory.sendMessage('changeSettings', {
-			type: 'set',
-			settings: { interfaceChatroomOfflineCharacterFilter: newValue },
-		});
-	}, [directory]);
-
-	const SELECTION_DESCRIPTIONS: Record<AccountSettings['interfaceChatroomOfflineCharacterFilter'], string> = {
+function ChatroomOfflineCharacters(): ReactElement {
+	const SELECTION_DESCRIPTIONS = useMemo((): Record<AccountSettings['interfaceChatroomOfflineCharacterFilter'], string> => ({
 		none: 'No effect (displayed the same as online characters)',
 		icon: 'Show icon under the character name',
 		darken: 'Darken',
 		ghost: 'Ghost (darken + semi-transparent)',
-	};
+	}), []);
 
-	return (
-		<div className='input-section'>
-			<label>Offline characters display effect</label>
-			<Select value={ selection } onChange={ onChange }>
-				{
-					(Object.keys(SELECTION_DESCRIPTIONS) as AccountSettings['interfaceChatroomOfflineCharacterFilter'][])
-						.map((v) => <option key={ v } value={ v }>{ SELECTION_DESCRIPTIONS[v] }</option>)
-				}
-			</Select>
-		</div>
-	);
+	return <SelectAccountSettings setting='interfaceChatroomOfflineCharacterFilter' label='Offline characters display effect' stringify={ SELECTION_DESCRIPTIONS } />;
 }
 
 function WardrobeSettings({ currentSettings }: { currentSettings: Immutable<AccountSettings>; }): ReactElement {
@@ -165,9 +118,9 @@ function WardrobeSettings({ currentSettings }: { currentSettings: Immutable<Acco
 			<WardrobeUseRoomBackground />
 			<WardrobeShowExtraButtons />
 			<WardrobeHoverPreview />
-			<WardrobeSelectSettings currentSettings={ currentSettings } setting='wardrobeOutfitsPreview' label='Saved item collection previews' stringify={ WARDROBE_PREVIEWS_DESCRIPTION } />
-			<WardrobeSelectSettings currentSettings={ currentSettings } setting='wardrobeSmallPreview' label='Item previews: List mode with small previews' stringify={ WARDROBE_PREVIEW_TYPE_DESCRIPTION } />
-			<WardrobeSelectSettings currentSettings={ currentSettings } setting='wardrobeBigPreview' label='Item previews: Grid mode with big previews' stringify={ WARDROBE_PREVIEW_TYPE_DESCRIPTION } />
+			<SelectAccountSettings setting='wardrobeOutfitsPreview' label='Saved item collection previews' stringify={ WARDROBE_PREVIEWS_DESCRIPTION } />
+			<SelectAccountSettings setting='wardrobeSmallPreview' label='Item previews: List mode with small previews' stringify={ WARDROBE_PREVIEW_TYPE_DESCRIPTION } />
+			<SelectAccountSettings setting='wardrobeBigPreview' label='Item previews: Grid mode with big previews' stringify={ WARDROBE_PREVIEW_TYPE_DESCRIPTION } />
 		</fieldset>
 	);
 }
@@ -221,41 +174,3 @@ const WARDROBE_PREVIEW_TYPE_DESCRIPTION: Record<AccountSettings['wardrobeSmallPr
 	icon: 'Show attribute icon',
 	image: 'Show preview image',
 };
-
-type StringKeyOf<T> = {
-	[K in keyof T]: T[K] extends string ? K : never
-}[keyof T];
-
-function WardrobeSelectSettings<K extends StringKeyOf<AccountSettings>>({ currentSettings, setting, label, stringify }: {
-	currentSettings: Immutable<AccountSettings>;
-	setting: K;
-	label: string;
-	stringify: Readonly<Record<AccountSettings[K], string>>;
-}): ReactElement {
-	const directory = useDirectoryConnector();
-	const [value, setValue] = useRemotelyUpdatedUserInput(currentSettings[setting], undefined, {
-		updateCallback: (newValue) => {
-			directory.sendMessage('changeSettings', {
-				type: 'set',
-				settings: { [setting]: newValue },
-			});
-		},
-	});
-	const onChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
-		const newValue = AccountSettingsSchema.shape[setting].parse(e.target.value);
-		setValue(newValue as AccountSettings[K]);
-	}, [setting, setValue]);
-	const options = useMemo(() => (Object.entries(stringify) as [AccountSettings[K], string][]).map(([k, v]) => (
-		<option key={ k } value={ k }>
-			{ v }
-		</option>
-	)), [stringify]);
-	return (
-		<div className='input-section'>
-			<label>{ label }</label>
-			<Select value={ value } onChange={ onChange }>
-				{ options }
-			</Select>
-		</div>
-	);
-}

--- a/pandora-client-web/src/components/settings/interfaceSettings.tsx
+++ b/pandora-client-web/src/components/settings/interfaceSettings.tsx
@@ -9,6 +9,7 @@ import { Button } from '../common/button/button';
 import { ColorInput } from '../common/colorInput/colorInput';
 import { Select, SelectProps } from '../common/select/select';
 import { useCurrentAccount, useDirectoryConnector, useEffectiveAccountSettings } from '../gameContext/directoryConnectorContextProvider';
+import { ToggleAccountSetting } from './helpers/accountSettings';
 
 export function InterfaceSettings(): ReactElement | null {
 	const account = useCurrentAccount();
@@ -161,9 +162,9 @@ function WardrobeSettings({ currentSettings }: { currentSettings: Immutable<Acco
 		<fieldset>
 			<legend>Wardrobe UI</legend>
 			<WardrobeBackgroundColor currentSettings={ currentSettings } />
-			<WardrobeUseRoomBackground currentSettings={ currentSettings } />
-			<WardrobeShowExtraButtons currentSettings={ currentSettings } />
-			<WardrobeHoverPreview currentSettings={ currentSettings } />
+			<WardrobeUseRoomBackground />
+			<WardrobeShowExtraButtons />
+			<WardrobeHoverPreview />
 			<WardrobeSelectSettings currentSettings={ currentSettings } setting='wardrobeOutfitsPreview' label='Saved item collection previews' stringify={ WARDROBE_PREVIEWS_DESCRIPTION } />
 			<WardrobeSelectSettings currentSettings={ currentSettings } setting='wardrobeSmallPreview' label='Item previews: List mode with small previews' stringify={ WARDROBE_PREVIEW_TYPE_DESCRIPTION } />
 			<WardrobeSelectSettings currentSettings={ currentSettings } setting='wardrobeBigPreview' label='Item previews: Grid mode with big previews' stringify={ WARDROBE_PREVIEW_TYPE_DESCRIPTION } />
@@ -198,67 +199,16 @@ function WardrobeBackgroundColor({ currentSettings }: { currentSettings: Immutab
 	);
 }
 
-function WardrobeUseRoomBackground({ currentSettings }: { currentSettings: Immutable<AccountSettings>; }): ReactElement {
-	const directory = useDirectoryConnector();
-	const [show, setShow] = useState(currentSettings.wardrobeUseRoomBackground);
-
-	const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		const newValue = e.target.checked;
-		setShow(newValue);
-		directory.sendMessage('changeSettings', {
-			type: 'set',
-			settings: { wardrobeUseRoomBackground: newValue },
-		});
-	};
-
-	return (
-		<div className='input-row'>
-			<input type='checkbox' checked={ show } onChange={ onChange } />
-			<label>Use room's background, if character is inside a room</label>
-		</div>
-	);
+function WardrobeUseRoomBackground(): ReactElement {
+	return <ToggleAccountSetting setting='wardrobeUseRoomBackground' label="Use room's background, if character is inside a room" />;
 }
 
-function WardrobeShowExtraButtons({ currentSettings }: { currentSettings: Immutable<AccountSettings>; }): ReactElement {
-	const directory = useDirectoryConnector();
-	const [show, setShow] = useState(currentSettings.wardrobeExtraActionButtons);
-
-	const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		const newValue = e.target.checked;
-		setShow(newValue);
-		directory.sendMessage('changeSettings', {
-			type: 'set',
-			settings: { wardrobeExtraActionButtons: newValue },
-		});
-	};
-
-	return (
-		<div className='input-row'>
-			<input type='checkbox' checked={ show } onChange={ onChange } />
-			<label>Show quick action buttons</label>
-		</div>
-	);
+function WardrobeShowExtraButtons(): ReactElement {
+	return <ToggleAccountSetting setting='wardrobeExtraActionButtons' label='Show quick action buttons' />;
 }
 
-function WardrobeHoverPreview({ currentSettings }: { currentSettings: Immutable<AccountSettings>; }): ReactElement {
-	const directory = useDirectoryConnector();
-	const [show, setShow] = useState(currentSettings.wardrobeHoverPreview);
-
-	const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		const newValue = e.target.checked;
-		setShow(newValue);
-		directory.sendMessage('changeSettings', {
-			type: 'set',
-			settings: { wardrobeHoverPreview: newValue },
-		});
-	};
-
-	return (
-		<div className='input-row'>
-			<input type='checkbox' checked={ show } onChange={ onChange } />
-			<label>Show preview when hovering over action button</label>
-		</div>
-	);
+function WardrobeHoverPreview(): ReactElement {
+	return <ToggleAccountSetting setting='wardrobeHoverPreview' label='Show preview when hovering over action button' />;
 }
 
 const WARDROBE_PREVIEWS_DESCRIPTION: Record<AccountSettings['wardrobeOutfitsPreview'], string> = {

--- a/pandora-client-web/src/components/settings/interfaceSettings.tsx
+++ b/pandora-client-web/src/components/settings/interfaceSettings.tsx
@@ -2,10 +2,7 @@ import type { Immutable } from 'immer';
 import { range } from 'lodash';
 import { AccountSettings, AccountSettingsSchema } from 'pandora-common';
 import React, { ReactElement, useMemo } from 'react';
-import { useColorInput } from '../../common/useColorInput';
 import { useUpdatedUserInput } from '../../common/useSyncUserInput';
-import { Button } from '../common/button/button';
-import { ColorInput } from '../common/colorInput/colorInput';
 import { Select } from '../common/select/select';
 import { useCurrentAccount, useDirectoryConnector, useEffectiveAccountSettings } from '../gameContext/directoryConnectorContextProvider';
 import { SelectAccountSettings, ToggleAccountSetting } from './helpers/accountSettings';
@@ -20,7 +17,7 @@ export function InterfaceSettings(): ReactElement | null {
 	return (
 		<>
 			<ChatroomSettings currentSettings={ currentSettings } />
-			<WardrobeSettings currentSettings={ currentSettings } />
+			<WardrobeSettings />
 		</>
 	);
 }
@@ -110,12 +107,10 @@ function ChatroomOfflineCharacters(): ReactElement {
 	return <SelectAccountSettings setting='interfaceChatroomOfflineCharacterFilter' label='Offline characters display effect' stringify={ SELECTION_DESCRIPTIONS } />;
 }
 
-function WardrobeSettings({ currentSettings }: { currentSettings: Immutable<AccountSettings>; }): ReactElement {
+function WardrobeSettings(): ReactElement {
 	return (
 		<fieldset>
 			<legend>Wardrobe UI</legend>
-			<WardrobeBackgroundColor currentSettings={ currentSettings } />
-			<WardrobeUseRoomBackground />
 			<WardrobeShowExtraButtons />
 			<WardrobeHoverPreview />
 			<SelectAccountSettings setting='wardrobeOutfitsPreview' label='Saved item collection previews' stringify={ WARDROBE_PREVIEWS_DESCRIPTION } />
@@ -123,37 +118,6 @@ function WardrobeSettings({ currentSettings }: { currentSettings: Immutable<Acco
 			<SelectAccountSettings setting='wardrobeBigPreview' label='Item previews: Grid mode with big previews' stringify={ WARDROBE_PREVIEW_TYPE_DESCRIPTION } />
 		</fieldset>
 	);
-}
-
-function WardrobeBackgroundColor({ currentSettings }: { currentSettings: Immutable<AccountSettings>; }): ReactElement {
-	const directory = useDirectoryConnector();
-	const [color, setColor] = useColorInput(currentSettings.wardrobeBackground);
-
-	return (
-		<div className='input-row'>
-			<label>Background</label>
-			<ColorInput
-				initialValue={ color }
-				onChange={ setColor }
-				inputColorTitle='Change background color'
-			/>
-			<Button
-				className='slim fadeDisabled'
-				onClick={ () => {
-					directory.sendMessage('changeSettings', {
-						type: 'set',
-						settings: { wardrobeBackground: color },
-					});
-				} }
-				disabled={ color === currentSettings.wardrobeBackground.toUpperCase() }>
-				Save
-			</Button>
-		</div>
-	);
-}
-
-function WardrobeUseRoomBackground(): ReactElement {
-	return <ToggleAccountSetting setting='wardrobeUseRoomBackground' label="Use room's background, if character is inside a room" />;
 }
 
 function WardrobeShowExtraButtons(): ReactElement {

--- a/pandora-client-web/src/components/settings/interfaceSettings.tsx
+++ b/pandora-client-web/src/components/settings/interfaceSettings.tsx
@@ -1,54 +1,62 @@
+import type { Immutable } from 'immer';
+import { range } from 'lodash';
+import { AccountSettings, AccountSettingsSchema, KnownObject } from 'pandora-common';
 import React, { ReactElement, useCallback, useMemo, useState } from 'react';
-import { useCurrentAccount, useDirectoryConnector } from '../gameContext/directoryConnectorContextProvider';
-import { DirectoryAccountSettingsSchema, IDirectoryAccountInfo, IDirectoryAccountSettings, KnownObject } from 'pandora-common';
+import { useColorInput } from '../../common/useColorInput';
+import { useRemotelyUpdatedUserInput } from '../../common/useRemotelyUpdatedUserInput';
+import { useUpdatedUserInput } from '../../common/useSyncUserInput';
 import { Button } from '../common/button/button';
 import { ColorInput } from '../common/colorInput/colorInput';
-import { useColorInput } from '../../common/useColorInput';
 import { Select, SelectProps } from '../common/select/select';
-import { useUpdatedUserInput } from '../../common/useSyncUserInput';
-import { range } from 'lodash';
-import { useRemotelyUpdatedUserInput } from '../../common/useRemotelyUpdatedUserInput';
+import { useCurrentAccount, useDirectoryConnector, useEffectiveAccountSettings } from '../gameContext/directoryConnectorContextProvider';
 
 export function InterfaceSettings(): ReactElement | null {
 	const account = useCurrentAccount();
+	const currentSettings = useEffectiveAccountSettings();
 
 	if (!account)
 		return <>Not logged in</>;
 
 	return (
 		<>
-			<ChatroomSettings account={ account } />
-			<WardrobeSettings account={ account } />
+			<ChatroomSettings currentSettings={ currentSettings } />
+			<WardrobeSettings currentSettings={ currentSettings } />
 		</>
 	);
 }
 
-function ChatroomSettings({ account }: { account: IDirectoryAccountInfo; }): ReactElement {
+function ChatroomSettings({ currentSettings }: { currentSettings: Immutable<AccountSettings>; }): ReactElement {
 	return (
 		<fieldset>
 			<legend>Chatroom UI</legend>
-			<ChatroomGraphicsRatio account={ account } />
-			<ChatroomChatFontSize account={ account } />
-			<ChatroomOfflineCharacters account={ account } />
+			<ChatroomGraphicsRatio currentSettings={ currentSettings } />
+			<ChatroomChatFontSize currentSettings={ currentSettings } />
+			<ChatroomOfflineCharacters currentSettings={ currentSettings } />
 		</fieldset>
 	);
 }
 
-function ChatroomGraphicsRatio({ account }: { account: IDirectoryAccountInfo; }): ReactElement {
+function ChatroomGraphicsRatio({ currentSettings }: { currentSettings: Immutable<AccountSettings>; }): ReactElement {
 	const directory = useDirectoryConnector();
 
-	const [ratioHorizontal, setRatioHorizontal] = useUpdatedUserInput(account.settings.interfaceChatroomGraphicsRatioHorizontal);
+	const [ratioHorizontal, setRatioHorizontal] = useUpdatedUserInput(currentSettings.interfaceChatroomGraphicsRatioHorizontal);
 	const onChangeRatioHorizontal = (e: React.ChangeEvent<HTMLSelectElement>) => {
-		const newValue = DirectoryAccountSettingsSchema.shape.interfaceChatroomGraphicsRatioHorizontal.parse(Number.parseInt(e.target.value, 10));
+		const newValue = AccountSettingsSchema.shape.interfaceChatroomGraphicsRatioHorizontal.parse(Number.parseInt(e.target.value, 10));
 		setRatioHorizontal(newValue);
-		directory.sendMessage('changeSettings', { interfaceChatroomGraphicsRatioHorizontal: newValue });
+		directory.sendMessage('changeSettings', {
+			type: 'set',
+			settings: { interfaceChatroomGraphicsRatioHorizontal: newValue },
+		});
 	};
 
-	const [ratioVertical, setRatioVertical] = useUpdatedUserInput(account.settings.interfaceChatroomGraphicsRatioVertical);
+	const [ratioVertical, setRatioVertical] = useUpdatedUserInput(currentSettings.interfaceChatroomGraphicsRatioVertical);
 	const onChangeRatioVertical = (e: React.ChangeEvent<HTMLSelectElement>) => {
-		const newValue = DirectoryAccountSettingsSchema.shape.interfaceChatroomGraphicsRatioVertical.parse(Number.parseInt(e.target.value, 10));
+		const newValue = AccountSettingsSchema.shape.interfaceChatroomGraphicsRatioVertical.parse(Number.parseInt(e.target.value, 10));
 		setRatioVertical(newValue);
-		directory.sendMessage('changeSettings', { interfaceChatroomGraphicsRatioVertical: newValue });
+		directory.sendMessage('changeSettings', {
+			type: 'set',
+			settings: { interfaceChatroomGraphicsRatioVertical: newValue },
+		});
 	};
 
 	return (
@@ -58,8 +66,8 @@ function ChatroomGraphicsRatio({ account }: { account: IDirectoryAccountInfo; })
 				<Select value={ ratioHorizontal.toString() } onChange={ onChangeRatioHorizontal }>
 					{
 						range(
-							DirectoryAccountSettingsSchema.shape.interfaceChatroomGraphicsRatioHorizontal._def.innerType.minValue ?? 1,
-							(DirectoryAccountSettingsSchema.shape.interfaceChatroomGraphicsRatioHorizontal._def.innerType.maxValue ?? 9) + 1,
+							AccountSettingsSchema.shape.interfaceChatroomGraphicsRatioHorizontal.minValue ?? 1,
+							(AccountSettingsSchema.shape.interfaceChatroomGraphicsRatioHorizontal.maxValue ?? 9) + 1,
 						).map((v) => <option key={ v } value={ v.toString() }>{ `${v}:${10 - v}` }</option>)
 					}
 				</Select>
@@ -69,8 +77,8 @@ function ChatroomGraphicsRatio({ account }: { account: IDirectoryAccountInfo; })
 				<Select value={ ratioVertical.toString() } onChange={ onChangeRatioVertical }>
 					{
 						range(
-							DirectoryAccountSettingsSchema.shape.interfaceChatroomGraphicsRatioVertical._def.innerType.minValue ?? 1,
-							(DirectoryAccountSettingsSchema.shape.interfaceChatroomGraphicsRatioVertical._def.innerType.maxValue ?? 9) + 1,
+							AccountSettingsSchema.shape.interfaceChatroomGraphicsRatioVertical.minValue ?? 1,
+							(AccountSettingsSchema.shape.interfaceChatroomGraphicsRatioVertical.maxValue ?? 9) + 1,
 						).map((v) => <option key={ v } value={ v.toString() }>{ `${v}:${10 - v}` }</option>)
 					}
 				</Select>
@@ -79,18 +87,21 @@ function ChatroomGraphicsRatio({ account }: { account: IDirectoryAccountInfo; })
 	);
 }
 
-function ChatroomChatFontSize({ account }: { account: IDirectoryAccountInfo; }): ReactElement {
+function ChatroomChatFontSize({ currentSettings }: { currentSettings: Immutable<AccountSettings>; }): ReactElement {
 	const directory = useDirectoryConnector();
-	const [size, setSize] = useState(account.settings.interfaceChatroomChatFontSize);
+	const [size, setSize] = useState(currentSettings.interfaceChatroomChatFontSize);
 
 	const onChange = useCallback<NonNullable<SelectProps['onChange']>>(({ target }) => {
-		const newValue = DirectoryAccountSettingsSchema.shape.interfaceChatroomChatFontSize.parse(target.value);
+		const newValue = AccountSettingsSchema.shape.interfaceChatroomChatFontSize.parse(target.value);
 
 		setSize(newValue);
-		directory.sendMessage('changeSettings', { interfaceChatroomChatFontSize: newValue });
+		directory.sendMessage('changeSettings', {
+			type: 'set',
+			settings: { interfaceChatroomChatFontSize: newValue },
+		});
 	}, [directory]);
 
-	const SELECTION_DESCRIPTIONS: Record<IDirectoryAccountSettings['interfaceChatroomChatFontSize'], string> = {
+	const SELECTION_DESCRIPTIONS: Record<AccountSettings['interfaceChatroomChatFontSize'], string> = {
 		xs: 'Extra small',
 		s: 'Small',
 		m: 'Medium (default)',
@@ -111,18 +122,21 @@ function ChatroomChatFontSize({ account }: { account: IDirectoryAccountInfo; }):
 	);
 }
 
-function ChatroomOfflineCharacters({ account }: { account: IDirectoryAccountInfo; }): ReactElement {
+function ChatroomOfflineCharacters({ currentSettings }: { currentSettings: Immutable<AccountSettings>; }): ReactElement {
 	const directory = useDirectoryConnector();
-	const [selection, setSelection] = useState(account.settings.interfaceChatroomOfflineCharacterFilter);
+	const [selection, setSelection] = useState(currentSettings.interfaceChatroomOfflineCharacterFilter);
 
 	const onChange = useCallback<NonNullable<SelectProps['onChange']>>(({ target }) => {
-		const newValue = DirectoryAccountSettingsSchema.shape.interfaceChatroomOfflineCharacterFilter.parse(target.value);
+		const newValue = AccountSettingsSchema.shape.interfaceChatroomOfflineCharacterFilter.parse(target.value);
 
 		setSelection(newValue);
-		directory.sendMessage('changeSettings', { interfaceChatroomOfflineCharacterFilter: newValue });
+		directory.sendMessage('changeSettings', {
+			type: 'set',
+			settings: { interfaceChatroomOfflineCharacterFilter: newValue },
+		});
 	}, [directory]);
 
-	const SELECTION_DESCRIPTIONS: Record<IDirectoryAccountSettings['interfaceChatroomOfflineCharacterFilter'], string> = {
+	const SELECTION_DESCRIPTIONS: Record<AccountSettings['interfaceChatroomOfflineCharacterFilter'], string> = {
 		none: 'No effect (displayed the same as online characters)',
 		icon: 'Show icon under the character name',
 		darken: 'Darken',
@@ -134,7 +148,7 @@ function ChatroomOfflineCharacters({ account }: { account: IDirectoryAccountInfo
 			<label>Offline characters display effect</label>
 			<Select value={ selection } onChange={ onChange }>
 				{
-					(Object.keys(SELECTION_DESCRIPTIONS) as IDirectoryAccountSettings['interfaceChatroomOfflineCharacterFilter'][])
+					(Object.keys(SELECTION_DESCRIPTIONS) as AccountSettings['interfaceChatroomOfflineCharacterFilter'][])
 						.map((v) => <option key={ v } value={ v }>{ SELECTION_DESCRIPTIONS[v] }</option>)
 				}
 			</Select>
@@ -142,24 +156,24 @@ function ChatroomOfflineCharacters({ account }: { account: IDirectoryAccountInfo
 	);
 }
 
-function WardrobeSettings({ account }: { account: IDirectoryAccountInfo; }): ReactElement {
+function WardrobeSettings({ currentSettings }: { currentSettings: Immutable<AccountSettings>; }): ReactElement {
 	return (
 		<fieldset>
 			<legend>Wardrobe UI</legend>
-			<WardrobeBackgroundColor account={ account } />
-			<WardrobeUseRoomBackground account={ account } />
-			<WardrobeShowExtraButtons account={ account } />
-			<WardrobeHoverPreview account={ account } />
-			<WardrobeSelectSettings account={ account } setting='wardrobeOutfitsPreview' label='Saved item collection previews' stringify={ WARDROBE_PREVIEWS_DESCRIPTION } />
-			<WardrobeSelectSettings account={ account } setting='wardrobeSmallPreview' label='Item previews: List mode with small previews' stringify={ WARDROBE_PREVIEW_TYPE_DESCRIPTION } />
-			<WardrobeSelectSettings account={ account } setting='wardrobeBigPreview' label='Item previews: Grid mode with big previews' stringify={ WARDROBE_PREVIEW_TYPE_DESCRIPTION } />
+			<WardrobeBackgroundColor currentSettings={ currentSettings } />
+			<WardrobeUseRoomBackground currentSettings={ currentSettings } />
+			<WardrobeShowExtraButtons currentSettings={ currentSettings } />
+			<WardrobeHoverPreview currentSettings={ currentSettings } />
+			<WardrobeSelectSettings currentSettings={ currentSettings } setting='wardrobeOutfitsPreview' label='Saved item collection previews' stringify={ WARDROBE_PREVIEWS_DESCRIPTION } />
+			<WardrobeSelectSettings currentSettings={ currentSettings } setting='wardrobeSmallPreview' label='Item previews: List mode with small previews' stringify={ WARDROBE_PREVIEW_TYPE_DESCRIPTION } />
+			<WardrobeSelectSettings currentSettings={ currentSettings } setting='wardrobeBigPreview' label='Item previews: Grid mode with big previews' stringify={ WARDROBE_PREVIEW_TYPE_DESCRIPTION } />
 		</fieldset>
 	);
 }
 
-function WardrobeBackgroundColor({ account }: { account: IDirectoryAccountInfo; }): ReactElement {
+function WardrobeBackgroundColor({ currentSettings }: { currentSettings: Immutable<AccountSettings>; }): ReactElement {
 	const directory = useDirectoryConnector();
-	const [color, setColor] = useColorInput(account.settings.wardrobeBackground);
+	const [color, setColor] = useColorInput(currentSettings.wardrobeBackground);
 
 	return (
 		<div className='input-row'>
@@ -171,22 +185,30 @@ function WardrobeBackgroundColor({ account }: { account: IDirectoryAccountInfo; 
 			/>
 			<Button
 				className='slim fadeDisabled'
-				onClick={ () => directory.sendMessage('changeSettings', { wardrobeBackground: color }) }
-				disabled={ color === account.settings.wardrobeBackground.toUpperCase() }>
+				onClick={ () => {
+					directory.sendMessage('changeSettings', {
+						type: 'set',
+						settings: { wardrobeBackground: color },
+					});
+				} }
+				disabled={ color === currentSettings.wardrobeBackground.toUpperCase() }>
 				Save
 			</Button>
 		</div>
 	);
 }
 
-function WardrobeUseRoomBackground({ account }: { account: IDirectoryAccountInfo; }): ReactElement {
+function WardrobeUseRoomBackground({ currentSettings }: { currentSettings: Immutable<AccountSettings>; }): ReactElement {
 	const directory = useDirectoryConnector();
-	const [show, setShow] = useState(account.settings.wardrobeUseRoomBackground);
+	const [show, setShow] = useState(currentSettings.wardrobeUseRoomBackground);
 
 	const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const newValue = e.target.checked;
 		setShow(newValue);
-		directory.sendMessage('changeSettings', { wardrobeUseRoomBackground: newValue });
+		directory.sendMessage('changeSettings', {
+			type: 'set',
+			settings: { wardrobeUseRoomBackground: newValue },
+		});
 	};
 
 	return (
@@ -197,14 +219,17 @@ function WardrobeUseRoomBackground({ account }: { account: IDirectoryAccountInfo
 	);
 }
 
-function WardrobeShowExtraButtons({ account }: { account: IDirectoryAccountInfo; }): ReactElement {
+function WardrobeShowExtraButtons({ currentSettings }: { currentSettings: Immutable<AccountSettings>; }): ReactElement {
 	const directory = useDirectoryConnector();
-	const [show, setShow] = useState(account.settings.wardrobeExtraActionButtons);
+	const [show, setShow] = useState(currentSettings.wardrobeExtraActionButtons);
 
 	const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const newValue = e.target.checked;
 		setShow(newValue);
-		directory.sendMessage('changeSettings', { wardrobeExtraActionButtons: newValue });
+		directory.sendMessage('changeSettings', {
+			type: 'set',
+			settings: { wardrobeExtraActionButtons: newValue },
+		});
 	};
 
 	return (
@@ -215,14 +240,17 @@ function WardrobeShowExtraButtons({ account }: { account: IDirectoryAccountInfo;
 	);
 }
 
-function WardrobeHoverPreview({ account }: { account: IDirectoryAccountInfo; }): ReactElement {
+function WardrobeHoverPreview({ currentSettings }: { currentSettings: Immutable<AccountSettings>; }): ReactElement {
 	const directory = useDirectoryConnector();
-	const [show, setShow] = useState(account.settings.wardrobeHoverPreview);
+	const [show, setShow] = useState(currentSettings.wardrobeHoverPreview);
 
 	const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const newValue = e.target.checked;
 		setShow(newValue);
-		directory.sendMessage('changeSettings', { wardrobeHoverPreview: newValue });
+		directory.sendMessage('changeSettings', {
+			type: 'set',
+			settings: { wardrobeHoverPreview: newValue },
+		});
 	};
 
 	return (
@@ -233,13 +261,13 @@ function WardrobeHoverPreview({ account }: { account: IDirectoryAccountInfo; }):
 	);
 }
 
-const WARDROBE_PREVIEWS_DESCRIPTION: Record<IDirectoryAccountSettings['wardrobeOutfitsPreview'], string> = {
+const WARDROBE_PREVIEWS_DESCRIPTION: Record<AccountSettings['wardrobeOutfitsPreview'], string> = {
 	disabled: 'Disabled (better performance)',
 	small: 'Enabled (small live previews)',
 	big: 'Enabled (big live previews)',
 };
 
-const WARDROBE_PREVIEW_TYPE_DESCRIPTION: Record<IDirectoryAccountSettings['wardrobeSmallPreview'], string> = {
+const WARDROBE_PREVIEW_TYPE_DESCRIPTION: Record<AccountSettings['wardrobeSmallPreview'], string> = {
 	icon: 'Show attribute icon',
 	image: 'Show preview image',
 };
@@ -248,23 +276,26 @@ type StringKeyOf<T> = {
 	[K in keyof T]: T[K] extends string ? K : never
 }[keyof T];
 
-function WardrobeSelectSettings<K extends StringKeyOf<IDirectoryAccountSettings>>({ account, setting, label, stringify }: {
-	account: IDirectoryAccountInfo;
+function WardrobeSelectSettings<K extends StringKeyOf<AccountSettings>>({ currentSettings, setting, label, stringify }: {
+	currentSettings: Immutable<AccountSettings>;
 	setting: K;
 	label: string;
-	stringify: Readonly<Record<IDirectoryAccountSettings[K], string>>;
+	stringify: Readonly<Record<AccountSettings[K], string>>;
 }): ReactElement {
 	const directory = useDirectoryConnector();
-	const [value, setValue] = useRemotelyUpdatedUserInput(account.settings[setting], [account], {
+	const [value, setValue] = useRemotelyUpdatedUserInput(currentSettings[setting], undefined, {
 		updateCallback: (newValue) => {
-			directory.sendMessage('changeSettings', { [setting]: newValue });
+			directory.sendMessage('changeSettings', {
+				type: 'set',
+				settings: { [setting]: newValue },
+			});
 		},
 	});
 	const onChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
-		const newValue = DirectoryAccountSettingsSchema.shape[setting].parse(e.target.value);
-		setValue(newValue as IDirectoryAccountSettings[K]);
+		const newValue = AccountSettingsSchema.shape[setting].parse(e.target.value);
+		setValue(newValue as AccountSettings[K]);
 	}, [setting, setValue]);
-	const options = useMemo(() => (Object.entries(stringify) as [IDirectoryAccountSettings[K], string][]).map(([k, v]) => (
+	const options = useMemo(() => (Object.entries(stringify) as [AccountSettings[K], string][]).map(([k, v]) => (
 		<option key={ k } value={ k }>
 			{ v }
 		</option>

--- a/pandora-client-web/src/components/wardrobe/views/wardrobeOutfitView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobeOutfitView.tsx
@@ -21,7 +21,7 @@ import {
 	LIMIT_OUTFIT_NAME_LENGTH,
 	OutfitMeasureCost,
 } from 'pandora-common';
-import { useEffectiveAccountSettings, useDirectoryChangeListener, useDirectoryConnector } from '../../gameContext/directoryConnectorContextProvider';
+import { useAccountSettings, useDirectoryChangeListener, useDirectoryConnector } from '../../gameContext/directoryConnectorContextProvider';
 import _, { clamp, first, noop } from 'lodash';
 import { Column, DivContainer, Row } from '../../common/container/container';
 import { toast } from 'react-toastify';
@@ -406,7 +406,7 @@ function TemporaryOutfitEntry({ outfit, saveOutfit, updateOutfit, beginEditOutfi
 	beginEditOutfit: () => void;
 	targetContainer: ItemContainerPath;
 }): ReactElement {
-	const { wardrobeOutfitsPreview } = useEffectiveAccountSettings();
+	const { wardrobeOutfitsPreview } = useAccountSettings();
 
 	return (
 		<div className='outfit'>
@@ -469,7 +469,7 @@ function OutfitEntry({ outfit, updateOutfit, reorderOutfit, beginEditOutfit, tar
 	beginEditOutfit: () => void;
 	targetContainer: ItemContainerPath;
 }): ReactElement {
-	const { wardrobeOutfitsPreview } = useEffectiveAccountSettings();
+	const { wardrobeOutfitsPreview } = useAccountSettings();
 	const [expanded, setExpanded] = useState(false);
 	const confirm = useConfirmDialog();
 

--- a/pandora-client-web/src/components/wardrobe/views/wardrobeOutfitView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobeOutfitView.tsx
@@ -21,7 +21,7 @@ import {
 	LIMIT_OUTFIT_NAME_LENGTH,
 	OutfitMeasureCost,
 } from 'pandora-common';
-import { useCurrentAccountSettings, useDirectoryChangeListener, useDirectoryConnector } from '../../gameContext/directoryConnectorContextProvider';
+import { useEffectiveAccountSettings, useDirectoryChangeListener, useDirectoryConnector } from '../../gameContext/directoryConnectorContextProvider';
 import _, { clamp, first, noop } from 'lodash';
 import { Column, DivContainer, Row } from '../../common/container/container';
 import { toast } from 'react-toastify';
@@ -406,7 +406,7 @@ function TemporaryOutfitEntry({ outfit, saveOutfit, updateOutfit, beginEditOutfi
 	beginEditOutfit: () => void;
 	targetContainer: ItemContainerPath;
 }): ReactElement {
-	const { wardrobeOutfitsPreview } = useCurrentAccountSettings();
+	const { wardrobeOutfitsPreview } = useEffectiveAccountSettings();
 
 	return (
 		<div className='outfit'>
@@ -469,7 +469,7 @@ function OutfitEntry({ outfit, updateOutfit, reorderOutfit, beginEditOutfit, tar
 	beginEditOutfit: () => void;
 	targetContainer: ItemContainerPath;
 }): ReactElement {
-	const { wardrobeOutfitsPreview } = useCurrentAccountSettings();
+	const { wardrobeOutfitsPreview } = useEffectiveAccountSettings();
 	const [expanded, setExpanded] = useState(false);
 	const confirm = useConfirmDialog();
 

--- a/pandora-client-web/src/components/wardrobe/wardrobeComponents.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobeComponents.tsx
@@ -21,7 +21,7 @@ import { useGraphicsUrl } from '../../assets/graphicsManager';
 import { useWardrobeContext, useWardrobeExecuteChecked } from './wardrobeContext';
 import { useStaggeredAppearanceActionResult } from './wardrobeCheckQueue';
 import _ from 'lodash';
-import { useEffectiveAccountSettings } from '../gameContext/directoryConnectorContextProvider';
+import { useAccountSettings } from '../gameContext/directoryConnectorContextProvider';
 import { useAssetPreferenceVisibilityCheck } from '../../graphics/graphicsCharacter';
 import { BrowserStorage } from '../../browserStorage';
 import { useObservable } from '../../observable';
@@ -298,7 +298,7 @@ export function InventoryAssetPreview({ asset, small }: {
 }
 
 function useAssetPreviewType(small: boolean): 'icon' | 'image' {
-	const { wardrobeSmallPreview, wardrobeBigPreview } = useEffectiveAccountSettings();
+	const { wardrobeSmallPreview, wardrobeBigPreview } = useAccountSettings();
 
 	if (small)
 		return wardrobeSmallPreview;

--- a/pandora-client-web/src/components/wardrobe/wardrobeComponents.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobeComponents.tsx
@@ -21,7 +21,7 @@ import { useGraphicsUrl } from '../../assets/graphicsManager';
 import { useWardrobeContext, useWardrobeExecuteChecked } from './wardrobeContext';
 import { useStaggeredAppearanceActionResult } from './wardrobeCheckQueue';
 import _ from 'lodash';
-import { useCurrentAccountSettings } from '../gameContext/directoryConnectorContextProvider';
+import { useEffectiveAccountSettings } from '../gameContext/directoryConnectorContextProvider';
 import { useAssetPreferenceVisibilityCheck } from '../../graphics/graphicsCharacter';
 import { BrowserStorage } from '../../browserStorage';
 import { useObservable } from '../../observable';
@@ -298,12 +298,12 @@ export function InventoryAssetPreview({ asset, small }: {
 }
 
 function useAssetPreviewType(small: boolean): 'icon' | 'image' {
-	const settings = useCurrentAccountSettings();
+	const { wardrobeSmallPreview, wardrobeBigPreview } = useEffectiveAccountSettings();
 
 	if (small)
-		return settings.wardrobeSmallPreview;
+		return wardrobeSmallPreview;
 
-	return settings.wardrobeBigPreview;
+	return wardrobeBigPreview;
 }
 
 export function InventoryAttributePreview({ attribute }: {

--- a/pandora-client-web/src/components/wardrobe/wardrobeContext.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobeContext.tsx
@@ -18,7 +18,7 @@ import { useShardConnector } from '../gameContext/shardConnectorContextProvider'
 import { useActionSpaceContext, useSpaceCharacters, useGameState, useGlobalState } from '../gameContext/gameStateContextProvider';
 import type { PlayerCharacter } from '../../character/player';
 import { EvalItemPath } from 'pandora-common/dist/assets/appearanceHelpers';
-import { useCurrentAccount } from '../gameContext/directoryConnectorContextProvider';
+import { useEffectiveAccountSettings } from '../gameContext/directoryConnectorContextProvider';
 import { WardrobeContext, WardrobeContextExtraItemActionComponent, WardrobeFocus, WardrobeHeldItem, WardrobeTarget } from './wardrobeTypes';
 import { useAsyncEvent } from '../../common/useEvent';
 import { toast } from 'react-toastify';
@@ -35,15 +35,13 @@ export const wardrobeContext = createContext<WardrobeContext | null>(null);
 export const WARDROBE_TARGET_ROOM: WardrobeTarget = freeze({ type: 'room' });
 
 export function WardrobeContextProvider({ target, player, children }: { target: WardrobeTarget; player: PlayerCharacter; children: ReactNode; }): ReactElement {
-	const account = useCurrentAccount();
+	const settings = useEffectiveAccountSettings();
 	const assetList = useAssetManager().assetList;
 	const gameState = useGameState();
 	const globalStateContainer = gameState.globalState;
 	const spaceContext = useActionSpaceContext();
 	const shardConnector = useShardConnector();
 	const characters = useSpaceCharacters();
-
-	AssertNotNullable(account);
 
 	const focus = useMemo(() => new Observable<Immutable<WardrobeFocus>>({ container: [], itemId: null }), []);
 	const extraItemActions = useMemo(() => new Observable<readonly WardrobeContextExtraItemActionComponent[]>([]), []);
@@ -104,9 +102,9 @@ export function WardrobeContextProvider({ target, player, children }: { target: 
 		actions,
 		execute: (action) => shardConnector?.awaitResponse('appearanceAction', action),
 		actionPreviewState,
-		showExtraActionButtons: account.settings.wardrobeExtraActionButtons,
-		showHoverPreview: account.settings.wardrobeHoverPreview,
-	}), [target, targetSelector, player, globalState, assetList, heldItem, focus, extraItemActions, actions, shardConnector, actionPreviewState, account.settings]);
+		showExtraActionButtons: settings.wardrobeExtraActionButtons,
+		showHoverPreview: settings.wardrobeHoverPreview,
+	}), [target, targetSelector, player, globalState, assetList, heldItem, focus, extraItemActions, actions, shardConnector, actionPreviewState, settings]);
 
 	return (
 		<wardrobeContext.Provider value={ context }>

--- a/pandora-client-web/src/components/wardrobe/wardrobeContext.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobeContext.tsx
@@ -18,7 +18,7 @@ import { useShardConnector } from '../gameContext/shardConnectorContextProvider'
 import { useActionSpaceContext, useSpaceCharacters, useGameState, useGlobalState } from '../gameContext/gameStateContextProvider';
 import type { PlayerCharacter } from '../../character/player';
 import { EvalItemPath } from 'pandora-common/dist/assets/appearanceHelpers';
-import { useEffectiveAccountSettings } from '../gameContext/directoryConnectorContextProvider';
+import { useAccountSettings } from '../gameContext/directoryConnectorContextProvider';
 import { WardrobeContext, WardrobeContextExtraItemActionComponent, WardrobeFocus, WardrobeHeldItem, WardrobeTarget } from './wardrobeTypes';
 import { useAsyncEvent } from '../../common/useEvent';
 import { toast } from 'react-toastify';
@@ -35,7 +35,7 @@ export const wardrobeContext = createContext<WardrobeContext | null>(null);
 export const WARDROBE_TARGET_ROOM: WardrobeTarget = freeze({ type: 'room' });
 
 export function WardrobeContextProvider({ target, player, children }: { target: WardrobeTarget; player: PlayerCharacter; children: ReactNode; }): ReactElement {
-	const settings = useEffectiveAccountSettings();
+	const settings = useAccountSettings();
 	const assetList = useAssetManager().assetList;
 	const gameState = useGameState();
 	const globalStateContainer = gameState.globalState;

--- a/pandora-client-web/src/components/wardrobe/wardrobeGraphics.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobeGraphics.tsx
@@ -20,7 +20,7 @@ import { useEvent } from '../../common/useEvent';
 import { GraphicsBackground, GraphicsScene, GraphicsSceneProps } from '../../graphics/graphicsScene';
 import { CHARACTER_PIVOT_POSITION, GraphicsCharacter } from '../../graphics/graphicsCharacter';
 import { ColorInput } from '../common/colorInput/colorInput';
-import { directoryConnectorContext, useCurrentAccountSettings, useDirectoryConnector } from '../gameContext/directoryConnectorContextProvider';
+import { directoryConnectorContext, useEffectiveAccountSettings, useDirectoryConnector } from '../gameContext/directoryConnectorContextProvider';
 import { useAssetManager } from '../../assets/assetManager';
 import { useSpaceInfo } from '../gameContext/gameStateContextProvider';
 import { RoomCharacter, useRoomCharacterOffsets, useRoomCharacterPosition } from '../../graphics/room/roomCharacter';
@@ -83,7 +83,7 @@ export function CharacterPreview({ character, characterState, overlay }: {
 }): ReactElement {
 	const spaceInfo = useSpaceInfo();
 	const assetManager = useAssetManager();
-	const accountSettings = useCurrentAccountSettings();
+	const accountSettings = useEffectiveAccountSettings();
 
 	const roomBackground = useMemo((): Immutable<RoomBackgroundData> => {
 		return ResolveBackground(assetManager, spaceInfo.config.background);
@@ -151,20 +151,23 @@ function WardrobeRoomBackground({
 }
 
 function WardrobeBackgroundColorPicker(): ReactElement | null {
-	const accountSettings = useCurrentAccountSettings();
+	const { wardrobeUseRoomBackground, wardrobeBackground } = useEffectiveAccountSettings();
 	const directory = useDirectoryConnector();
 
 	const onChange = useEvent((newColor: HexColorString) => {
-		directory.sendMessage('changeSettings', { wardrobeBackground: newColor });
+		directory.sendMessage('changeSettings', {
+			type: 'set',
+			settings: { wardrobeBackground: newColor },
+		});
 	});
 
 	// Don't show the picker, if it would have no effect
-	if (accountSettings.wardrobeUseRoomBackground)
+	if (wardrobeUseRoomBackground)
 		return null;
 
 	return (
 		<ColorInput
-			initialValue={ accountSettings.wardrobeBackground }
+			initialValue={ wardrobeBackground }
 			onChange={ onChange }
 			throttle={ 100 }
 			hideTextInput={ true }

--- a/pandora-client-web/src/graphics/room/roomCharacter.tsx
+++ b/pandora-client-web/src/graphics/room/roomCharacter.tsx
@@ -20,7 +20,7 @@ import { useEvent } from '../../common/useEvent';
 import { MASK_SIZE, SwapCullingDirection } from '../graphicsLayer';
 import { useCharacterRestrictionsManager } from '../../components/gameContext/gameStateContextProvider';
 import { RoomProjectionResolver, useCharacterDisplayFilters, usePlayerVisionFilters } from './roomScene';
-import { useEffectiveAccountSettings } from '../../components/gameContext/directoryConnectorContextProvider';
+import { useAccountSettings } from '../../components/gameContext/directoryConnectorContextProvider';
 import { useTexture } from '../useTexture';
 import disconnectedIcon from '../../assets/icons/disconnected.svg';
 import { useAppOptional } from '../utility';
@@ -268,7 +268,7 @@ const RoomCharacterDisplay = React.forwardRef(function RoomCharacterDisplay({
 		isOnline,
 	} = useCharacterData(character);
 
-	const { interfaceChatroomOfflineCharacterFilter } = useEffectiveAccountSettings();
+	const { interfaceChatroomOfflineCharacterFilter } = useAccountSettings();
 
 	const playerFilters = usePlayerVisionFilters(character.isPlayer());
 	const characterFilters = useCharacterDisplayFilters(character);

--- a/pandora-client-web/src/graphics/room/roomCharacter.tsx
+++ b/pandora-client-web/src/graphics/room/roomCharacter.tsx
@@ -20,7 +20,7 @@ import { useEvent } from '../../common/useEvent';
 import { MASK_SIZE, SwapCullingDirection } from '../graphicsLayer';
 import { useCharacterRestrictionsManager } from '../../components/gameContext/gameStateContextProvider';
 import { RoomProjectionResolver, useCharacterDisplayFilters, usePlayerVisionFilters } from './roomScene';
-import { useCurrentAccountSettings } from '../../components/gameContext/directoryConnectorContextProvider';
+import { useEffectiveAccountSettings } from '../../components/gameContext/directoryConnectorContextProvider';
 import { useTexture } from '../useTexture';
 import disconnectedIcon from '../../assets/icons/disconnected.svg';
 import { useAppOptional } from '../utility';
@@ -268,7 +268,7 @@ const RoomCharacterDisplay = React.forwardRef(function RoomCharacterDisplay({
 		isOnline,
 	} = useCharacterData(character);
 
-	const { interfaceChatroomOfflineCharacterFilter } = useCurrentAccountSettings();
+	const { interfaceChatroomOfflineCharacterFilter } = useEffectiveAccountSettings();
 
 	const playerFilters = usePlayerVisionFilters(character.isPlayer());
 	const characterFilters = useCharacterDisplayFilters(character);

--- a/pandora-client-web/src/graphics/room/roomScene.tsx
+++ b/pandora-client-web/src/graphics/room/roomScene.tsx
@@ -23,7 +23,7 @@ import { useAssetManager } from '../../assets/assetManager';
 import { Character, useCharacterData } from '../../character/character';
 import { CommonProps } from '../../common/reactTypes';
 import { useEvent } from '../../common/useEvent';
-import { directoryConnectorContext, useCurrentAccountSettings } from '../../components/gameContext/directoryConnectorContextProvider';
+import { directoryConnectorContext, useEffectiveAccountSettings } from '../../components/gameContext/directoryConnectorContextProvider';
 import { useCharacterRestrictionsManager, useCharacterState, useGameState, useGlobalState, useSpaceCharacters, useSpaceInfo } from '../../components/gameContext/gameStateContextProvider';
 import { usePlayer, usePlayerState } from '../../components/gameContext/playerContextProvider';
 import { shardConnectorContext, useShardConnector } from '../../components/gameContext/shardConnectorContextProvider';
@@ -394,7 +394,7 @@ export function useCharacterDisplayFilters(character: Character<ICharacterRoomDa
 		isOnline,
 	} = useCharacterData(character);
 
-	const { interfaceChatroomOfflineCharacterFilter } = useCurrentAccountSettings();
+	const { interfaceChatroomOfflineCharacterFilter } = useEffectiveAccountSettings();
 
 	const onlineFilters = useMemo(() => [], []);
 

--- a/pandora-client-web/src/graphics/room/roomScene.tsx
+++ b/pandora-client-web/src/graphics/room/roomScene.tsx
@@ -23,7 +23,7 @@ import { useAssetManager } from '../../assets/assetManager';
 import { Character, useCharacterData } from '../../character/character';
 import { CommonProps } from '../../common/reactTypes';
 import { useEvent } from '../../common/useEvent';
-import { directoryConnectorContext, useEffectiveAccountSettings } from '../../components/gameContext/directoryConnectorContextProvider';
+import { directoryConnectorContext, useAccountSettings } from '../../components/gameContext/directoryConnectorContextProvider';
 import { useCharacterRestrictionsManager, useCharacterState, useGameState, useGlobalState, useSpaceCharacters, useSpaceInfo } from '../../components/gameContext/gameStateContextProvider';
 import { usePlayer, usePlayerState } from '../../components/gameContext/playerContextProvider';
 import { shardConnectorContext, useShardConnector } from '../../components/gameContext/shardConnectorContextProvider';
@@ -394,7 +394,7 @@ export function useCharacterDisplayFilters(character: Character<ICharacterRoomDa
 		isOnline,
 	} = useCharacterData(character);
 
-	const { interfaceChatroomOfflineCharacterFilter } = useEffectiveAccountSettings();
+	const { interfaceChatroomOfflineCharacterFilter } = useAccountSettings();
 
 	const onlineFilters = useMemo(() => [], []);
 

--- a/pandora-client-web/src/ui/components/chat/chat.tsx
+++ b/pandora-client-web/src/ui/components/chat/chat.tsx
@@ -19,14 +19,14 @@ import { AutoCompleteHint, ChatInputArea, useChatCommandContext, useChatInput } 
 import { Scrollable } from '../../../components/common/scrollbar/scrollbar';
 import { useAutoScroll } from '../../../common/useAutoScroll';
 import { IChatMessageProcessed, IsActionMessage, RenderActionContent, RenderChatPart } from './chatMessages';
-import { useEffectiveAccountSettings } from '../../../components/gameContext/directoryConnectorContextProvider';
+import { useAccountSettings } from '../../../components/gameContext/directoryConnectorContextProvider';
 import { Column } from '../../../components/common/container/container';
 import { COMMANDS } from './commands';
 
 export function Chat(): ReactElement | null {
 	const messages = useChatMessages();
 	const shardConnector = useShardConnector();
-	const { interfaceChatroomChatFontSize } = useEffectiveAccountSettings();
+	const { interfaceChatroomChatFontSize } = useAccountSettings();
 	const [messagesDiv, scroll, isScrolling] = useAutoScroll<HTMLDivElement>([messages]);
 	const lastMessageCount = useRef(0);
 	let newMessageCount = 0;

--- a/pandora-client-web/src/ui/components/chat/chat.tsx
+++ b/pandora-client-web/src/ui/components/chat/chat.tsx
@@ -19,14 +19,14 @@ import { AutoCompleteHint, ChatInputArea, useChatCommandContext, useChatInput } 
 import { Scrollable } from '../../../components/common/scrollbar/scrollbar';
 import { useAutoScroll } from '../../../common/useAutoScroll';
 import { IChatMessageProcessed, IsActionMessage, RenderActionContent, RenderChatPart } from './chatMessages';
-import { useCurrentAccountSettings } from '../../../components/gameContext/directoryConnectorContextProvider';
+import { useEffectiveAccountSettings } from '../../../components/gameContext/directoryConnectorContextProvider';
 import { Column } from '../../../components/common/container/container';
 import { COMMANDS } from './commands';
 
 export function Chat(): ReactElement | null {
 	const messages = useChatMessages();
 	const shardConnector = useShardConnector();
-	const { interfaceChatroomChatFontSize } = useCurrentAccountSettings();
+	const { interfaceChatroomChatFontSize } = useEffectiveAccountSettings();
 	const [messagesDiv, scroll, isScrolling] = useAutoScroll<HTMLDivElement>([messages]);
 	const lastMessageCount = useRef(0);
 	let newMessageCount = 0;

--- a/pandora-client-web/src/ui/screens/room/room.tsx
+++ b/pandora-client-web/src/ui/screens/room/room.tsx
@@ -9,13 +9,13 @@ import { usePlayerState } from '../../../components/gameContext/playerContextPro
 import { Chat } from '../../components/chat/chat';
 import { Scrollable } from '../../../components/common/scrollbar/scrollbar';
 import { RoomControls, PersonalSpaceControls, useRoomConstructionModeCheck } from './roomControls';
-import { useEffectiveAccountSettings } from '../../../components/gameContext/directoryConnectorContextProvider';
+import { useAccountSettings } from '../../../components/gameContext/directoryConnectorContextProvider';
 import { useIsPortrait } from '../../../styles/mediaQueries';
 import { useSpaceInfo } from '../../../components/gameContext/gameStateContextProvider';
 import './room.scss';
 
 export function RoomScreen(): ReactElement | null {
-	const { interfaceChatroomGraphicsRatioHorizontal, interfaceChatroomGraphicsRatioVertical } = useEffectiveAccountSettings();
+	const { interfaceChatroomGraphicsRatioHorizontal, interfaceChatroomGraphicsRatioVertical } = useAccountSettings();
 	const isPortrait = useIsPortrait();
 	const spaceInfo = useSpaceInfo();
 	useRoomConstructionModeCheck();

--- a/pandora-client-web/src/ui/screens/room/room.tsx
+++ b/pandora-client-web/src/ui/screens/room/room.tsx
@@ -9,13 +9,13 @@ import { usePlayerState } from '../../../components/gameContext/playerContextPro
 import { Chat } from '../../components/chat/chat';
 import { Scrollable } from '../../../components/common/scrollbar/scrollbar';
 import { RoomControls, PersonalSpaceControls, useRoomConstructionModeCheck } from './roomControls';
-import { useCurrentAccountSettings } from '../../../components/gameContext/directoryConnectorContextProvider';
+import { useEffectiveAccountSettings } from '../../../components/gameContext/directoryConnectorContextProvider';
 import { useIsPortrait } from '../../../styles/mediaQueries';
 import { useSpaceInfo } from '../../../components/gameContext/gameStateContextProvider';
 import './room.scss';
 
 export function RoomScreen(): ReactElement | null {
-	const { interfaceChatroomGraphicsRatioHorizontal, interfaceChatroomGraphicsRatioVertical } = useCurrentAccountSettings();
+	const { interfaceChatroomGraphicsRatioHorizontal, interfaceChatroomGraphicsRatioVertical } = useEffectiveAccountSettings();
 	const isPortrait = useIsPortrait();
 	const spaceInfo = useSpaceInfo();
 	useRoomConstructionModeCheck();

--- a/pandora-common/src/account/index.ts
+++ b/pandora-common/src/account/index.ts
@@ -1,2 +1,3 @@
 export * from './account';
 export * from './accountRoles';
+export * from './settings';

--- a/pandora-common/src/account/settings.ts
+++ b/pandora-common/src/account/settings.ts
@@ -1,0 +1,103 @@
+import { z } from 'zod';
+import { AccountRoleSchema } from './accountRoles';
+import { KnownObject, ParseArrayNotEmpty, TimeSpanMs } from '../utility';
+import { DisplayNameSchema, HexColorStringSchema } from '../validation';
+
+export const DirectoryAccountSettingsSchema = z.object({
+	visibleRoles: z.array(AccountRoleSchema).max(AccountRoleSchema.options.length),
+	labelColor: HexColorStringSchema.catch('#ffffff'),
+	displayName: DisplayNameSchema.nullable().catch(null),
+	/** Hides online status from friends */
+	hideOnlineStatus: z.boolean().default(false),
+	/**
+	 * - 'all' - Allow direct messages from anyone
+	 * - 'room' - Allow direct messages from friends and people in the same space | TODO(spaces): Update?
+	 * - 'friends' - Only allow direct messages from friends
+	 */
+	allowDirectMessagesFrom: z.enum(['all', 'room', 'friends']).default('all'),
+	/**
+	 * Controls whether to show extra quick actions in wardrobe
+	 * (actions that are doable with multiple clicks even without this button, but the button allows doing them as single click)
+	 */
+	wardrobeExtraActionButtons: z.boolean().catch(true),
+	/**
+	 * Controls whether to show character preview when hovering over an action button.
+	 * (when action is possible the character preview shows the result state while hovering)
+	 */
+	wardrobeHoverPreview: z.boolean().catch(true),
+	/**
+	 * If outfits tab should generate previews for outfits and if the previews should be small or big.
+	 */
+	wardrobeOutfitsPreview: z.enum(['disabled', 'small', 'big']).default('small'),
+	// TODO(spaces): Consider dropping this option, it might no longer be needed
+	/**
+	 * Color to use as wardrobe character preview background, unless room background is used (see `wardrobeUseRoomBackground` setting).
+	 */
+	wardrobeBackground: HexColorStringSchema.catch('#aaaaaa'),
+	// TODO(spaces): Consider dropping this option, it might no longer be needed
+	/**
+	 * Controls whether wardrobe should use the room's background, if character is in a room.
+	 * If character is not in the room, or if this is `false`, then `wardrobeBackground` setting is used.
+	 */
+	wardrobeUseRoomBackground: z.boolean().catch(true),
+	/**
+	 * Controls whether to show the attribute icons or preview images in small preview.
+	 */
+	wardrobeSmallPreview: z.enum(['icon', 'image']).default('image'),
+	/**
+	 * Controls whether to show the attribute icons or preview images in big preview.
+	 */
+	wardrobeBigPreview: z.enum(['icon', 'image']).default('image'),
+	/**
+	 * Controls how many parts (of 10 total) the room graphics takes, while in horizontal mode
+	 */
+	interfaceChatroomGraphicsRatioHorizontal: z.number().int().min(1).max(9).catch(7),
+	/**
+	 * Controls how many parts (of 10 total) the room graphics takes, while in vertical mode
+	 */
+	interfaceChatroomGraphicsRatioVertical: z.number().int().min(1).max(9).catch(4),
+	/**
+	 * Controls how offline characters are displayed in a room:
+	 * - None: No difference between online and offline characters
+	 * - Icon: Show disconnected icon under the name (not shown on other options)
+	 * - Darken: The characters are darkened (similar to blindness)
+	 * - Ghost: Darken + semi-transparent
+	 */
+	interfaceChatroomOfflineCharacterFilter: z.enum(['none', 'icon', 'darken', 'ghost']).default('ghost'),
+	/**
+	 * Controls how big the font size used in the main chat area is
+	 */
+	interfaceChatroomChatFontSize: z.enum(['xs', 's', 'm', 'l', 'xl']).default('m'),
+});
+
+export type IDirectoryAccountSettings = z.infer<typeof DirectoryAccountSettingsSchema>;
+
+export const ACCOUNT_SETTINGS_DEFAULT = Object.freeze<IDirectoryAccountSettings>({
+	visibleRoles: [],
+	labelColor: '#ffffff',
+	displayName: null,
+	hideOnlineStatus: false,
+	allowDirectMessagesFrom: 'all',
+	wardrobeExtraActionButtons: true,
+	wardrobeBackground: '#aaaaaa',
+	wardrobeUseRoomBackground: true,
+	wardrobeHoverPreview: true,
+	wardrobeOutfitsPreview: 'small',
+	wardrobeSmallPreview: 'image',
+	wardrobeBigPreview: 'image',
+	interfaceChatroomGraphicsRatioHorizontal: 7,
+	interfaceChatroomGraphicsRatioVertical: 4,
+	interfaceChatroomOfflineCharacterFilter: 'ghost',
+	interfaceChatroomChatFontSize: 'm',
+});
+
+export const ACCOUNT_SETTINGS_LIMITED_LIMITS = Object.freeze({
+	displayName: TimeSpanMs(1, 'weeks'),
+} as const satisfies Partial<Record<keyof IDirectoryAccountSettings, number>>);
+
+export const DirectoryAccountSettingsLimitedKeysSchema = z.enum(ParseArrayNotEmpty(KnownObject.keys(ACCOUNT_SETTINGS_LIMITED_LIMITS)));
+export type DirectoryAccountSettingsLimitedKeys = z.infer<typeof DirectoryAccountSettingsLimitedKeysSchema>;
+
+export const DirectoryAccountSettingsCooldownsSchema = z.record(DirectoryAccountSettingsLimitedKeysSchema, z.number().optional());
+export type DirectoryAccountSettingsCooldowns = z.infer<typeof DirectoryAccountSettingsCooldownsSchema>;
+

--- a/pandora-common/src/account/settings.ts
+++ b/pandora-common/src/account/settings.ts
@@ -31,17 +31,6 @@ export const AccountSettingsSchema = z.object({
 	 * If outfits tab should generate previews for outfits and if the previews should be small or big.
 	 */
 	wardrobeOutfitsPreview: z.enum(['disabled', 'small', 'big']),
-	// TODO(spaces): Consider dropping this option, it might no longer be needed
-	/**
-	 * Color to use as wardrobe character preview background, unless room background is used (see `wardrobeUseRoomBackground` setting).
-	 */
-	wardrobeBackground: HexColorStringSchema,
-	// TODO(spaces): Consider dropping this option, it might no longer be needed
-	/**
-	 * Controls whether wardrobe should use the room's background, if character is in a room.
-	 * If character is not in the room, or if this is `false`, then `wardrobeBackground` setting is used.
-	 */
-	wardrobeUseRoomBackground: z.boolean(),
 	/**
 	 * Controls whether to show the attribute icons or preview images in small preview.
 	 */
@@ -82,8 +71,6 @@ export const ACCOUNT_SETTINGS_DEFAULT = Object.freeze<AccountSettings>({
 	wardrobeExtraActionButtons: true,
 	wardrobeHoverPreview: true,
 	wardrobeOutfitsPreview: 'small',
-	wardrobeBackground: '#aaaaaa',
-	wardrobeUseRoomBackground: true,
 	wardrobeSmallPreview: 'image',
 	wardrobeBigPreview: 'image',
 	interfaceChatroomGraphicsRatioHorizontal: 7,

--- a/pandora-common/src/account/settings.ts
+++ b/pandora-common/src/account/settings.ts
@@ -3,59 +3,61 @@ import { AccountRoleSchema } from './accountRoles';
 import { KnownObject, ParseArrayNotEmpty, TimeSpanMs } from '../utility';
 import { DisplayNameSchema, HexColorStringSchema } from '../validation';
 
-export const DirectoryAccountSettingsSchema = z.object({
+//#region Settings declarations
+
+export const AccountSettingsSchema = z.object({
 	visibleRoles: z.array(AccountRoleSchema).max(AccountRoleSchema.options.length),
-	labelColor: HexColorStringSchema.catch('#ffffff'),
-	displayName: DisplayNameSchema.nullable().catch(null),
+	labelColor: HexColorStringSchema,
+	displayName: DisplayNameSchema.nullable(),
 	/** Hides online status from friends */
-	hideOnlineStatus: z.boolean().default(false),
+	hideOnlineStatus: z.boolean(),
 	/**
 	 * - 'all' - Allow direct messages from anyone
 	 * - 'room' - Allow direct messages from friends and people in the same space | TODO(spaces): Update?
 	 * - 'friends' - Only allow direct messages from friends
 	 */
-	allowDirectMessagesFrom: z.enum(['all', 'room', 'friends']).default('all'),
+	allowDirectMessagesFrom: z.enum(['all', 'room', 'friends']),
 	/**
 	 * Controls whether to show extra quick actions in wardrobe
 	 * (actions that are doable with multiple clicks even without this button, but the button allows doing them as single click)
 	 */
-	wardrobeExtraActionButtons: z.boolean().catch(true),
+	wardrobeExtraActionButtons: z.boolean(),
 	/**
 	 * Controls whether to show character preview when hovering over an action button.
 	 * (when action is possible the character preview shows the result state while hovering)
 	 */
-	wardrobeHoverPreview: z.boolean().catch(true),
+	wardrobeHoverPreview: z.boolean(),
 	/**
 	 * If outfits tab should generate previews for outfits and if the previews should be small or big.
 	 */
-	wardrobeOutfitsPreview: z.enum(['disabled', 'small', 'big']).default('small'),
+	wardrobeOutfitsPreview: z.enum(['disabled', 'small', 'big']),
 	// TODO(spaces): Consider dropping this option, it might no longer be needed
 	/**
 	 * Color to use as wardrobe character preview background, unless room background is used (see `wardrobeUseRoomBackground` setting).
 	 */
-	wardrobeBackground: HexColorStringSchema.catch('#aaaaaa'),
+	wardrobeBackground: HexColorStringSchema,
 	// TODO(spaces): Consider dropping this option, it might no longer be needed
 	/**
 	 * Controls whether wardrobe should use the room's background, if character is in a room.
 	 * If character is not in the room, or if this is `false`, then `wardrobeBackground` setting is used.
 	 */
-	wardrobeUseRoomBackground: z.boolean().catch(true),
+	wardrobeUseRoomBackground: z.boolean(),
 	/**
 	 * Controls whether to show the attribute icons or preview images in small preview.
 	 */
-	wardrobeSmallPreview: z.enum(['icon', 'image']).default('image'),
+	wardrobeSmallPreview: z.enum(['icon', 'image']),
 	/**
 	 * Controls whether to show the attribute icons or preview images in big preview.
 	 */
-	wardrobeBigPreview: z.enum(['icon', 'image']).default('image'),
+	wardrobeBigPreview: z.enum(['icon', 'image']),
 	/**
 	 * Controls how many parts (of 10 total) the room graphics takes, while in horizontal mode
 	 */
-	interfaceChatroomGraphicsRatioHorizontal: z.number().int().min(1).max(9).catch(7),
+	interfaceChatroomGraphicsRatioHorizontal: z.number().int().min(1).max(9),
 	/**
 	 * Controls how many parts (of 10 total) the room graphics takes, while in vertical mode
 	 */
-	interfaceChatroomGraphicsRatioVertical: z.number().int().min(1).max(9).catch(4),
+	interfaceChatroomGraphicsRatioVertical: z.number().int().min(1).max(9),
 	/**
 	 * Controls how offline characters are displayed in a room:
 	 * - None: No difference between online and offline characters
@@ -63,26 +65,25 @@ export const DirectoryAccountSettingsSchema = z.object({
 	 * - Darken: The characters are darkened (similar to blindness)
 	 * - Ghost: Darken + semi-transparent
 	 */
-	interfaceChatroomOfflineCharacterFilter: z.enum(['none', 'icon', 'darken', 'ghost']).default('ghost'),
+	interfaceChatroomOfflineCharacterFilter: z.enum(['none', 'icon', 'darken', 'ghost']),
 	/**
 	 * Controls how big the font size used in the main chat area is
 	 */
-	interfaceChatroomChatFontSize: z.enum(['xs', 's', 'm', 'l', 'xl']).default('m'),
+	interfaceChatroomChatFontSize: z.enum(['xs', 's', 'm', 'l', 'xl']),
 });
+export type AccountSettings = z.infer<typeof AccountSettingsSchema>;
 
-export type IDirectoryAccountSettings = z.infer<typeof DirectoryAccountSettingsSchema>;
-
-export const ACCOUNT_SETTINGS_DEFAULT = Object.freeze<IDirectoryAccountSettings>({
+export const ACCOUNT_SETTINGS_DEFAULT = Object.freeze<AccountSettings>({
 	visibleRoles: [],
 	labelColor: '#ffffff',
 	displayName: null,
 	hideOnlineStatus: false,
 	allowDirectMessagesFrom: 'all',
 	wardrobeExtraActionButtons: true,
-	wardrobeBackground: '#aaaaaa',
-	wardrobeUseRoomBackground: true,
 	wardrobeHoverPreview: true,
 	wardrobeOutfitsPreview: 'small',
+	wardrobeBackground: '#aaaaaa',
+	wardrobeUseRoomBackground: true,
 	wardrobeSmallPreview: 'image',
 	wardrobeBigPreview: 'image',
 	interfaceChatroomGraphicsRatioHorizontal: 7,
@@ -93,11 +94,15 @@ export const ACCOUNT_SETTINGS_DEFAULT = Object.freeze<IDirectoryAccountSettings>
 
 export const ACCOUNT_SETTINGS_LIMITED_LIMITS = Object.freeze({
 	displayName: TimeSpanMs(1, 'weeks'),
-} as const satisfies Partial<Record<keyof IDirectoryAccountSettings, number>>);
+} as const satisfies Partial<Record<keyof AccountSettings, number>>);
 
-export const DirectoryAccountSettingsLimitedKeysSchema = z.enum(ParseArrayNotEmpty(KnownObject.keys(ACCOUNT_SETTINGS_LIMITED_LIMITS)));
-export type DirectoryAccountSettingsLimitedKeys = z.infer<typeof DirectoryAccountSettingsLimitedKeysSchema>;
+//#endregion
 
-export const DirectoryAccountSettingsCooldownsSchema = z.record(DirectoryAccountSettingsLimitedKeysSchema, z.number().optional());
-export type DirectoryAccountSettingsCooldowns = z.infer<typeof DirectoryAccountSettingsCooldownsSchema>;
+export const AccountSettingsKeysSchema = z.enum(ParseArrayNotEmpty(KnownObject.keys(AccountSettingsSchema.shape)));
+export type AccountSettingsKeys = z.infer<typeof AccountSettingsKeysSchema>;
 
+export const AccountSettingsLimitedKeysSchema = z.enum(ParseArrayNotEmpty(KnownObject.keys(ACCOUNT_SETTINGS_LIMITED_LIMITS)));
+export type AccountSettingsLimitedKeys = z.infer<typeof AccountSettingsLimitedKeysSchema>;
+
+export const AccountSettingsCooldownsSchema = z.record(AccountSettingsLimitedKeysSchema, z.number().optional());
+export type AccountSettingsCooldowns = z.infer<typeof AccountSettingsCooldownsSchema>;

--- a/pandora-common/src/networking/client_directory.ts
+++ b/pandora-common/src/networking/client_directory.ts
@@ -1,6 +1,6 @@
 import { Immutable } from 'immer';
 import { z } from 'zod';
-import { AccountId, AccountIdSchema, AccountRoleSchema, ConfiguredAccountRoleSchema, DirectoryAccountSettingsSchema, IAccountRoleManageInfo } from '../account';
+import { AccountId, AccountIdSchema, AccountRoleSchema, ConfiguredAccountRoleSchema, AccountSettingsSchema, IAccountRoleManageInfo, AccountSettingsKeysSchema } from '../account';
 import { AssetFrameworkOutfitWithIdSchema } from '../assets/item/unified';
 import { ICharacterSelfInfo } from '../character/characterData';
 import { CharacterId, CharacterIdSchema } from '../character/characterTypes';
@@ -190,7 +190,16 @@ export const ClientDirectorySchema = {
 		response: null,
 	},
 	changeSettings: {
-		request: DirectoryAccountSettingsSchema.partial(),
+		request: z.discriminatedUnion('type', [
+			z.object({
+				type: z.literal('set'),
+				settings: AccountSettingsSchema.partial(),
+			}),
+			z.object({
+				type: z.literal('reset'),
+				settings: AccountSettingsKeysSchema.array().max(AccountSettingsKeysSchema.options.length),
+			}),
+		]),
 		response: null,
 	},
 	setInitialCryptoKey: {

--- a/pandora-common/src/networking/client_directory.ts
+++ b/pandora-common/src/networking/client_directory.ts
@@ -1,15 +1,15 @@
-import type { SocketInterfaceDefinition, SocketInterfaceDefinitionVerified, SocketInterfaceHandlerPromiseResult, SocketInterfaceHandlerResult, SocketInterfaceRequest, SocketInterfaceResponse } from './helpers';
-import { AccountCryptoKeySchema, DirectoryAccountSettingsSchema, IDirectoryAccountInfo, IDirectoryDirectMessage, IDirectoryDirectMessageAccount, IDirectoryDirectMessageInfo, IDirectoryShardInfo } from './directory_client';
-import { CharacterId, CharacterIdSchema } from '../character/characterTypes';
-import { ICharacterSelfInfo } from '../character/characterData';
-import { SpaceDirectoryConfigSchema, SpaceDirectoryUpdateSchema, SpaceListExtendedInfo, SpaceListInfo, SpaceId, SpaceIdSchema, SpaceInviteIdSchema, SpaceInvite, SpaceInviteCreateSchema } from '../space/space';
-import { AccountId, AccountIdSchema, AccountRoleSchema, ConfiguredAccountRoleSchema, IAccountRoleManageInfo } from '../account';
-import { EmailAddressSchema, HexColorString, HexColorStringSchema, PasswordSha512Schema, SimpleTokenSchema, UserNameSchema, ZodCast, ZodTruncate } from '../validation';
-import { z } from 'zod';
-import { Satisfies } from '../utility';
 import { Immutable } from 'immer';
+import { z } from 'zod';
+import { AccountId, AccountIdSchema, AccountRoleSchema, ConfiguredAccountRoleSchema, DirectoryAccountSettingsSchema, IAccountRoleManageInfo } from '../account';
 import { AssetFrameworkOutfitWithIdSchema } from '../assets/item/unified';
+import { ICharacterSelfInfo } from '../character/characterData';
+import { CharacterId, CharacterIdSchema } from '../character/characterTypes';
 import { LIMIT_ACCOUNT_PROFILE_LENGTH, LIMIT_DIRECT_MESSAGE_LENGTH_BASE64 } from '../inputLimits';
+import { SpaceDirectoryConfigSchema, SpaceDirectoryUpdateSchema, SpaceId, SpaceIdSchema, SpaceInvite, SpaceInviteCreateSchema, SpaceInviteIdSchema, SpaceListExtendedInfo, SpaceListInfo } from '../space/space';
+import { Satisfies } from '../utility';
+import { EmailAddressSchema, HexColorString, HexColorStringSchema, PasswordSha512Schema, SimpleTokenSchema, UserNameSchema, ZodCast, ZodTruncate } from '../validation';
+import { AccountCryptoKeySchema, IDirectoryAccountInfo, IDirectoryDirectMessage, IDirectoryDirectMessageAccount, IDirectoryDirectMessageInfo, IDirectoryShardInfo } from './directory_client';
+import type { SocketInterfaceDefinition, SocketInterfaceDefinitionVerified, SocketInterfaceHandlerPromiseResult, SocketInterfaceHandlerResult, SocketInterfaceRequest, SocketInterfaceResponse } from './helpers';
 
 // Fix for pnpm resolution weirdness
 import type { } from '../account/accountRoles';

--- a/pandora-common/src/networking/directory_client.ts
+++ b/pandora-common/src/networking/directory_client.ts
@@ -1,12 +1,12 @@
+import { Immutable } from 'immer';
 import { z } from 'zod';
-import { IAccountRoleInfo, AccountRoleSchema, AccountId } from '../account';
+import { AccountId, IAccountRoleInfo, type DirectoryAccountSettingsCooldowns, type IDirectoryAccountSettings } from '../account';
 import type { CharacterId } from '../character';
 import type { ShardFeature } from '../space/space';
-import { KnownObject, ParseArrayNotEmpty, Satisfies, TimeSpanMs } from '../utility';
-import { DisplayNameSchema, HexColorStringSchema, ZodCast } from '../validation';
+import { Satisfies } from '../utility';
+import { ZodCast } from '../validation';
 import type { IAccountContact, IAccountFriendStatus } from './client_directory';
 import { SocketInterfaceDefinition, SocketInterfaceDefinitionVerified, SocketInterfaceHandlerPromiseResult, SocketInterfaceHandlerResult, SocketInterfaceRequest, SocketInterfaceResponse } from './helpers';
-import { Immutable } from 'immer';
 
 export type IDirectoryStatus = {
 	time: number;
@@ -22,104 +22,6 @@ export function CreateDefaultDirectoryStatus(): IDirectoryStatus {
 		onlineCharacters: 0,
 	};
 }
-
-export const DirectoryAccountSettingsSchema = z.object({
-	visibleRoles: z.array(AccountRoleSchema).max(AccountRoleSchema.options.length),
-	labelColor: HexColorStringSchema.catch('#ffffff'),
-	displayName: DisplayNameSchema.nullable().catch(null),
-	/** Hides online status from friends */
-	hideOnlineStatus: z.boolean().default(false),
-	/**
-	 * - 'all' - Allow direct messages from anyone
-	 * - 'room' - Allow direct messages from friends and people in the same space | TODO(spaces): Update?
-	 * - 'friends' - Only allow direct messages from friends
-	 */
-	allowDirectMessagesFrom: z.enum(['all', 'room', 'friends']).default('all'),
-	/**
-	 * Controls whether to show extra quick actions in wardrobe
-	 * (actions that are doable with multiple clicks even without this button, but the button allows doing them as single click)
-	 */
-	wardrobeExtraActionButtons: z.boolean().catch(true),
-	/**
-	 * Controls whether to show character preview when hovering over an action button.
-	 * (when action is possible the character preview shows the result state while hovering)
-	 */
-	wardrobeHoverPreview: z.boolean().catch(true),
-	/**
-	 * If outfits tab should generate previews for outfits and if the previews should be small or big.
-	 */
-	wardrobeOutfitsPreview: z.enum(['disabled', 'small', 'big']).default('small'),
-	// TODO(spaces): Consider dropping this option, it might no longer be needed
-	/**
-	 * Color to use as wardrobe character preview background, unless room background is used (see `wardrobeUseRoomBackground` setting).
-	 */
-	wardrobeBackground: HexColorStringSchema.catch('#aaaaaa'),
-	// TODO(spaces): Consider dropping this option, it might no longer be needed
-	/**
-	 * Controls whether wardrobe should use the room's background, if character is in a room.
-	 * If character is not in the room, or if this is `false`, then `wardrobeBackground` setting is used.
-	 */
-	wardrobeUseRoomBackground: z.boolean().catch(true),
-	/**
-	 * Controls whether to show the attribute icons or preview images in small preview.
-	 */
-	wardrobeSmallPreview: z.enum(['icon', 'image']).default('image'),
-	/**
-	 * Controls whether to show the attribute icons or preview images in big preview.
-	 */
-	wardrobeBigPreview: z.enum(['icon', 'image']).default('image'),
-	/**
-	 * Controls how many parts (of 10 total) the room graphics takes, while in horizontal mode
-	 */
-	interfaceChatroomGraphicsRatioHorizontal: z.number().int().min(1).max(9).catch(7),
-	/**
-	 * Controls how many parts (of 10 total) the room graphics takes, while in vertical mode
-	 */
-	interfaceChatroomGraphicsRatioVertical: z.number().int().min(1).max(9).catch(4),
-	/**
-	 * Controls how offline characters are displayed in a room:
-	 * - None: No difference between online and offline characters
-	 * - Icon: Show disconnected icon under the name (not shown on other options)
-	 * - Darken: The characters are darkened (similar to blindness)
-	 * - Ghost: Darken + semi-transparent
-	 */
-	interfaceChatroomOfflineCharacterFilter: z.enum(['none', 'icon', 'darken', 'ghost']).default('ghost'),
-	/**
-	 * Controls how big the font size used in the main chat area is
-	 */
-	interfaceChatroomChatFontSize: z.enum(['xs', 's', 'm', 'l', 'xl']).default('m'),
-});
-
-export type IDirectoryAccountSettings = z.infer<typeof DirectoryAccountSettingsSchema>;
-
-export const ACCOUNT_SETTINGS_DEFAULT = Object.freeze<IDirectoryAccountSettings>({
-	visibleRoles: [],
-	labelColor: '#ffffff',
-	displayName: null,
-	hideOnlineStatus: false,
-	allowDirectMessagesFrom: 'all',
-	wardrobeExtraActionButtons: true,
-	wardrobeBackground: '#aaaaaa',
-	wardrobeUseRoomBackground: true,
-	wardrobeHoverPreview: true,
-	wardrobeOutfitsPreview: 'small',
-	wardrobeSmallPreview: 'image',
-	wardrobeBigPreview: 'image',
-	interfaceChatroomGraphicsRatioHorizontal: 7,
-	interfaceChatroomGraphicsRatioVertical: 4,
-	interfaceChatroomOfflineCharacterFilter: 'ghost',
-	interfaceChatroomChatFontSize: 'm',
-});
-
-export const ACCOUNT_SETTINGS_LIMITED_LIMITS = Object.freeze({
-	displayName: TimeSpanMs(1, 'weeks'),
-} as const satisfies Partial<Record<keyof IDirectoryAccountSettings, number>>);
-
-export const DirectoryAccountSettingsLimitedKeysSchema = z.enum(ParseArrayNotEmpty(KnownObject.keys(ACCOUNT_SETTINGS_LIMITED_LIMITS)));
-export type DirectoryAccountSettingsLimitedKeys = z.infer<typeof DirectoryAccountSettingsLimitedKeysSchema>;
-
-export const DirectoryAccountSettingsCooldownsSchema = z.record(DirectoryAccountSettingsLimitedKeysSchema, z.number().optional());
-export type DirectoryAccountSettingsCooldowns = z.infer<typeof DirectoryAccountSettingsCooldownsSchema>;
 
 // TODO: This needs reasonable size limits
 export const AccountCryptoKeySchema = z.object({

--- a/pandora-common/src/networking/directory_client.ts
+++ b/pandora-common/src/networking/directory_client.ts
@@ -1,6 +1,6 @@
 import { Immutable } from 'immer';
 import { z } from 'zod';
-import { AccountId, IAccountRoleInfo, type DirectoryAccountSettingsCooldowns, type IDirectoryAccountSettings } from '../account';
+import { AccountId, IAccountRoleInfo, type AccountSettingsCooldowns, type AccountSettings } from '../account';
 import type { CharacterId } from '../character';
 import type { ShardFeature } from '../space/space';
 import { Satisfies } from '../utility';
@@ -41,8 +41,21 @@ export type IDirectoryAccountInfo = {
 	roles?: IAccountRoleInfo;
 	/** Limit of how many spaces this account can own */
 	spaceOwnershipLimit: number;
-	settings: IDirectoryAccountSettings;
-	settingsCooldowns: DirectoryAccountSettingsCooldowns;
+	/**
+	 * Modified settings of the account.
+	 *
+	 * This representation of the settings is sparse; only modified settings are saved.
+	 * Settings modified to the default are saved as well, so potential change of default wouldn't change the user-selected setting.
+	 * This lets us both save on stored data, but also change defaults for users that never changed it themselves.
+	 * Also lets us show non-default settings to users with a button to reset them.
+	 */
+	settings: Partial<AccountSettings>;
+	/**
+	 * Cooldowns for limited settings.
+	 *
+	 * These represent time at which said setting can be changed again.
+	 */
+	settingsCooldowns: AccountSettingsCooldowns;
 	cryptoKey?: IAccountCryptoKey;
 };
 

--- a/pandora-server-directory/src/account/accountContacts.ts
+++ b/pandora-server-directory/src/account/accountContacts.ts
@@ -35,11 +35,12 @@ export class AccountContacts {
 		if (!this.loaded) {
 			return null;
 		}
-		const showStatus = !this.account.data.settings.hideOnlineStatus;
+		const accountSettings = this.account.getEffectiveSettings();
+		const showStatus = !accountSettings.hideOnlineStatus;
 		const online = showStatus && this.account.isOnline();
 		return {
 			id: this.account.id,
-			labelColor: this.account.data.settings.labelColor,
+			labelColor: accountSettings.labelColor,
 			online,
 			characters: !online ? [] : (
 				[...this.account.characters.values()]
@@ -80,13 +81,14 @@ export class AccountContacts {
 	public async canReceiveDM(from: Account): Promise<boolean> {
 		await this.load();
 		const { contact } = this.get(from.id) ?? {};
+		const accountSettings = this.account.getEffectiveSettings();
 
 		// No access if blocked
 		if (contact && (contact.type === 'mutualBlock' || contact.type === 'oneSidedBlock'))
 			return false;
 
 		// If allowing all, allow
-		if (this.account.data.settings.allowDirectMessagesFrom === 'all')
+		if (accountSettings.allowDirectMessagesFrom === 'all')
 			return true;
 
 		// If friend, allow
@@ -94,7 +96,7 @@ export class AccountContacts {
 			return true;
 
 		// If allowing from the same space and accounts share a space, allow
-		if (this.account.data.settings.allowDirectMessagesFrom === 'room' && AccountsHaveCharacterInSameSpace(this.account, from))
+		if (accountSettings.allowDirectMessagesFrom === 'room' && AccountsHaveCharacterInSameSpace(this.account, from))
 			return true;
 
 		// Default: No access

--- a/pandora-server-directory/src/account/accountDirectMessages.ts
+++ b/pandora-server-directory/src/account/accountDirectMessages.ts
@@ -144,10 +144,12 @@ export class AccountDirectMessages {
 
 	private _getAccountInfo(): IDirectoryDirectMessageAccount {
 		const account = this._account;
+		const accountSettings = account.getEffectiveSettings();
+
 		return {
 			id: account.id,
 			displayName: account.displayName,
-			labelColor: account.data.settings.labelColor,
+			labelColor: accountSettings.labelColor,
 			publicKeyData: account.directMessages._publicKey,
 		};
 	}

--- a/pandora-server-directory/src/database/databaseProvider.ts
+++ b/pandora-server-directory/src/database/databaseProvider.ts
@@ -42,9 +42,9 @@ export interface PandoraDatabase extends Service {
 	createAccount(data: DatabaseAccountWithSecure): Promise<DatabaseAccountWithSecure | 'usernameTaken' | 'emailTaken'>;
 
 	/**
-	 * Sets account settings
+	 * Sets account data
 	 * @param id - Account id
-	 * @param data - Settings data
+	 * @param data - data to set
 	 */
 	updateAccountData(id: AccountId, data: DatabaseAccountUpdate): Promise<void>;
 

--- a/pandora-server-directory/src/networking/manager_client.ts
+++ b/pandora-server-directory/src/networking/manager_client.ts
@@ -594,11 +594,17 @@ export const ConnectionManagerClient = new class ConnectionManagerClient impleme
 		await connection.account.secure.setGitHubInfo(null);
 	}
 
-	private async handleChangeSettings(settings: IClientDirectoryArgument['changeSettings'], connection: ClientConnection): IClientDirectoryPromiseResult['changeSettings'] {
+	private async handleChangeSettings(request: IClientDirectoryArgument['changeSettings'], connection: ClientConnection): IClientDirectoryPromiseResult['changeSettings'] {
 		if (!connection.isLoggedIn())
 			throw new BadMessageError();
 
-		await connection.account.changeSettings(settings);
+		if (request.type === 'set') {
+			await connection.account.changeSettings(request.settings);
+		} else if (request.type === 'reset') {
+			await connection.account.resetSettings(request.settings);
+		} else {
+			AssertNever(request);
+		}
 	}
 
 	private async handleManageGetAccountRoles({ id }: IClientDirectoryArgument['manageGetAccountRoles']): IClientDirectoryPromiseResult['manageGetAccountRoles'] {


### PR DESCRIPTION
This PR changes our settings saving structure to be sparse - defaults are not present in the saved data, but instead used when setting is accessed.
Changing setting back to default value manually will still save the default value explicitly.
This combination will allow us to change defaults for settings, such that people that never touched it will get the new default, but people who modified it manually with keep their value (even if their value was previous default).
Resetting the setting using reset button will delete it from settings storage, causing user to potentially get new default value if it changes.

Also reworks the settings UI slightly:
- Refactors much of the code to be more generic, making it easier to add more settings in the future
- Adds reset button to most settings. This button is dim if the setting uses Pandora's default and clickable when the setting was modified.

Locally saved graphics settings got the same treatment.

This PR also drops two obsolete wardrobe settings that had no effect since introduction of private spaces, as character is always in some room/space.