### PR TITLE
[CHANGE] update privacy policy

### DIFF
--- a/pandora-client-web/src/components/Eula/privacyPolicy.tsx
+++ b/pandora-client-web/src/components/Eula/privacyPolicy.tsx
@@ -4,7 +4,7 @@ import { ExternalLink } from '../common/link/externalLink';
 // ********************************
 // Update both of these variables whenever you make any changes to EULA and/or Privacy Policy!
 // ********************************
-export const EULA_VERSION = 2;
+export const EULA_VERSION = 1;
 export const EULA_LAST_UPDATED = 'March 04, 2024';
 
 export function PrivacyPolicyContent(): ReactElement {
@@ -77,8 +77,6 @@ export function PrivacyPolicyContent(): ReactElement {
 			<p>We do not share Your personal information with third parties.</p>
 			<h3>How do We store the data?</h3>
 			<p>We will retain the aforementioned data potentially indefinitely so We can fulfill the purposes described in this Privacy Policy; typically for the lifetime of Your Pandora account.</p>
-			<p>If You do not log into Your Pandora account during a full calendar year, We will delete Your Pandora account and all the data stored in it during the following year.</p>
-			<p>In the case of Direct/Private Messages to other users, We will retain the encrypted data for a maximum of one year.</p>
 			<p>The server that stores the data is inside the European Union.</p>
 			<h3>Cookies</h3>
 			<p>When You visit our website, We may collect information from You automatically through cookies or similar technology.</p>

--- a/pandora-client-web/src/components/Eula/privacyPolicy.tsx
+++ b/pandora-client-web/src/components/Eula/privacyPolicy.tsx
@@ -4,8 +4,8 @@ import { ExternalLink } from '../common/link/externalLink';
 // ********************************
 // Update both of these variables whenever you make any changes to EULA and/or Privacy Policy!
 // ********************************
-export const EULA_VERSION = 1;
-export const EULA_LAST_UPDATED = 'March 04, 2023';
+export const EULA_VERSION = 2;
+export const EULA_LAST_UPDATED = 'March 04, 2024';
 
 export function PrivacyPolicyContent(): ReactElement {
 	return (
@@ -29,7 +29,7 @@ export function PrivacyPolicyContent(): ReactElement {
 			</p>
 			<ul>
 				<li>
-					Email Address: We store Your email address hashed (pseudonymized), so we are not able to see it and use it to contact you.
+					Email Address: We store Your email address hashed (pseudonymized), so We are not able to see it and use it to contact you.
 				</li>
 				<li>
 					Usage Data
@@ -75,8 +75,10 @@ export function PrivacyPolicyContent(): ReactElement {
 				</li>
 			</ul>
 			<p>We do not share Your personal information with third parties.</p>
-			<h3>How do we store the data?</h3>
-			<p>We will retain the aforementioned data potentially indefinitely so we can fulfill the purposes described in this Privacy Policy; typically for the lifetime of Your Pandora account.</p>
+			<h3>How do We store the data?</h3>
+			<p>We will retain the aforementioned data potentially indefinitely so We can fulfill the purposes described in this Privacy Policy; typically for the lifetime of Your Pandora account.</p>
+			<p>If You do not log into Your Pandora account during a full calendar year, We will delete Your Pandora account and all the data stored in it during the following year.</p>
+			<p>In the case of Direct/Private Messages to other users, We will retain the encrypted data for a maximum of one year.</p>
 			<p>The server that stores the data is inside the European Union.</p>
 			<h3>Cookies</h3>
 			<p>When You visit our website, We may collect information from You automatically through cookies or similar technology.</p>
@@ -129,7 +131,7 @@ export function PrivacyPolicyContent(): ReactElement {
 				</li>
 				<li>
 					<strong>The right to data portability</strong><br />
-					You have the right to request that We transfer the data that we have collected to You, provided that Your request does not adversely affect the rights and freedoms of others.
+					You have the right to request that We transfer the data that We have collected to You, provided that Your request does not adversely affect the rights and freedoms of others.
 				</li>
 			</ul>
 			<p>

--- a/pandora-common/src/inputLimits.ts
+++ b/pandora-common/src/inputLimits.ts
@@ -39,7 +39,7 @@ export const LIMIT_SPACE_DESCRIPTION_LENGTH = 10_000;
 /** The maximum length of a chat message */
 export const LIMIT_CHAT_MESSAGE_LENGTH = 25_000;
 
-/** The maximum length of a direct message (not yet used)
+/** The maximum length of a direct message
  *
  * Since DMs are encrypted using AES-GCM 256, and then Base64 encoded, whatever character limit we set
  * should be increased by roughly 35-40% at least when checked by directory.


### PR DESCRIPTION
Updates the privacy policy to revision 2 after exactly one year!

Tries to implement (2) of https://github.com/Project-Pandora-Game/pandora/issues/559

and https://github.com/Project-Pandora-Game/pandora/issues/578

Questions I have:

1. Is it enough to update the privacy policy or do we need some terms of use that state this?
2. Do we need some automatic way that deletes messages when they are older than 1 year? Doing it manually sounds very error prone and tedious. I feel we should do that before we update the privacy policy with this PR.