### PR TITLE
[DEV] Tests coverage collection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
         run: pnpm run -C pandora-tests type-check
       - name: Run E2E tests
         run: pnpm run -C pandora-tests test-e2e
+      - name: Collect coverage
+        run: pnpm run -C pandora-tests coverage:report --reporter=text
       - name: Save test report
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
       - run: pnpm run type-check:test
-      - run: pnpm run test --ci
+      - run: pnpm run test --ci --coverage
 
   test-e2e:
     name: Test (E2E)

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /data
 /node_modules
 /coverage
+/.nyc_output
 /docker.env

--- a/.hooks/coverage-collect.cjs
+++ b/.hooks/coverage-collect.cjs
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 /* Scripts are run in Node, so don't make use of the logger or ES imports */
 /* eslint-disable no-console, @typescript-eslint/no-var-requires*/
 

--- a/.hooks/coverage-collect.js
+++ b/.hooks/coverage-collect.js
@@ -1,0 +1,61 @@
+#!/usr/bin/node
+/* Scripts are run in Node, so don't make use of the logger or ES imports */
+/* eslint-disable no-console, @typescript-eslint/no-var-requires*/
+
+const { constants } = require('fs');
+const { copyFile } = require('fs/promises');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const rimraf = require('rimraf');
+
+collectCoverage();
+
+async function collectCoverage() {
+	const COVERAGE_TEMP = path.resolve(process.cwd(), './.nyc_output');
+	const COVERAGE_OUTPUT = path.resolve(process.cwd(), './coverage');
+
+	if (fs.existsSync(COVERAGE_TEMP)) {
+		rimraf.sync(COVERAGE_TEMP);
+	}
+	fs.mkdirSync(COVERAGE_TEMP)
+
+	if (fs.existsSync(COVERAGE_OUTPUT)) {
+		rimraf.sync(COVERAGE_OUTPUT);
+	}
+	fs.mkdirSync(COVERAGE_OUTPUT)
+
+	for (const project of ['pandora-common', 'pandora-server-directory', 'pandora-server-shard', 'pandora-client-web', 'pandora-tests']) {
+		try {
+			await copyFile(
+				path.resolve(process.cwd(), project, 'coverage/coverage-final.json'),
+				path.resolve(COVERAGE_TEMP, `coverage-${project}.json`),
+				constants.COPYFILE_EXCL,
+			);
+		} catch (error) {
+			console.error(`Failed to copy coverage file from ${project}:\n`, error);
+			process.exitCode = 1;
+		}
+	}
+
+	console.log("\n\nCollecting overall coverage from all tests...\n\n")
+
+	const { error } = spawnSync('pnpm', [
+		'exec',
+		'nyc',
+		'report',
+		'--cwd', path.resolve(process.cwd()), // This is "working directory" only for istanbul, not for rest of command
+		'--temp-dir', COVERAGE_TEMP, // This needs to be an absolute path
+		'--report-dir', COVERAGE_OUTPUT,
+		'--reporter=html',
+		'--reporter=json',
+		'--reporter=text-summary',
+	], {
+		stdio: 'inherit',
+	});
+	if (error)
+		throw error;
+
+	// Cleanup the temporary collection directory
+	rimraf.sync(COVERAGE_TEMP);
+}

--- a/.hooks/postinstall.cjs
+++ b/.hooks/postinstall.cjs
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /* Scripts are run in Node, so don't make use of the logger or ES imports */
 /* eslint-disable no-console, @typescript-eslint/no-var-requires*/
 const { constants } = require('fs');

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	},
 	"scripts": {
 		"postinstall": "node .hooks/postinstall.cjs",
-		"ci": "pnpm run build && pnpm run check-common-install && pnpm run lint && pnpm run type-check:test && pnpm run test --ci && pnpm run test-e2e",
+		"ci": "pnpm run build && pnpm run check-common-install && pnpm run lint && pnpm run type-check:test && pnpm run test --ci --coverage && pnpm run test-e2e && pnpm run coverage:collect",
 		"deploy": "pnpm run build && pnpm run deploy-client-rsync",
 		"deploy-client": "pnpm --filter pandora-client-web run build && pnpm run deploy-client-rsync",
 		"deploy-client-rsync": "rsync -rltOvcP --delete-delay ./pandora-client-web/dist/ ../pandora-client-web/dist",
@@ -23,7 +23,8 @@
 		"lint:fix": "pnpm -r --no-bail --parallel run lint:fix",
 		"type-check:test": "pnpm -r --no-bail --parallel run type-check:test",
 		"test": "pnpm -r --no-bail --parallel run test",
-		"test-e2e": "pnpm run -C pandora-tests type-check && pnpm run -C pandora-tests playwright-setup && pnpm run -C pandora-tests test-e2e",
+		"test-e2e": "pnpm run -C pandora-tests type-check && pnpm run -C pandora-tests playwright-setup && pnpm run -C pandora-tests test-e2e && pnpm run -C pandora-tests coverage:report",
+		"coverage:collect": "node .hooks/coverage-collect.js",
 		"build": "pnpm -r --no-bail run build",
 		"dev": "pnpm --filter pandora-common run build && pnpm -r --parallel run dev"
 	},
