### PR TITLE
[FIX] Prevent Zalgo text

### DIFF
--- a/pandora-client-web/src/components/directMessage/directMessage.scss
+++ b/pandora-client-web/src/components/directMessage/directMessage.scss
@@ -21,6 +21,13 @@
 		white-space: pre-wrap;
 		overflow-wrap: break-word;
 
+		&:not(:hover) {
+			// Prevent Zalgo text from getting weird (but still show it if the message is hovered)
+			overflow: hidden;
+			overflow: clip;
+			overflow-clip-margin: 0.05em;
+		}
+
 		&__info {
 			float: right;
 			color: $grey-mid;

--- a/pandora-client-web/src/ui/screens/room/room.scss
+++ b/pandora-client-web/src/ui/screens/room/room.scss
@@ -110,6 +110,13 @@
 		white-space: pre-wrap;
 		overflow-wrap: break-word;
 
+		&:not(:hover) {
+			// Prevent Zalgo text from getting weird (but still show it if the message is hovered)
+			overflow: hidden;
+			overflow: clip;
+			overflow-clip-margin: 0.05em;
+		}
+
 		&.serverMessage {
 			border-left: solid 5px $white;
 			background-color: #202020;


### PR DESCRIPTION
Adds a clip to the chat messages so a message can't overflow itself. The full message is still shown on hover in case something gets clipped unintentionally or admin just wants to see what message's author tried to do.
A bit stricter "hidden" is used as backup for iOS devices that still might not support clip.