### PR TITLE
[DEV] Small cleanup after spaces changes

### DIFF
--- a/pandora-common/src/account/settings.ts
+++ b/pandora-common/src/account/settings.ts
@@ -13,10 +13,10 @@ export const AccountSettingsSchema = z.object({
 	hideOnlineStatus: z.boolean(),
 	/**
 	 * - 'all' - Allow direct messages from anyone
-	 * - 'room' - Allow direct messages from friends and people in the same space | TODO(spaces): Update?
+	 * - 'space' - Allow direct messages from friends and people in the same space
 	 * - 'friends' - Only allow direct messages from friends
 	 */
-	allowDirectMessagesFrom: z.enum(['all', 'room', 'friends']),
+	allowDirectMessagesFrom: z.enum(['all', 'space', 'friends']).catch('all'),
 	/**
 	 * Controls whether to show extra quick actions in wardrobe
 	 * (actions that are doable with multiple clicks even without this button, but the button allows doing them as single click)

--- a/pandora-common/src/inputLimits.ts
+++ b/pandora-common/src/inputLimits.ts
@@ -9,6 +9,9 @@
 /** The maximum length of an account name */
 export const LIMIT_ACCOUNT_NAME_LENGTH = 32;
 
+/** Character limit for an account */
+export const LIMIT_CHARACTER_COUNT = 5;
+
 /** The minimum length of a character name */
 export const LIMIT_CHARACTER_NAME_MIN_LENGTH = 3;
 /** The maximum length of a character name */
@@ -16,6 +19,9 @@ export const LIMIT_CHARACTER_NAME_LENGTH = 32;
 
 /** The maximum length of an e-mail address */
 export const LIMIT_MAIL_LENGTH = 256;
+
+/** Space ownership limit for an account */
+export const LIMIT_SPACE_OWNED_COUNT = 5;
 
 /** The maximum amount of characters inside a space */
 export const LIMIT_SPACE_MAX_CHARACTER_NUMBER = 100;

--- a/pandora-server-directory/src/account/account.ts
+++ b/pandora-server-directory/src/account/account.ts
@@ -14,12 +14,13 @@ import {
 	IShardAccountDefinition,
 	ITEM_LIMIT_ACCOUNT_OUTFIT_STORAGE,
 	KnownObject,
+	LIMIT_CHARACTER_COUNT,
+	LIMIT_SPACE_OWNED_COUNT,
 	OutfitMeasureCost,
 	ServerRoom,
 	type AccountSettings,
 	type AccountSettingsKeys,
 } from 'pandora-common';
-import { ENV } from '../config';
 import { GetDatabase } from '../database/databaseProvider';
 import { DatabaseAccount, DatabaseAccountUpdate, DatabaseAccountWithSecure, DirectMessageAccounts } from '../database/databaseStructure';
 import type { ClientConnection } from '../networking/connection_client';
@@ -28,8 +29,6 @@ import { AccountDirectMessages } from './accountDirectMessages';
 import { AccountRoles } from './accountRoles';
 import AccountSecure, { GenerateAccountSecureData } from './accountSecure';
 import { CharacterInfo } from './character';
-
-const { CHARACTER_LIMIT_NORMAL, ROOM_LIMIT_NORMAL } = ENV;
 
 /** Currently logged in or recently used account */
 export class Account {
@@ -275,7 +274,7 @@ export class Account {
 	}
 
 	public async createCharacter(): Promise<CharacterInfo | null> {
-		if (this.characters.size > CHARACTER_LIMIT_NORMAL || Array.from(this.characters.values()).some((i) => i.inCreation))
+		if (this.characters.size > LIMIT_CHARACTER_COUNT || Array.from(this.characters.values()).some((i) => i.inCreation))
 			return null;
 
 		const info = await GetDatabase().createCharacter(this.data.id);
@@ -334,7 +333,7 @@ export class Account {
 	//#region Spaces
 
 	public get spaceOwnershipLimit(): number {
-		return ROOM_LIMIT_NORMAL;
+		return LIMIT_SPACE_OWNED_COUNT;
 	}
 
 	//#endregion

--- a/pandora-server-directory/src/account/accountContacts.ts
+++ b/pandora-server-directory/src/account/accountContacts.ts
@@ -96,7 +96,7 @@ export class AccountContacts {
 			return true;
 
 		// If allowing from the same space and accounts share a space, allow
-		if (accountSettings.allowDirectMessagesFrom === 'room' && AccountsHaveCharacterInSameSpace(this.account, from))
+		if (accountSettings.allowDirectMessagesFrom === 'space' && AccountsHaveCharacterInSameSpace(this.account, from))
 			return true;
 
 		// Default: No access

--- a/pandora-server-directory/src/config.ts
+++ b/pandora-server-directory/src/config.ts
@@ -67,17 +67,6 @@ export const EnvParser = CreateEnvParser({
 
 	//#endregion
 
-	//#region Limits
-
-	// TODO(spaces): Move these limits into common limits definitions
-
-	/** Character limit for normal account */
-	CHARACTER_LIMIT_NORMAL: z.number().default(5),
-	/** Room ownership limit for normal account */
-	ROOM_LIMIT_NORMAL: z.number().default(5),
-
-	//#endregion
-
 	//#region Development
 
 	/** Key needed to register, if set */

--- a/pandora-server-directory/src/networking/manager_client.ts
+++ b/pandora-server-directory/src/networking/manager_client.ts
@@ -1,4 +1,4 @@
-import { AccountRole, Assert, AssertNever, AssertNotNullable, Awaitable, BadMessageError, ClientDirectoryAuthMessageSchema, GetLogger, IClientDirectory, IClientDirectoryArgument, IClientDirectoryAuthMessage, IClientDirectoryPromiseResult, IClientDirectoryResult, IDirectoryStatus, IMessageHandler, IShardTokenConnectInfo, MessageHandler, SecondFactorData, SecondFactorResponse, SecondFactorType, Service } from 'pandora-common';
+import { AccountRole, Assert, AssertNever, AssertNotNullable, Awaitable, BadMessageError, ClientDirectoryAuthMessageSchema, GetLogger, IClientDirectory, IClientDirectoryArgument, IClientDirectoryAuthMessage, IClientDirectoryPromiseResult, IClientDirectoryResult, IDirectoryStatus, IMessageHandler, IShardTokenConnectInfo, LIMIT_CHARACTER_COUNT, MessageHandler, SecondFactorData, SecondFactorResponse, SecondFactorType, Service } from 'pandora-common';
 import { SocketInterfaceRequest, SocketInterfaceResponse } from 'pandora-common/dist/networking/helpers';
 import promClient from 'prom-client';
 import { z } from 'zod';
@@ -13,7 +13,7 @@ import { ShardTokenStore } from '../shard/shardTokenStore';
 import { SpaceManager } from '../spaces/spaceManager';
 import { Sleep } from '../utility';
 import type { ClientConnection } from './connection_client';
-const { BETA_KEY_ENABLED, CHARACTER_LIMIT_NORMAL, HCAPTCHA_SECRET_KEY, HCAPTCHA_SITE_KEY } = ENV;
+const { BETA_KEY_ENABLED, HCAPTCHA_SECRET_KEY, HCAPTCHA_SITE_KEY } = ENV;
 
 /** Time (in ms) of how often the directory should send status updates */
 export const STATUS_UPDATE_INTERVAL = 60_000;
@@ -297,7 +297,7 @@ export const ConnectionManagerClient = new class ConnectionManagerClient impleme
 
 		return {
 			characters: connection.account.listCharacters(),
-			limit: CHARACTER_LIMIT_NORMAL,
+			limit: LIMIT_CHARACTER_COUNT,
 		};
 	}
 

--- a/pandora-server-directory/src/networking/manager_client.ts
+++ b/pandora-server-directory/src/networking/manager_client.ts
@@ -1,19 +1,19 @@
-import { GetLogger, SpaceDirectoryConfigSchema, MessageHandler, IClientDirectory, IClientDirectoryArgument, IClientDirectoryPromiseResult, BadMessageError, IClientDirectoryResult, IClientDirectoryAuthMessage, IDirectoryStatus, AccountRole, ZodMatcher, ClientDirectoryAuthMessageSchema, IMessageHandler, AssertNotNullable, Assert, AssertNever, IShardTokenConnectInfo, Service, Awaitable, SecondFactorData, SecondFactorType, SecondFactorResponse } from 'pandora-common';
+import { AccountRole, Assert, AssertNever, AssertNotNullable, Awaitable, BadMessageError, ClientDirectoryAuthMessageSchema, GetLogger, IClientDirectory, IClientDirectoryArgument, IClientDirectoryAuthMessage, IClientDirectoryPromiseResult, IClientDirectoryResult, IDirectoryStatus, IMessageHandler, IShardTokenConnectInfo, MessageHandler, SecondFactorData, SecondFactorResponse, SecondFactorType, Service } from 'pandora-common';
+import { SocketInterfaceRequest, SocketInterfaceResponse } from 'pandora-common/dist/networking/helpers';
+import promClient from 'prom-client';
+import { z } from 'zod';
+import type { Account } from '../account/account';
 import { accountManager } from '../account/accountManager';
 import { AccountProcedurePasswordReset, AccountProcedureResendVerifyEmail } from '../account/accountProcedures';
 import { ENV } from '../config';
-const { BETA_KEY_ENABLED, CHARACTER_LIMIT_NORMAL, HCAPTCHA_SECRET_KEY, HCAPTCHA_SITE_KEY } = ENV;
-import { ShardManager } from '../shard/shardManager';
-import type { Account } from '../account/account';
 import { GitHubVerifier } from '../services/github/githubVerify';
-import promClient from 'prom-client';
-import { ShardTokenStore } from '../shard/shardTokenStore';
-import { SocketInterfaceRequest, SocketInterfaceResponse } from 'pandora-common/dist/networking/helpers';
 import { BetaKeyStore } from '../shard/betaKeyStore';
+import { ShardManager } from '../shard/shardManager';
+import { ShardTokenStore } from '../shard/shardTokenStore';
 import { SpaceManager } from '../spaces/spaceManager';
-import type { ClientConnection } from './connection_client';
-import { z } from 'zod';
 import { Sleep } from '../utility';
+import type { ClientConnection } from './connection_client';
+const { BETA_KEY_ENABLED, CHARACTER_LIMIT_NORMAL, HCAPTCHA_SECRET_KEY, HCAPTCHA_SITE_KEY } = ENV;
 
 /** Time (in ms) of how often the directory should send status updates */
 export const STATUS_UPDATE_INTERVAL = 60_000;
@@ -37,10 +37,6 @@ const messagesMetric = new promClient.Counter({
 	help: 'Count of received messages from clients',
 	labelNames: ['messageType'],
 });
-
-// TODO(spaces): Drop these
-const IsIChatRoomDirectoryConfig = ZodMatcher(SpaceDirectoryConfigSchema);
-const IsClientDirectoryAuthMessage = ZodMatcher(ClientDirectoryAuthMessageSchema);
 
 /** Class that stores all currently connected clients */
 export const ConnectionManagerClient = new class ConnectionManagerClient implements IMessageHandler<IClientDirectory, ClientConnection>, Service {
@@ -151,8 +147,9 @@ export const ConnectionManagerClient = new class ConnectionManagerClient impleme
 		// Send current server status to the client
 		connection.sendMessage('serverStatus', MakeStatus());
 		// Check if connect-time authentication is valid and process it
-		if (IsClientDirectoryAuthMessage(auth)) {
-			this.handleAuth(connection, auth)
+		const parsedAuth = ClientDirectoryAuthMessageSchema.safeParse(auth);
+		if (parsedAuth.success) {
+			this.handleAuth(connection, parsedAuth.data)
 				.catch((error) => {
 					logger.error(`Error processing connect auth from ${connection.id}`, error);
 				});
@@ -407,7 +404,7 @@ export const ConnectionManagerClient = new class ConnectionManagerClient impleme
 	}
 
 	private async handleSpaceCreate(spaceConfig: IClientDirectoryArgument['spaceCreate'], connection: ClientConnection): IClientDirectoryPromiseResult['spaceCreate'] {
-		if (!connection.isLoggedIn() || !connection.character || !IsIChatRoomDirectoryConfig(spaceConfig))
+		if (!connection.isLoggedIn() || !connection.character)
 			throw new BadMessageError();
 
 		const character = connection.character;

--- a/pandora-server-directory/src/spaces/spaceManager.ts
+++ b/pandora-server-directory/src/spaces/spaceManager.ts
@@ -1,13 +1,13 @@
-import { AccountId, Assert, AssertNotNullable, AsyncSynchronized, GetLogger, SpaceDirectoryConfig, SpaceDirectoryData, SpaceId, Service, SpaceDirectoryDataSchema, SPACE_DIRECTORY_PROPERTIES } from 'pandora-common';
+import { diffString } from 'json-diff';
+import { isEqual, pick } from 'lodash';
+import { AccountId, Assert, AssertNotNullable, AsyncSynchronized, GetLogger, SPACE_DIRECTORY_PROPERTIES, Service, SpaceDirectoryConfig, SpaceDirectoryData, SpaceDirectoryDataSchema, SpaceId } from 'pandora-common';
+import promClient from 'prom-client';
+import { Account } from '../account/account';
+import { accountManager } from '../account/accountManager';
+import { CharacterInfo } from '../account/character';
+import { GetDatabase } from '../database/databaseProvider';
 import { ConnectionManagerClient } from '../networking/manager_client';
 import { Space } from './space';
-import promClient from 'prom-client';
-import { GetDatabase } from '../database/databaseProvider';
-import { accountManager } from '../account/accountManager';
-import { Account } from '../account/account';
-import { CharacterInfo } from '../account/character';
-import { isEqual, pick } from 'lodash';
-import { diffString } from 'json-diff';
 
 /** Time (in ms) after which manager prunes spaces without any activity (search or characters inside) */
 export const SPACE_INACTIVITY_THRESHOLD = 60_000;
@@ -16,21 +16,19 @@ export const TICK_INTERVAL = 15_000;
 
 const logger = GetLogger('SpaceManager');
 
-// TODO(spaces): Consider migrating metric ids
-
 // TODO
 // const totalSpacesMetric = new promClient.Gauge({
-//     name: 'pandora_directory_rooms',
+//     name: 'pandora_directory_spaces',
 //     help: 'Total count of spaces that exist',
 // });
 
 const loadedSpacesMetric = new promClient.Gauge({
-	name: 'pandora_directory_rooms_loaded',
+	name: 'pandora_directory_spaces_loaded',
 	help: 'Current count of spaces loaded into memory',
 });
 
 const inUseSpacesMetric = new promClient.Gauge({
-	name: 'pandora_directory_rooms_in_use',
+	name: 'pandora_directory_spaces_in_use',
 	help: 'Current count of spaces in use',
 });
 

--- a/pandora-server-shard/src/spaces/spaceManager.ts
+++ b/pandora-server-shard/src/spaces/spaceManager.ts
@@ -1,13 +1,12 @@
-import { SpaceId, GetLogger, IShardSpaceDefinition, Assert } from 'pandora-common';
-import { PublicSpace } from './publicSpace';
+import { Assert, GetLogger, IShardSpaceDefinition, SpaceId } from 'pandora-common';
 import promClient from 'prom-client';
 import { assetManager } from '../assets/assetManager';
+import { PublicSpace } from './publicSpace';
 
 const logger = GetLogger('SpaceManager');
 
-// TODO(spaces): Consider migrating metric ids
 const spacesMetric = new promClient.Gauge({
-	name: 'pandora_shard_rooms',
+	name: 'pandora_shard_spaces',
 	help: 'Current count of spaces loaded on this shard',
 });
 


### PR DESCRIPTION
This PR bundles a few smaller cleanups:
- Metric ids are renamed to use spaces naming
- Old socket message guards were removed, as we use Zod everywhere
- DM preference value was changed to use `space` instead of `room` (do we actually have GUI for setting this?)
- Old character and space ownership limits were moved to the new common limits declarations instead of being env-dependent (we didn't even have them in env config template)