@@ -31,6 +32,8 @@
 		"js-yaml": "4.1.0"
 	},
 	"devDependencies": {
-		"jest": "29.7.0"
+		"jest": "29.7.0",
+		"nyc": "15.1.0",
+		"rimraf": "5.0.5"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"type-check:test": "pnpm -r --no-bail --parallel run type-check:test",
 		"test": "pnpm -r --no-bail --parallel run test",
 		"test-e2e": "pnpm run -C pandora-tests type-check && pnpm run -C pandora-tests playwright-setup && pnpm run -C pandora-tests test-e2e && pnpm run -C pandora-tests coverage:report",
-		"coverage:collect": "node .hooks/coverage-collect.js",
+		"coverage:collect": "node .hooks/coverage-collect.cjs",
 		"build": "pnpm -r --no-bail run build",
 		"dev": "pnpm --filter pandora-common run build && pnpm -r --parallel run dev"
 	},

--- a/pandora-client-web/jest.config.js
+++ b/pandora-client-web/jest.config.js
@@ -8,6 +8,11 @@ module.exports = {
 	clearMocks: true,
 	collectCoverageFrom: ['src/**/*.ts', 'src/**/*.tsx'],
 	coverageDirectory: 'coverage',
+	coverageReporters: [
+		'html',
+		'json',
+		'text-summary',
+	],
 	errorOnDeprecated: true,
 	moduleNameMapper: {
 		'\\.(png|jpe?g|gif|svg|eot|ttf|woff2?)$': '<rootDir>/test/stubs/resourceStub.ts',

--- a/pandora-client-web/webpack.config.ts
+++ b/pandora-client-web/webpack.config.ts
@@ -185,16 +185,13 @@ function GenerateRules(env: WebpackEnv): RuleSetRule[] {
 			test: /\.s?css$/i,
 			use: GenerateStyleLoaders(env),
 		},
-	];
-
-	if (!env.prod) {
-		moduleRules.push({
+		{
 			enforce: 'pre',
 			test: /\.js$/i,
 			exclude: /node_modules/,
 			loader: 'source-map-loader',
-		});
-	}
+		},
+	];
 
 	return moduleRules;
 }

--- a/pandora-common/jest.config.js
+++ b/pandora-common/jest.config.js
@@ -8,6 +8,11 @@ module.exports = {
 	clearMocks: true,
 	collectCoverageFrom: ['src/**/*.ts', 'src/**/*.tsx'],
 	coverageDirectory: 'coverage',
+	coverageReporters: [
+		'html',
+		'json',
+		'text-summary',
+	],
 	errorOnDeprecated: true,
 	setupFilesAfterEnv: ['<rootDir>/test/setup.ts'],
 	transform: {

--- a/pandora-server-directory/jest.config.js
+++ b/pandora-server-directory/jest.config.js
@@ -11,6 +11,11 @@ module.exports = {
 		'!src/index.ts',
 	],
 	coverageDirectory: 'coverage',
+	coverageReporters: [
+		'html',
+		'json',
+		'text-summary',
+	],
 	errorOnDeprecated: true,
 	watchPathIgnorePatterns: ['globalConfig'],
 	setupFilesAfterEnv: ['<rootDir>/test/setup.ts'],

--- a/pandora-server-shard/jest.config.js
+++ b/pandora-server-shard/jest.config.js
@@ -11,6 +11,11 @@ module.exports = {
 		'!src/index.ts',
 	],
 	coverageDirectory: 'coverage',
+	coverageReporters: [
+		'html',
+		'json',
+		'text-summary',
+	],
 	errorOnDeprecated: true,
 	setupFilesAfterEnv: ['<rootDir>/test/setup.ts'],
 	transform: {

--- a/pandora-tests/.gitignore
+++ b/pandora-tests/.gitignore
@@ -1,5 +1,6 @@
 /node_modules
 /test-results/
+/coverage/
 /playwright-report/
 /playwright/.cache/
 /temp

--- a/pandora-tests/package.json
+++ b/pandora-tests/package.json
@@ -11,6 +11,7 @@
 		"type-check:test-e2e": "tsc -p ./test/tsconfig.json --noEmit",
 		"type-check:test-config": "tsc -p ./tsconfig.json --noEmit",
 		"test-e2e": "playwright test",
+		"coverage:report": "nyc report --cwd .. -t ./pandora-tests/temp/nyc_coverage --reporter=html",
 		"playwright-setup": "playwright install chromium",
 		"playwright-setup-ci": "playwright install --with-deps chromium"
 	},
@@ -20,12 +21,14 @@
 		"@typescript-eslint/eslint-plugin": "7.1.1",
 		"@typescript-eslint/parser": "7.1.1",
 		"eslint": "8.57.0",
+		"nyc": "15.1.0",
 		"pandora-common": "workspace:*",
 		"pandora-server-directory": "workspace:*",
 		"pandora-server-shard": "workspace:*",
 		"rimraf": "5.0.5",
 		"superstatic": "9.0.3",
 		"tslib": "2.6.2",
-		"typescript": "5.3.3"
+		"typescript": "5.3.3",
+		"v8-to-istanbul": "9.2.0"
 	}
 }

--- a/pandora-tests/package.json
+++ b/pandora-tests/package.json
@@ -11,7 +11,7 @@
 		"type-check:test-e2e": "tsc -p ./test/tsconfig.json --noEmit",
 		"type-check:test-config": "tsc -p ./tsconfig.json --noEmit",
 		"test-e2e": "playwright test",
-		"coverage:report": "nyc report --cwd .. -t ./pandora-tests/temp/nyc_coverage --reporter=html",
+		"coverage:report": "nyc report --cwd .. -t ./pandora-tests/temp/nyc_coverage --report-dir ./pandora-tests/coverage --reporter=html --reporter=json --reporter=text-summary",
 		"playwright-setup": "playwright install chromium",
 		"playwright-setup-ci": "playwright install --with-deps chromium"
 	},

--- a/pandora-tests/test/_setup/config.ts
+++ b/pandora-tests/test/_setup/config.ts
@@ -16,3 +16,5 @@ export const TEST_CLIENT_DIST_DIR = path.resolve(TEST_TEMP, './client_dist');
 export const TEST_SERVER_DIRECTORY_PROJECT_DIR = path.resolve(TEST_PROJECT_PANDORA_DIR, './pandora-server-directory');
 export const TEST_SERVER_DIRECTORY_ENTRYPOINT = path.resolve(TEST_SERVER_DIRECTORY_PROJECT_DIR, './dist/index.js');
 export const TEST_SERVER_DIRECTORY_TEST_DIR = path.resolve(TEST_TEMP, './server_directory');
+
+export const TEST_COVERAGE_TEMP = path.resolve(TEST_TEMP, './nyc_coverage');

--- a/pandora-tests/test/_setup/global_setup.ts
+++ b/pandora-tests/test/_setup/global_setup.ts
@@ -4,7 +4,7 @@ import { spawnSync, SpawnSyncOptions } from 'child_process';
 import * as fs from 'fs';
 import * as rimraf from 'rimraf';
 
-import { TEST_CLIENT_DIST_DIR, TEST_HTTP_SERVER_PORT, TEST_TEMP, TEST_CLIENT_DIRECTORY_ADDRESS, TEST_CLIENT_EDITOR_ASSETS_ADDRESS, TEST_SERVER_DIRECTORY_TEST_DIR } from './config';
+import { TEST_CLIENT_DIST_DIR, TEST_HTTP_SERVER_PORT, TEST_TEMP, TEST_CLIENT_DIRECTORY_ADDRESS, TEST_CLIENT_EDITOR_ASSETS_ADDRESS, TEST_SERVER_DIRECTORY_TEST_DIR, TEST_COVERAGE_TEMP } from './config';
 
 import type { WEBPACK_CONFIG } from '../../../pandora-client-web/src/config/definition';
 import type { EnvInputJson } from 'pandora-common';
@@ -55,6 +55,12 @@ setup('Setup', () => {
 			} satisfies EnvInputJson<typeof WEBPACK_CONFIG>,
 		});
 	}
+
+	// Clean coverage temporary directory
+	if (fs.existsSync(TEST_COVERAGE_TEMP)) {
+		rimraf.sync(TEST_COVERAGE_TEMP);
+	}
+	fs.mkdirSync(TEST_COVERAGE_TEMP);
 
 	console.log('\n--- Global setup done ---\n');
 });

--- a/pandora-tests/test/directory_connection.test.ts
+++ b/pandora-tests/test/directory_connection.test.ts
@@ -1,6 +1,8 @@
 import { test, expect } from '@playwright/test';
-import { TestOpenPandora } from './utils/helpers';
+import { SetupTestingEnv, TestOpenPandora } from './utils/helpers';
 import { TestStartDirectory, TestStopDirectory } from './utils/server';
+
+SetupTestingEnv();
 
 test.describe('Directory Connection', () => {
 	test('Should see directory toast when directory is not running', async ({ page }) => {

--- a/pandora-tests/test/directory_connection.test.ts
+++ b/pandora-tests/test/directory_connection.test.ts
@@ -18,7 +18,7 @@ test.describe('Directory Connection', () => {
 
 		await TestStartDirectory();
 
-		await expect(page.getByText('Connected to Directory')).toBeVisible();
+		await expect(page.getByText('Connected to Directory')).toBeVisible({ timeout: 10_000 });
 		await expect(page.getByText('Connecting to Directory...')).toBeHidden();
 	});
 
@@ -27,11 +27,11 @@ test.describe('Directory Connection', () => {
 		await TestStartDirectory();
 
 		// Wait for connection
-		await expect(page.getByText('Connected to Directory')).toBeVisible();
+		await expect(page.getByText('Connected to Directory')).toBeVisible({ timeout: 10_000 });
 
 		// Stop directory and check for warning toast
 		await TestStopDirectory();
-		await expect(page.getByText('Directory connection lost')).toBeVisible();
+		await expect(page.getByText('Directory connection lost')).toBeVisible({ timeout: 10_000 });
 	});
 
 	test('Should show information about directory reconnection', async ({ page }) => {
@@ -39,16 +39,16 @@ test.describe('Directory Connection', () => {
 		await TestStartDirectory();
 
 		// Wait for connection
-		await expect(page.getByText('Connected to Directory')).toBeVisible();
+		await expect(page.getByText('Connected to Directory')).toBeVisible({ timeout: 10_000 });
 
 		// Stop directory and check for warning toast
 		await TestStopDirectory();
-		await expect(page.getByText('Directory connection lost')).toBeVisible();
+		await expect(page.getByText('Directory connection lost')).toBeVisible({ timeout: 10_000 });
 
 		// Restart directory, expecting reconnect
 		await TestStartDirectory();
 
-		await expect(page.getByText('Reconnected to Directory')).toBeVisible();
+		await expect(page.getByText('Reconnected to Directory')).toBeVisible({ timeout: 10_000 });
 		await expect(page.getByText('Directory connection lost')).toBeHidden();
 	});
 });

--- a/pandora-tests/test/eula.test.ts
+++ b/pandora-tests/test/eula.test.ts
@@ -1,5 +1,7 @@
 import { test, expect } from '@playwright/test';
-import { TEST_EULA_TEXT, TestOpenPandora } from './utils/helpers';
+import { SetupTestingEnv, TEST_EULA_TEXT, TestOpenPandora } from './utils/helpers';
+
+SetupTestingEnv();
 
 test.describe('EULA', () => {
 	test('Shows privacy policy', async ({ page }) => {

--- a/pandora-tests/test/load.test.ts
+++ b/pandora-tests/test/load.test.ts
@@ -1,5 +1,7 @@
 import { test, expect } from '@playwright/test';
-import { TestOpenPandora } from './utils/helpers';
+import { SetupTestingEnv, TestOpenPandora } from './utils/helpers';
+
+SetupTestingEnv();
 
 test.describe('Load', () => {
 	test('Should load Pandora', async ({ page }) => {

--- a/pandora-tests/test/utils/coverage.ts
+++ b/pandora-tests/test/utils/coverage.ts
@@ -1,0 +1,146 @@
+/* eslint-disable no-console */
+import { Page } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import { TEST_CLIENT_DIR, TEST_CLIENT_DIST_DIR, TEST_COVERAGE_TEMP } from '../_setup/config';
+import v8ToIstanbul from 'v8-to-istanbul';
+
+type FilterType<T, F> = T extends F ? T : never;
+
+// When library doesn't export the type it expects...
+type SourceMapInput = FilterType<
+	NonNullable<Parameters<(typeof v8ToIstanbul)>[2]>,
+	{ originalSource: string; }
+>['sourceMap']['sourcemap'];
+
+type EncodedSourceMap = FilterType<SourceMapInput, { mappings: string; }>;
+
+function GenerateRandomId(): string {
+	return crypto.randomBytes(16).toString('hex');
+}
+
+export async function CoverageProcessPage(page: Page, baseUrl: string | undefined): Promise<void> {
+	const coverageResult = await page.coverage.stopJSCoverage();
+
+	if (baseUrl == null)
+		return;
+
+	for (const result of coverageResult) {
+		let filePath: string;
+		if (result.url.startsWith(baseUrl)) {
+			filePath = path.resolve(
+				TEST_CLIENT_DIST_DIR,
+				result.url
+					.slice(baseUrl.length)
+					.replace(/^\/?/, './'),
+			);
+		} else {
+			continue;
+		}
+
+		if (!fs.existsSync(filePath)) {
+			console.warn('Resolved coverage file not found:\n', filePath);
+		}
+
+		// Get sourcemap if possible
+		const sourcemapPath = `${filePath}.map`;
+		let sourcemapContent: EncodedSourceMap | undefined;
+
+		if (fs.existsSync(sourcemapPath)) {
+			// @ts-expect-error: It should hopefully be the right type
+			sourcemapContent = (JSON.parse(fs.readFileSync(sourcemapPath, 'utf-8')) as unknown);
+		}
+
+		// Rewrite sourcemap's original file paths
+		if (sourcemapContent != null) {
+			sourcemapContent = MapSourcePaths(sourcemapContent);
+		}
+
+		// Prepare converter
+		const converter = v8ToIstanbul(
+			filePath,
+			0,
+			sourcemapContent ? {
+				source: fs.readFileSync(filePath, 'utf-8'),
+				originalSource: '',
+				sourceMap: {
+					sourcemap: sourcemapContent,
+				},
+			} : {
+				source: fs.readFileSync(filePath, 'utf-8'),
+			},
+			(sourcePath) => {
+				// Ignore any webpack runtime code
+				if (sourcePath.includes('webpack-internal:'))
+					return true;
+
+				// Ignore any libraries (pandora-common is not here)
+				if (sourcePath.includes('node_modules'))
+					return true;
+
+				// Ignore non-TS/JS files (like images)
+				if (!/\.(ts|js)x?$/.test(sourcePath)) {
+					return true;
+				}
+
+				// Check the file actually exists
+				if (!fs.existsSync(sourcePath)) {
+					console.warn('Source path target not found:', sourcePath);
+				}
+
+				// Ignore .js files (these cause error for some reason, otherwise they should be included)
+				if (sourcePath.endsWith('.js'))
+					return true;
+
+				return false;
+			},
+		);
+		await converter.load();
+
+		converter.applyCoverage(result.functions);
+
+		const istanbulData = converter.toIstanbul();
+
+		// Save this report with random name
+		fs.writeFileSync(
+			path.join(
+				TEST_COVERAGE_TEMP,
+				`client_coverage_${GenerateRandomId()}.json`,
+			),
+			JSON.stringify(istanbulData),
+			{ encoding: 'utf-8' },
+		);
+	}
+}
+
+// Rewriting rules for webpack
+const mappings: readonly [string, string][] = [
+	['webpack://pandora-client-web/webpack/', 'webpack-internal://'],
+	['webpack://pandora-client-web/', TEST_CLIENT_DIR + '/'],
+];
+
+function MapSourcePaths(sourcemap: EncodedSourceMap): EncodedSourceMap {
+	return {
+		...sourcemap,
+		sources: sourcemap.sources.map((source) => {
+			if (typeof source !== 'string')
+				return source;
+
+			for (const [k, v] of mappings) {
+				if (source.startsWith(k)) {
+					source = v + source.slice(k.length);
+
+					// The resolve *MUST* be done,
+					// otherwise remapping fails at a later stage,
+					// resulting in all files having 0 functions/statements
+					if (fs.existsSync(source)) {
+						source = path.resolve(source);
+					}
+				}
+			}
+
+			return source;
+		}).filter(Boolean),
+	};
+}

--- a/pandora-tests/test/utils/helpers.ts
+++ b/pandora-tests/test/utils/helpers.ts
@@ -18,7 +18,6 @@ const handleLog = (message: ConsoleMessage) => {
 	}
 };
 
-// eslint-disable-next-line @typescript-eslint/require-await
 export async function TestSetupPage(page: Page): Promise<void> {
 	page.on('console', handleLog);
 

--- a/pandora-tests/test/wiki.test.ts
+++ b/pandora-tests/test/wiki.test.ts
@@ -1,5 +1,7 @@
 import { test, expect } from '@playwright/test';
-import { TestOpenPandora } from './utils/helpers';
+import { SetupTestingEnv, TestOpenPandora } from './utils/helpers';
+
+SetupTestingEnv();
 
 test.describe('Wiki', () => {
 	test('Selects default tab', async ({ page }) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -587,6 +587,9 @@ importers:
       eslint:
         specifier: 8.57.0
         version: 8.57.0
+      nyc:
+        specifier: 15.1.0
+        version: 15.1.0
       pandora-common:
         specifier: workspace:*
         version: link:../pandora-common
@@ -608,6 +611,9 @@ importers:
       typescript:
         specifier: 5.3.3
         version: 5.3.3
+      v8-to-istanbul:
+        specifier: 9.2.0
+        version: 9.2.0
 
 packages:
 
@@ -3236,7 +3242,7 @@ packages:
       slash: 3.0.0
       string-length: 4.0.2
       strip-ansi: 6.0.1
-      v8-to-istanbul: 9.1.3
+      v8-to-istanbul: 9.2.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5471,7 +5477,6 @@ packages:
       clean-stack: 2.2.0
       indent-string: 4.0.0
     dev: true
-    optional: true
 
   /ajv-formats@2.1.1(ajv@8.12.0):
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
@@ -5574,6 +5579,17 @@ packages:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+    dev: true
+
+  /append-transform@2.0.0:
+    resolution: {integrity: sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==}
+    engines: {node: '>=8'}
+    dependencies:
+      default-require-extensions: 3.0.1
+    dev: true
+
+  /archy@1.0.0:
+    resolution: {integrity: sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==}
     dev: true
 
   /arg@4.1.3:
@@ -6199,6 +6215,16 @@ packages:
     dev: true
     optional: true
 
+  /caching-transform@4.0.0:
+    resolution: {integrity: sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==}
+    engines: {node: '>=8'}
+    dependencies:
+      hasha: 5.2.2
+      make-dir: 3.1.0
+      package-hash: 4.0.0
+      write-file-atomic: 3.0.3
+    dev: true
+
   /call-bind@1.0.5:
     resolution: {integrity: sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==}
     dependencies:
@@ -6337,7 +6363,6 @@ packages:
     engines: {node: '>=6'}
     requiresBuild: true
     dev: true
-    optional: true
 
   /clean-webpack-plugin@4.0.0(webpack@5.90.3):
     resolution: {integrity: sha512-WuWE1nyTNAyW5T7oNyys2EN0cfP2fdRxhxnIQWiAp0bMabPdHhoGxM8A6YL2GhqwgrPnnaemVE7nv5XJ2Fhh2w==}
@@ -6357,6 +6382,14 @@ packages:
   /client-zip@2.4.4:
     resolution: {integrity: sha512-Ixk40BUI7VvNDxW7SCze20GbCuC+gjP4tGkXUpo6/W96bOf96HSed6cOQVeUOIe74SJAG/dIrBr7AtR4xBVnsA==}
     dev: false
+
+  /cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+    dev: true
 
   /cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -6459,7 +6492,6 @@ packages:
 
   /commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
-    dev: false
 
   /compressible@2.0.18:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
@@ -6532,6 +6564,10 @@ packages:
   /content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  /convert-source-map@1.9.0:
+    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
+    dev: true
 
   /convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -6910,6 +6946,11 @@ packages:
       ms: 2.1.2
       supports-color: 5.5.0
 
+  /decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /decimal.js@10.4.3:
     resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
     dev: true
@@ -6965,6 +7006,13 @@ packages:
     engines: {node: '>= 10'}
     dependencies:
       execa: 5.1.1
+    dev: true
+
+  /default-require-extensions@3.0.1:
+    resolution: {integrity: sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==}
+    engines: {node: '>=8'}
+    dependencies:
+      strip-bom: 4.0.0
     dev: true
 
   /define-data-property@1.1.1:
@@ -7534,6 +7582,10 @@ packages:
       is-symbol: 1.0.4
     dev: true
 
+  /es6-error@4.1.1:
+    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+    dev: true
+
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
@@ -8084,7 +8136,6 @@ packages:
       commondir: 1.0.1
       make-dir: 3.1.0
       pkg-dir: 4.2.0
-    dev: false
 
   /find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -8136,6 +8187,14 @@ packages:
       is-callable: 1.2.7
     dev: true
 
+  /foreground-child@2.0.0:
+    resolution: {integrity: sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      cross-spawn: 7.0.3
+      signal-exit: 3.0.7
+    dev: true
+
   /foreground-child@3.1.1:
     resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
     engines: {node: '>=14'}
@@ -8166,6 +8225,10 @@ packages:
 
   /from@0.1.7:
     resolution: {integrity: sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==}
+    dev: true
+
+  /fromentries@1.3.2:
+    resolution: {integrity: sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==}
     dev: true
 
   /fs-minipass@2.1.0:
@@ -8460,6 +8523,14 @@ packages:
   /has-yarn@2.1.0:
     resolution: {integrity: sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==}
     engines: {node: '>=8'}
+    dev: true
+
+  /hasha@5.2.2:
+    resolution: {integrity: sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      is-stream: 2.0.1
+      type-fest: 0.8.1
     dev: true
 
   /hasown@2.0.0:
@@ -9107,6 +9178,11 @@ packages:
       get-intrinsic: 1.2.4
     dev: true
 
+  /is-windows@1.0.2:
+    resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
@@ -9163,6 +9239,25 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /istanbul-lib-hook@3.0.0:
+    resolution: {integrity: sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      append-transform: 2.0.0
+    dev: true
+
+  /istanbul-lib-instrument@4.0.3:
+    resolution: {integrity: sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@babel/core': 7.23.7
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-coverage: 3.2.0
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /istanbul-lib-instrument@5.2.1:
     resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
     engines: {node: '>=8'}
@@ -9187,6 +9282,18 @@ packages:
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /istanbul-lib-processinfo@2.0.3:
+    resolution: {integrity: sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==}
+    engines: {node: '>=8'}
+    dependencies:
+      archy: 1.0.0
+      cross-spawn: 7.0.3
+      istanbul-lib-coverage: 3.2.0
+      p-map: 3.0.0
+      rimraf: 3.0.2
+      uuid: 8.3.2
     dev: true
 
   /istanbul-lib-report@3.0.1:
@@ -9897,6 +10004,10 @@ packages:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
     dev: true
 
+  /lodash.flattendeep@4.4.0:
+    resolution: {integrity: sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==}
+    dev: true
+
   /lodash.isnil@4.0.0:
     resolution: {integrity: sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==}
     dev: false
@@ -10436,6 +10547,13 @@ packages:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
     dev: true
 
+  /node-preload@0.2.1:
+    resolution: {integrity: sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      process-on-spawn: 1.0.0
+    dev: true
+
   /node-releases@2.0.14:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
     dev: true
@@ -10504,6 +10622,42 @@ packages:
 
   /nwsapi@2.2.7:
     resolution: {integrity: sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==}
+    dev: true
+
+  /nyc@15.1.0:
+    resolution: {integrity: sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==}
+    engines: {node: '>=8.9'}
+    hasBin: true
+    dependencies:
+      '@istanbuljs/load-nyc-config': 1.1.0
+      '@istanbuljs/schema': 0.1.3
+      caching-transform: 4.0.0
+      convert-source-map: 1.9.0
+      decamelize: 1.2.0
+      find-cache-dir: 3.3.2
+      find-up: 4.1.0
+      foreground-child: 2.0.0
+      get-package-type: 0.1.0
+      glob: 7.2.3
+      istanbul-lib-coverage: 3.2.0
+      istanbul-lib-hook: 3.0.0
+      istanbul-lib-instrument: 4.0.3
+      istanbul-lib-processinfo: 2.0.3
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 4.0.1
+      istanbul-reports: 3.1.6
+      make-dir: 3.1.0
+      node-preload: 0.2.1
+      p-map: 3.0.0
+      process-on-spawn: 1.0.0
+      resolve-from: 5.0.0
+      rimraf: 3.0.2
+      signal-exit: 3.0.7
+      spawn-wrap: 2.0.0
+      test-exclude: 6.0.0
+      yargs: 15.4.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /object-assign@4.1.1:
@@ -10676,6 +10830,13 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /p-map@3.0.0:
+    resolution: {integrity: sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      aggregate-error: 3.1.0
+    dev: true
+
   /p-map@4.0.0:
     resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
     engines: {node: '>=10'}
@@ -10696,6 +10857,16 @@ packages:
   /p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
+
+  /package-hash@4.0.0:
+    resolution: {integrity: sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      graceful-fs: 4.2.11
+      hasha: 5.2.2
+      lodash.flattendeep: 4.4.0
+      release-zalgo: 1.0.0
+    dev: true
 
   /param-case@3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
@@ -11638,6 +11809,13 @@ packages:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
     dev: true
 
+  /process-on-spawn@1.0.0:
+    resolution: {integrity: sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==}
+    engines: {node: '>=8'}
+    dependencies:
+      fromentries: 1.3.2
+    dev: true
+
   /prom-client@15.1.0:
     resolution: {integrity: sha512-cCD7jLTqyPdjEPBo/Xk4Iu8jxjuZgZJ3e/oET3L+ZwOuap/7Cw3dH/TJSsZKs1TQLZ2IHpIlRAKw82ef06kmMw==}
     engines: {node: ^16 || ^18 || >=20}
@@ -12055,6 +12233,13 @@ packages:
     engines: {node: '>= 0.10'}
     dev: true
 
+  /release-zalgo@1.0.0:
+    resolution: {integrity: sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==}
+    engines: {node: '>=4'}
+    dependencies:
+      es6-error: 4.1.1
+    dev: true
+
   /renderkid@3.0.0:
     resolution: {integrity: sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==}
     dependencies:
@@ -12073,6 +12258,10 @@ packages:
   /require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
     dev: true
 
   /requires-port@1.0.0:
@@ -12353,6 +12542,10 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+    dev: true
+
   /set-function-length@1.1.1:
     resolution: {integrity: sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==}
     engines: {node: '>= 0.4'}
@@ -12571,6 +12764,18 @@ packages:
     dependencies:
       memory-pager: 1.5.0
     dev: false
+
+  /spawn-wrap@2.0.0:
+    resolution: {integrity: sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==}
+    engines: {node: '>=8'}
+    dependencies:
+      foreground-child: 2.0.0
+      is-windows: 1.0.2
+      make-dir: 3.1.0
+      rimraf: 3.0.2
+      signal-exit: 3.0.7
+      which: 2.0.2
+    dev: true
 
   /spdy-transport@3.0.0:
     resolution: {integrity: sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==}
@@ -13194,6 +13399,11 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /type-fest@0.8.1:
+    resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
+    engines: {node: '>=8'}
+    dev: true
+
   /type-fest@4.11.0:
     resolution: {integrity: sha512-DPsoHKtnCUqqoB5Y4OPyat7ObSLz1XOkhHTmz+gOkz2p1xs+BBneTvHWriTwc313eozfBWh8b45EpaV3ZrrPPQ==}
     engines: {node: '>=16'}
@@ -13490,8 +13700,8 @@ packages:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
     dev: true
 
-  /v8-to-istanbul@9.1.3:
-    resolution: {integrity: sha512-9lDD+EVI2fjFsMWXc6dy5JJzBsVTcQ2fVkfBvncZ6xJWG9wtBhOldG+mHkSL0+V1K/xgZz0JDO5UT5hFwHUghg==}
+  /v8-to-istanbul@9.2.0:
+    resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
     engines: {node: '>=10.12.0'}
     dependencies:
       '@jridgewell/trace-mapping': 0.3.21
@@ -13786,6 +13996,10 @@ packages:
       is-weakset: 2.0.2
     dev: true
 
+  /which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+    dev: true
+
   /which-typed-array@1.1.13:
     resolution: {integrity: sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==}
     engines: {node: '>= 0.4'}
@@ -13839,6 +14053,15 @@ packages:
   /wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
     dev: false
+
+  /wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+    dev: true
 
   /wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -13925,6 +14148,10 @@ packages:
     engines: {node: '>=0.4.0'}
     dev: false
 
+  /y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+    dev: true
+
   /y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -13937,9 +14164,34 @@ packages:
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
+  /yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+    dev: true
+
   /yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+    dev: true
+
+  /yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
     dev: true
 
   /yargs@17.7.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,12 @@ importers:
       jest:
         specifier: 29.7.0
         version: 29.7.0(@types/node@18.19.21)(ts-node@10.9.2)
+      nyc:
+        specifier: 15.1.0
+        version: 15.1.0
+      rimraf:
+        specifier: 5.0.5
+        version: 5.0.5
 
   pandora-client-web:
     dependencies:


### PR DESCRIPTION
This PR adds coverage collection for E2E tests (both client and server), and adds few more bits to combine coverage from individual and E2E tests into a single report.
Locally this can be obtained by running `pnpm run ci` in the workspace root (will take a few minutes).
In CI the coverage is collected but not used yet. In the future we could easily setup something like CodeCov to get coverage diff for each PR.

There is a slight slowdown involved in the coverage collection, but I would say relatively minor one.

The coverage collection for client (+common) during E2E testing was easy, but getting it transformed into a reasonable format was not. It is a bit inaccurate due to the minimization the client build does despite the existence of sourcemaps. It took me several hours to get it to report anything else than 0/0 for anything but lines... But it does work, even if the percentage is not accurate and lines might get reported as run even if they weren't, the functions coverage is accurate and branches coverage is accurate for functions that were run at least once.