### PR TITLE
[CHANGE] new user guide, wiki improvements, and garbling improvements

### DIFF
--- a/pandora-client-web/src/components/wiki/pages/characters.tsx
+++ b/pandora-client-web/src/components/wiki/pages/characters.tsx
@@ -131,7 +131,7 @@ export function WikiCharacters(): ReactElement {
 					allowing and denying that character all further uses of each permission from now on
 				</li>
 				<li>... allow all, which sets all mentioned permissions with no exceptions defined for the requesting character to "yes" just for the requester</li>
-				<li>... dismiss the popup, which is akin to not taking any decision at this point in time and leave things as they are.</li>
+				<li>... dismiss the popup, which is akin to closing the popup after you are happy with the individual permission changes you did.</li>
 			</ul>
 			<p>
 				Note that the interaction that was leading to the prompt has to be repeated again after permission was granted. The server

--- a/pandora-client-web/src/components/wiki/pages/characters.tsx
+++ b/pandora-client-web/src/components/wiki/pages/characters.tsx
@@ -127,11 +127,10 @@ export function WikiCharacters(): ReactElement {
 			</p>
 			<ul>
 				<li>
-					... add permanent exceptions for the requesting character for every permission individually in the popup, either
-					allowing and denying that character all further uses of each permission from now on
+					... "deny" the requesting character asking for a specific permission from now on (unless you change the permission's settings manually).
 				</li>
-				<li>... allow all, which sets all mentioned permissions with no exceptions defined for the requesting character to "yes" just for the requester</li>
-				<li>... dismiss the popup, which is akin to closing the popup after you are happy with the individual permission changes you did.</li>
+				<li>... "allow all", which adds an exception for the requesting character to be able to use all mentioned permissions.</li>
+				<li>... "dismiss" the popup, which ignores the request, only saving any permission-specific blocks you selected.</li>
 			</ul>
 			<p>
 				Note that the interaction that was leading to the prompt has to be repeated again after permission was granted. The server

--- a/pandora-client-web/src/components/wiki/pages/greeting.tsx
+++ b/pandora-client-web/src/components/wiki/pages/greeting.tsx
@@ -8,6 +8,7 @@ import { ExternalLink } from '../../common/link/externalLink';
 import { Button } from '../../common/button/button';
 import { usePlayer } from '../../gameContext/playerContextProvider';
 import { useNavigate } from 'react-router';
+import { Link } from 'react-router-dom';
 
 export function WikiGreeting(): ReactElement {
 	const characterSelected = usePlayer() != null;
@@ -25,12 +26,14 @@ export function WikiGreeting(): ReactElement {
 					<br />
 					Pandora is a <ExternalLink href='https://wikipedia.org/wiki/BDSM'>BDSM</ExternalLink> club.<br />
 					We want Pandora to be a safe and welcoming place, but that also requires your help!
-					Please be aware that different people have different preferences and limits.<br />
-					It is also important to be aware of what a <ExternalLink href='https://en.wikipedia.org/wiki/Safeword'><b>Safeword</b></ExternalLink> is and respect it when others use it.<br />
+					Please be aware that different people have different preferences and limits.
+					It is also important to be aware of what a <ExternalLink href='https://en.wikipedia.org/wiki/Safeword'><b>Safeword</b></ExternalLink> is and respect it when
+					other users mention a safeword in their profile or tell you their safeword upfront and end up using it during a play.
+					Chat messages that ask for help or to be freed with a [OOC] tag in front have to be treated like an indirect safeword usage.<br />
 					<br />
 					During your stay you will often encounter various restraining items.
 					Restraints in Pandora are very secure and can really get you stuck with no one else being able to help so please be mindful of that.
-					As always, communication with others is the most important tool in our club community, but Pandora also offers several emergency mechanisms to keep you safe.<br />
+					As always, communication with others is the most important tool in our club community, but Pandora also offers several mechanisms to keep you safe.<br />
 					First of those is the ability to enforce your own limits through <i>permissions</i> - allowing you to prevent others from doing certain things to your character.
 					Right now, the club is a totally safe space. You have to permit other visitors to be able to do actions individually or
 					generally, before anything can happen to you. Moreover, due to the security of restraints in Pandora, stricter ones such as
@@ -41,7 +44,8 @@ export function WikiGreeting(): ReactElement {
 					Both modes prevent interactions in both ways while active. Do note, however, that we consider safemode a last-resort option for emergencies.
 					It comes with a cooldown period that simulates stopping the play after a safeword usage to recover and be safe.<br />
 					<br />
-					You can find more guidance by pressing the "<img src={ wikiIcon } width='14' height='13' alt='Wiki' />"-button on the top bar.<br />
+					You can find more guidance by pressing the "<img src={ wikiIcon } width='14' height='13' alt='Wiki' />"-button on the top bar.
+					There, you can also find a <Link to='/wiki/new'><b>new user guide</b></Link>.<br />
 					<br />
 					The club is still being renovated so you can expect many new things over time or even help us with building it up! Please be aware that the Pandora team
 					has a firm vision of how the club shall work, so not all ideas will be embraced. If you want to help, it is best to familiarize yourself with the club

--- a/pandora-client-web/src/components/wiki/pages/greeting.tsx
+++ b/pandora-client-web/src/components/wiki/pages/greeting.tsx
@@ -28,8 +28,7 @@ export function WikiGreeting(): ReactElement {
 					We want Pandora to be a safe and welcoming place, but that also requires your help!
 					Please be aware that different people have different preferences and limits.
 					It is also important to be aware of what a <ExternalLink href='https://en.wikipedia.org/wiki/Safeword'><b>Safeword</b></ExternalLink> is and respect it when
-					other users mention a safeword in their profile or tell you their safeword upfront and end up using it during a play.
-					Chat messages that ask for help or to be freed with a [OOC] tag in front have to be treated like an indirect safeword usage.<br />
+					others mention a safeword in their profile or tell you their safeword.
 					<br />
 					During your stay you will often encounter various restraining items.
 					Restraints in Pandora are very secure and can really get you stuck with no one else being able to help so please be mindful of that.

--- a/pandora-client-web/src/components/wiki/pages/intro.tsx
+++ b/pandora-client-web/src/components/wiki/pages/intro.tsx
@@ -2,11 +2,15 @@ import React, { ReactElement } from 'react';
 import { MESSAGE_EDIT_TIMEOUT } from '../../gameContext/gameStateContextProvider';
 import { ExternalLink } from '../../common/link/externalLink';
 import { Link } from 'react-router-dom';
+import { Row } from '../../common/container/container';
 
 export function WikiIntroduction(): ReactElement {
 	return (
 		<>
-			<h2>Introduction to Pandora with some quick hints to get you started</h2>
+			<Row alignX='end'>
+				<Link to='/wiki/' target='_blank' rel='noopener noreferrer'>⧉ Open wiki in a separate window</Link>
+			</Row>
+			<h2>Wiki: Introduction to Pandora's features with further information</h2>
 
 			<p>
 				Pandora's vision is to establish a consensual BDSM roleplaying platform that focuses on text-heavy interactions with visual support
@@ -14,12 +18,16 @@ export function WikiIntroduction(): ReactElement {
 				enhancing the immersion. It is a social chat platform with a focus on kinky roleplaying, rather than a game.
 			</p>
 
+			<p>
+				If you are new to Pandora, it is recommended to first <Link to='/wiki/new'>click this link</Link> that leads to the new user guide, before proceeding.
+			</p>
+
 			The following will list some of the existing core features of Pandora.
 			Some of these features are explained in greater detail further below and in other tabs of this wiki.
 			<ol type='1'>
 				<li>Dynamically generated body model with many poses and free arm movement</li>
 				<li>Front and back character view</li>
-				<li>Persistent multiplayer spaces and a character-specific personal space</li>
+				<li>Persistent chatroom spaces and a character-specific personal space</li>
 				<li>A feature-rich room chat (e.g. message editing, advanced text styling)</li>
 				<li>Free character placement and movement inside rooms</li>
 				<li>Room-level furniture and devices that can be placed freely and that persist with the lifetime of the room</li>
@@ -127,6 +135,8 @@ export function WikiIntroduction(): ReactElement {
 			<h4>11. Using back/forward buttons/keys</h4>
 			<p>
 				Pandora has the ability to use the browser's back/forward buttons to navigate in Pandora and URLs can be copied, linked, and used.
+				You can even have certain account-level views open in a parallel window, such as the chatroom and the wiki, contacts, or direct messages
+				screen side by side.
 			</p>
 
 			<h4>12. User safety features for emergencies</h4>

--- a/pandora-client-web/src/components/wiki/pages/intro.tsx
+++ b/pandora-client-web/src/components/wiki/pages/intro.tsx
@@ -168,10 +168,11 @@ export function WikiIntroduction(): ReactElement {
 
 			That's not all of course! We have many exciting features planned for the future:
 			<ul>
-				<li>Advanced spectator mode for spaces that will help to not disrupt the chat during plays and that can be managed by space admins</li>
+				<li>Spectator mode for spaces that will help to not disrupt the chat during plays and that can be managed by space admins</li>
 				<li>Showing and managing relationships between characters</li>
 				<li>Allowing every item to have a custom name and description</li>
 				<li>Allowing spaces to contain several connected rooms with a user-defined layout and ways to move from room to room</li>
+				<li>Multi-Layered bondage</li>
 				<li>Improvements to the new user experience & safety</li>
 				<li>Character rules</li>
 				<li>Room templates</li>

--- a/pandora-client-web/src/components/wiki/pages/intro.tsx
+++ b/pandora-client-web/src/components/wiki/pages/intro.tsx
@@ -8,7 +8,7 @@ export function WikiIntroduction(): ReactElement {
 	return (
 		<>
 			<Row alignX='end'>
-				<Link to='/wiki/' target='_blank' rel='noopener noreferrer'>⧉ Open wiki in a separate window</Link>
+				<a href='/wiki/' target='_blank' rel='noopener noreferrer'>⧉ Open wiki in a separate window</a>
 			</Row>
 			<h2>Wiki: Introduction to Pandora's features with further information</h2>
 
@@ -19,7 +19,7 @@ export function WikiIntroduction(): ReactElement {
 			</p>
 
 			<p>
-				If you are new to Pandora, it is recommended to first <Link to='/wiki/new'>click this link</Link> that leads to the new user guide, before proceeding.
+				If you are new to Pandora, it is recommended to first click the following link that leads to the <Link to='/wiki/new'>new user guide</Link>, before proceeding.
 			</p>
 
 			The following will list some of the existing core features of Pandora.

--- a/pandora-client-web/src/components/wiki/pages/items.tsx
+++ b/pandora-client-web/src/components/wiki/pages/items.tsx
@@ -66,7 +66,8 @@ export function WikiItems(): ReactElement {
 				To move a deployed item on the room background, you need to enable the room construction mode with the according button in the "Room"-tab.
 				While you are in this mode, every room-level item has a red icon below it. Clicking it and selecting "move" will turn the item into a move mode.
 				While in move mode, there are here are two icons under the item. You can drag the left one to move the item in all directions over the floor.
-				The right icon is used to lift the item up or down (alongside the z-axis) by dragging up or down. Leave the move mode by pressing the red/green button shortly.
+				The right blue icon is used to lift the item up or down (alongside the z-axis) by dragging up or down. The set value can be reset by
+				shortly pressing on the icon again. You can leave the move mode by pressing the red/green button shortly.
 			</p>
 			<ul>
 				<li>Only space admins can color, place, move, and undeploy room device per default.</li>
@@ -78,8 +79,8 @@ export function WikiItems(): ReactElement {
 				<li>You are unable to leave the room while your character occupies a character slot of a room device.</li>
 				<li>Room devices can also be stored in a <Link to='#IT_Saving_collections'>saved items collection</Link>, like regular items.</li>
 				<li>
-					Warning: Room devices can get you stuck in an empty room, which would make
-					using <Link to='/wiki/characters#SA_Safemode'>safemode</Link> the only way out.
+					Warning: Room devices can get someone stuck in an empty private space, which would make
+					using <Link to='/wiki/characters#SA_Safemode'>safemode</Link> the only way out, unless the affected user is permitted to invite someone else to the space.
 				</li>
 			</ul>
 

--- a/pandora-client-web/src/components/wiki/pages/new.tsx
+++ b/pandora-client-web/src/components/wiki/pages/new.tsx
@@ -10,13 +10,13 @@ export function WikiNew(): ReactElement {
 			<h3>First steps when starting</h3>
 
 			<p>
-				This guide is targeting brand new users in Pandora and will help to take the first steps in the club.
+				This guide is targeting brand new users of Pandora and will help with taking the first steps in the club.
 			</p>
 			<p>
 				Your account can currently have up to { LIMIT_CHARACTER_COUNT } characters, but initially you start with one character
 				with a randomized appearance.
-				You find yourself in your personal space, which is like a safe sandbox to try things out alone.
-				From there you can for instance open the wardrobe where you can change your body
+				You find yourself in your personal space, which can be used as a (mostly safe) sandbox to try things out alone.
+				From there you can, for instance, open the wardrobe where you can change your body
 				and looks as well as your clothes. By default you own all items existing in Pandora from the start.
 			</p>
 			<p>

--- a/pandora-client-web/src/components/wiki/pages/new.tsx
+++ b/pandora-client-web/src/components/wiki/pages/new.tsx
@@ -1,3 +1,4 @@
+import { LIMIT_CHARACTER_COUNT } from 'pandora-common';
 import React, { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -12,7 +13,8 @@ export function WikiNew(): ReactElement {
 				This guide is targeting brand new users in Pandora and will help to take the first steps in the club.
 			</p>
 			<p>
-				Your account can have several characters, but initially you start with one character with a randomized appearance.
+				Your account can currently have up to { LIMIT_CHARACTER_COUNT } characters, but initially you start with one character
+				with a randomized appearance.
 				You find yourself in your personal space, which is like a safe sandbox to try things out alone.
 				From there you can for instance open the wardrobe where you can change your body
 				and looks as well as your clothes. By default you own all items existing in Pandora from the start.

--- a/pandora-client-web/src/components/wiki/pages/new.tsx
+++ b/pandora-client-web/src/components/wiki/pages/new.tsx
@@ -1,0 +1,196 @@
+import React, { ReactElement } from 'react';
+import { Link } from 'react-router-dom';
+
+export function WikiNew(): ReactElement {
+	return (
+		<>
+			<h2>New user guide</h2>
+
+			<h3>First steps when starting</h3>
+
+			<p>
+				This guide is targeting brand new users in Pandora and will help to take the first steps in the club.
+			</p>
+			<p>
+				Your account can have several characters, but initially you start with one character with a randomized appearance.
+				You find yourself in your personal space, which is like a safe sandbox to try things out alone.
+				From there you can for instance open the wardrobe where you can change your body
+				and looks as well as your clothes. By default you own all items existing in Pandora from the start.
+			</p>
+			<p>
+				From your personal room you can also switch to a list of online spaces where you can meet other users of the platform.
+				By default, Pandora is a safe space where no one can do anything to you. When someone else wants to do anything
+				to your character, a permission popup will open asking you if you consent to this action.
+			</p>
+			<p>
+				It may be wise to first talk to other users a bit and get to know them and look if they have a profile that tells you
+				something about them, before you give any permissions to them.
+			</p>
+
+			<h3>Main chat message types</h3>
+
+			<p>
+				There are several types of messages that you can use in a space's chat. Feel free to experiment with them, as your personal
+				space also has a chat tab.
+			</p>
+
+			<h4>Chat commands</h4>
+
+			<p>
+				Every message starting with a "/" character is a command. There is no "/help" command, but you rather get a full list of commands
+				and what they do when you simply start typing a "/" into the chat input field. Command messages cannot be seen by other users in the room.
+			</p>
+
+			<h4>Normal talking</h4>
+
+			<p>
+				When you type something into the chat input field your character says this to everyone in the room. It is also called
+				in-character or standard message, and the message is printed in the chat with your character's name in front of it.
+				While it is usually not needed, you can also use the "/say" command to send a normal message.
+			</p>
+
+			<h4>Out-of-character talking / OOC</h4>
+
+			<p>
+				The next type are out-of-character or short "OOC" messages. Those are written by putting a "((" in front of your message.
+				Alternatively you can also use the "/ooc" command to send such a message.
+				The [OOC] tag in front of a message signals everyone that this text was not spoken by your character but comes from the real human
+				user behind the screen. It can for example be used to convey limits or talk about not being comfortable with how the scene goes
+				or to indicate that you have to leave the club soon. It is especially used to ask
+				to be let go or to stop the play, representing a kind of "safeword" usage. It is frowned upon if it is used to circumvent the effects
+				of a gag to keep talking as the character to
+				other characters, as it is confusing for others to differentiate if the message came from the character or the human user.<br />
+				Please respect the responsible use of OOC and take the content seriously. It is no longer fun and games if someone asks
+				to be freed in an OOC message!
+			</p>
+
+			<h4>Emotes</h4>
+
+			<p>
+				Emote type messages are actions by your character or world-building text descriptions that enhance the roleplaying experience.
+				Character emotes are written by a leading "*" symbol (or with a "/me" command) and describe the state or action of
+				your character, such as: <i>Yourcharactername is petting Eve's head.</i>
+			</p>
+
+			<p>
+				On the other hand, starting the message with  double "**" characters (or with an "/emote" command) writes a general, nameless
+				emote that lets you describe the
+				environment, other events happening in the room, or something other users can see or notice. It is the most important tool
+				for immersive roleplaying.
+			</p>
+
+			<h4>Whispers</h4>
+
+			<p>
+				There are several ways to whisper someone in the same room, but the main ones are listed in the following.<br />
+				Any of them puts you into a whisper mode that you need to explicitly leave by using the "Cancel"-button above the chat input.
+				Whispered messages can only be seen by the target and not by anyone else. Note that you can also send an OOC message as a
+				whisper by starting message with "((".
+			</p>
+			<ul>
+				<li>You can click on a character's name in the chat itself.</li>
+				<li>You can click on a character's name under the character on the room background to open a context menu and select "Whisper" there.</li>
+				<li>You can click on the "Whisper"-button next to a character name in the "Room"-tab.</li>
+				<li>You can use the chat command "/w [target]" using either the character name or the character ID as whisper target argument.</li>
+			</ul>
+
+			<p>
+				There are further advanced, chat-related topics that you can read about in the other tabs of this wiki, such
+				as switching <Link to='/wiki/spaces#SP_Room_chat_Chat_modes'>"chat modes"</Link> or <Link to='/wiki/spaces#SP_Room_chat_Editing_text'>"text editing"</Link>.
+			</p>
+
+			<h3>User safety</h3>
+
+			<p>
+				While Pandora is a completely safe space as long as you do not give any permissions to other users, the consequences of trusting
+				someone with certain permissions is not particularly problematic as the restraints and locks that are allowed to be used by other
+				users by default can all be removed by other users, too, when you ask for help.
+			</p>
+			<p>
+				However, there are a few items that cannot be removed by other users, but these items are disabled on a new account to protect
+				new users. Be wary if someone instructs you to enable some "fun locks they want to use for a play" in your account, as they can get
+				you really stuck. If you ever find yourself in such a case, you can still use the last resort, which is "safemode" (more on that later).
+			</p>
+			<p>
+				Another way that can get you stuck is if you permit someone to put you into a room furniture/device that restraints you, as you
+				then can no longer leave the room and disconnecting or closing Pandora will not make you leave your current room either.
+				Again, if you get into such a situation where you no longer feel in a consensual situation and in case communicating with OOC messages
+				would not help, using the "safemode" is the only way out.
+			</p>
+			<p>
+				You can enter "safemode" via the button under your character in the "Room"-tab, in the same row where the wardrobe and profile buttons are.
+				It should be seen as a last resort tool and you should try to resolve a situation if possible by communicating OOC first before using it,
+				as it can potentially hurt the other user if you use "safemode" for seemingly no reason.
+			</p>
+
+			<p>
+				This was just a brief overview of this topic. There is a whole <Link to='/wiki/safety'>wiki-tab</Link> dedicated to it
+				that we recommend to read at your own leisure. It for instance describes how to set
+				a <Link to='/wiki/safety#SA_Display_name'>custom display name</Link>.
+			</p>
+
+			<h3>Decorating your room</h3>
+
+			<p>
+				You can decorate your personal space with <Link to='/wiki/items#IT_Room-level_items'>room-level items</Link>, such as
+				picture frames, chairs, or kinky furniture. To do that you can click the button "Room inventory" in your personal space,
+				which leads you to the inventory of your personal space. This basically represents the items standing around or being stored
+				inside the room, except the items worn or held by your own character.
+			</p>
+
+			<p>
+				To for instance place a "Heart Throne" in the room, you either filter the right side of the inventory by typing in the name of the item
+				or you press the bed-icon to filter the list of items you can create in the room inventory to only show furniture.
+				Click the Heart Throne and create it in the room inventory on the left side. Before it appears in the room, you need to deploy it first.
+				Press on the Heart Throne on the left side and press the "Deploy the device" button on the right side.<br />
+				Afterwards, the left area shows you a preview of the furniture inside your personal space and you can use the "Back"-button in the top
+				right to go back to the room view.
+			</p>
+
+			<p>
+				To move the throne, you need to enter "room construction mode" with the according button under the "personal space"-tab. This turns
+				the blue button under the throne into a red action button. Clicking it lets you select "Move" in the context menu.
+				Now you can move the item around on the background by dragging the left icon to the desired position. Not important now,
+				but in case you were wondering, the right button is used to move the device up or down vertically, so along the z-axis.
+				After you are done positioning the throne, you can exit move-mode by clicking the left button again. Afterwards, you can disable
+				room construction mode again.
+			</p>
+
+			<p>
+				Maybe you now want to sit on your newly added throne? Drag the name under your character towards the throne to move next to it.
+				Then click on the blue action button under it, select "Slots" in the context menu,
+				and then "Sitting on the throne", which is the name of the character slot that this item has. Finally, select your character name
+				to sit on it.
+			</p>
+
+			<p>
+				Again a reminder that some of the more kinky furniture can tie your character to the room device, which makes you unable to leave the
+				space and can trap the character in it, if you are in a private space with no one there to help.
+				Therefore it is advised to be mindful of that when giving someone the permission to make you enter a character slot of a
+				room-level item. Kinky furniture is therefore maybe not the best tool to use in a first roleplaying scene at a "first date".
+				If you find yourself stuck in an empty public space, you can ask a friend for help with a direct message
+				by <Link to='/wiki/spaces#SP_Space_invites'>inviting them</Link> to the space.
+				Entering "safemode" can still free you of course as well, so the worst-case consequences are not necessarily severe.
+			</p>
+
+			<h3>Creating your own chatroom space</h3>
+
+			<p>
+				Trying out things in your personal space is nice and cozy, but eventually you may want to either join a space with other users or
+				even host your own space. You can do that by clicking the "List of spaces" button, and then press the last row
+				"Create a new space". This brings you to a screen where you can enter the properties of your new space, such as name, description,
+				and background image.<br />
+				The default setting of a new space is private, so if you want it to be public, you need to switch this default setting
+				to "Yes".
+			</p>
+			<p>
+				Spaces in Pandora are persistent. This means that all settings, the items in the room inventory, and all deployed furniture
+				stays like it was, after you left the space. So the next time you log in you will still see your space in the list of spaces
+				and everything will be like you set it up before.<br />
+				You can find out more about how spaces work under the <Link to='/wiki/spaces'>spaces-tab</Link> in the wiki. For now we recommend you
+				to continue reading about the <Link to='/wiki/introduction'>core features of Pandora</Link> to get an impression of what you can expect,
+				in case reading about this interests you.
+			</p>
+		</>
+	);
+}

--- a/pandora-client-web/src/components/wiki/pages/new.tsx
+++ b/pandora-client-web/src/components/wiki/pages/new.tsx
@@ -17,51 +17,54 @@ export function WikiNew(): ReactElement {
 				with a randomized appearance.
 				You find yourself in your personal space, which can be used as a (mostly safe) sandbox to try things out alone.
 				From there you can, for instance, open the wardrobe where you can change your body
-				and looks as well as your clothes. By default you own all items existing in Pandora from the start.
+				and looks as well as your clothes.
+				You always own all items that exist in Pandora - there is no need to buy them or get them anywhere.
 			</p>
 			<p>
 				From your personal room you can also switch to a list of online spaces where you can meet other users of the platform.
-				By default, Pandora is a safe space where no one can do anything to you. When someone else wants to do anything
-				to your character, a permission popup will open asking you if you consent to this action.
+				Pandora is a safe space by default - no one can do anything to you. When someone else wants to do anything
+				to your character, a permission popup will open asking you if you consent to their action.
 			</p>
 			<p>
-				It may be wise to first talk to other users a bit and get to know them and look if they have a profile that tells you
-				something about them, before you give any permissions to them.
+				It is advised to first talk to other users a bit, get to know them, and look if they have a profile that tells you
+				something about them before you give any permissions to them.
 			</p>
 
 			<h3>Main chat message types</h3>
 
 			<p>
 				There are several types of messages that you can use in a space's chat. Feel free to experiment with them, as your personal
-				space also has a chat tab.
+				space also has a chat tab that is only visible to you.
 			</p>
 
 			<h4>Chat commands</h4>
 
 			<p>
-				Every message starting with a "/" character is a command. There is no "/help" command, but you rather get a full list of commands
-				and what they do when you simply start typing a "/" into the chat input field. Command messages cannot be seen by other users in the room.
+				Any message starting with a "/" is a command. There is no "/help" command, but you rather get a full list of commands
+				and what they do when you simply start typing a "/" into the chat input field. Command messages cannot be seen by other users in the room (but their results might be, for example a command to roll a dice ("/dice") will show the result to everyone in the space by default).
 			</p>
 
-			<h4>Normal talking</h4>
+			<h4>Normal/In-character talking (IC)</h4>
 
 			<p>
-				When you type something into the chat input field your character says this to everyone in the room. It is also called
-				in-character or standard message, and the message is printed in the chat with your character's name in front of it.
-				While it is usually not needed, you can also use the "/say" command to send a normal message.
+				When you type something into the chat input field it is understood as your character saying this out loud to everyone in the space. It is also called
+				in-character (IC) or standard message, and the message is printed in the chat with your character's name in front of it.
+				While it is usually not needed, you can also use the "/say" command to send an in-character message.
 			</p>
 
-			<h4>Out-of-character talking / OOC</h4>
+			<h4>Out-of-character talking (OOC)</h4>
 
 			<p>
-				The next type are out-of-character or short "OOC" messages. Those are written by putting a "((" in front of your message.
+				The next type is an out-of-character (or short "OOC") message. Those are written by putting a "((" in front of your message.
 				Alternatively you can also use the "/ooc" command to send such a message.
-				The [OOC] tag in front of a message signals everyone that this text was not spoken by your character but comes from the real human
-				user behind the screen. It can for example be used to convey limits or talk about not being comfortable with how the scene goes
+				The [OOC] tag in front of a message signals everyone that this text was not spoken by your character but comes from the human
+				user behind the screen. It can be, for example, used to convey limits, talk about not being comfortable with how the scene is going,
 				or to indicate that you have to leave the club soon. It is especially used to ask
-				to be let go or to stop the play, representing a kind of "safeword" usage. It is frowned upon if it is used to circumvent the effects
-				of a gag to keep talking as the character to
-				other characters, as it is confusing for others to differentiate if the message came from the character or the human user.<br />
+				to be let go or to stop the play, representing a kind of "safeword" usage.<br />
+				It is generally frowned upon using this to talk as your character in this way (IC-in-OOC),
+				especially if done to circumvent some in-character restrictions,
+				such as the character being gagged.
+				It also makes it confusing for others to differentiate if the message is meant to be understood as from the character or the user behind it.<br />
 				Please respect the responsible use of OOC and take the content seriously. It is no longer fun and games if someone asks
 				to be freed in an OOC message!
 			</p>
@@ -70,12 +73,12 @@ export function WikiNew(): ReactElement {
 
 			<p>
 				Emote type messages are actions by your character or world-building text descriptions that enhance the roleplaying experience.
-				Character emotes are written by a leading "*" symbol (or with a "/me" command) and describe the state or action of
-				your character, such as: <i>Yourcharactername is petting Eve's head.</i>
+				Character emotes are written using a leading "*" symbol (or with a "/me" command) and describe the state or action of
+				your character, such as: <i>Character is petting Eve's head.</i>
 			</p>
 
 			<p>
-				On the other hand, starting the message with  double "**" characters (or with an "/emote" command) writes a general, nameless
+				On the other hand, starting the message with double "**" (or with an "/emote" command) writes a general, nameless
 				emote that lets you describe the
 				environment, other events happening in the room, or something other users can see or notice. It is the most important tool
 				for immersive roleplaying.
@@ -84,16 +87,16 @@ export function WikiNew(): ReactElement {
 			<h4>Whispers</h4>
 
 			<p>
-				There are several ways to whisper someone in the same room, but the main ones are listed in the following.<br />
+				There are several ways to whisper someone in the same room, but the main ones are listed here.<br />
 				Any of them puts you into a whisper mode that you need to explicitly leave by using the "Cancel"-button above the chat input.
-				Whispered messages can only be seen by the target and not by anyone else. Note that you can also send an OOC message as a
-				whisper by starting message with "((".
+				Whispered messages can only be seen by the target and not by anyone else. Note, that you can also send an OOC message as a
+				whisper by starting the message with "((" while whispering.
 			</p>
 			<ul>
 				<li>You can click on a character's name in the chat itself.</li>
-				<li>You can click on a character's name under the character on the room background to open a context menu and select "Whisper" there.</li>
+				<li>You can click on a character's name under the character on the room graphics to open a context menu and select "Whisper" there.</li>
 				<li>You can click on the "Whisper"-button next to a character name in the "Room"-tab.</li>
-				<li>You can use the chat command "/w [target]" using either the character name or the character ID as whisper target argument.</li>
+				<li>You can use the chat command "/whisper target" (or "/w target") using either the character's name or the character's ID as the whisper target argument.</li>
 			</ul>
 
 			<p>
@@ -109,15 +112,14 @@ export function WikiNew(): ReactElement {
 				users by default can all be removed by other users, too, when you ask for help.
 			</p>
 			<p>
-				However, there are a few items that cannot be removed by other users, but these items are disabled on a new account to protect
+				However, there are a few items that cannot be removed by other users. These items are disabled on a new account to protect
 				new users. Be wary if someone instructs you to enable some "fun locks they want to use for a play" in your account, as they can get
-				you really stuck. If you ever find yourself in such a case, you can still use the last resort, which is "safemode" (more on that later).
+				you truly stuck. If you ever find yourself stuck, you can still use the last resort, which is "safemode" (more on that later).
 			</p>
 			<p>
-				Another way that can get you stuck is if you permit someone to put you into a room furniture/device that restraints you, as you
-				then can no longer leave the room and disconnecting or closing Pandora will not make you leave your current room either.
-				Again, if you get into such a situation where you no longer feel in a consensual situation and in case communicating with OOC messages
-				would not help, using the "safemode" is the only way out.
+				Another way that can get you stuck is if you permit someone to put you into a room furniture/device that restraints you. Then you can no longer leave the room/space and disconnecting or closing Pandora will not make you leave your current room/space either.<br />
+				Again, if you get into a situation which no longer feels consensual or safe and in case communicating with OOC messages
+				would not help, using "safemode" is the only way out.
 			</p>
 			<p>
 				You can enter "safemode" via the button under your character in the "Room"-tab, in the same row where the wardrobe and profile buttons are.
@@ -126,9 +128,8 @@ export function WikiNew(): ReactElement {
 			</p>
 
 			<p>
-				This was just a brief overview of this topic. There is a whole <Link to='/wiki/safety'>wiki-tab</Link> dedicated to it
-				that we recommend to read at your own leisure. It for instance describes how to set
-				a <Link to='/wiki/safety#SA_Display_name'>custom display name</Link>.
+				This was just a brief overview of this topic. There is a whole <Link to='/wiki/safety'>wiki-tab dedicated to safety</Link> that
+				we recommend to read at your own leisure.
 			</p>
 
 			<h3>Decorating your room</h3>
@@ -137,58 +138,58 @@ export function WikiNew(): ReactElement {
 				You can decorate your personal space with <Link to='/wiki/items#IT_Room-level_items'>room-level items</Link>, such as
 				picture frames, chairs, or kinky furniture. To do that you can click the button "Room inventory" in your personal space,
 				which leads you to the inventory of your personal space. This basically represents the items standing around or being stored
-				inside the room, except the items worn or held by your own character.
+				inside the room.
 			</p>
 
 			<p>
-				To for instance place a "Heart Throne" in the room, you either filter the right side of the inventory by typing in the name of the item
+				To, for instance, place a "Heart Throne" in the room, you either filter the right side of the inventory by typing the name of the item
 				or you press the bed-icon to filter the list of items you can create in the room inventory to only show furniture.
 				Click the Heart Throne and create it in the room inventory on the left side. Before it appears in the room, you need to deploy it first.
-				Press on the Heart Throne on the left side and press the "Deploy the device" button on the right side.<br />
-				Afterwards, the left area shows you a preview of the furniture inside your personal space and you can use the "Back"-button in the top
+				Press on the Heart Throne on the left side and press the "Deploy the device" button in the menu that appears on the right side.<br />
+				Afterwards, you should see the preview focus on the furniture. You can then use the "Back"-button in the top
 				right to go back to the room view.
 			</p>
 
 			<p>
-				To move the throne, you need to enter "room construction mode" with the according button under the "personal space"-tab. This turns
-				the blue button under the throne into a red action button. Clicking it lets you select "Move" in the context menu.
+				To move the throne, you need to "Enable room construction mode" with the according button under the "personal space"-tab (or "Room" tab if you are in a public space). This turns
+				the blue button under the throne into a red action button. Clicking it lets you select "Move" in the context menu.<br />
 				Now you can move the item around on the background by dragging the left icon to the desired position. Not important now,
-				but in case you were wondering, the right button is used to move the device up or down vertically, so along the z-axis.
+				but in case you were wondering, the right button is used to move the device up or down vertically, so along the z-axis.<br />
 				After you are done positioning the throne, you can exit move-mode by clicking the left button again. Afterwards, you can disable
 				room construction mode again.
+				Disabling the construction mode also leaves the move-mode if you don't leave it first.
 			</p>
 
 			<p>
 				Maybe you now want to sit on your newly added throne? Drag the name under your character towards the throne to move next to it.
+				(This is technically not needed, but this is a roleplay platform, so do play the part! When you want to sit on a chair you don't just teleport to it - you walk to it first!)
 				Then click on the blue action button under it, select "Slots" in the context menu,
 				and then "Sitting on the throne", which is the name of the character slot that this item has. Finally, select your character name
 				to sit on it.
 			</p>
 
 			<p>
-				Again a reminder that some of the more kinky furniture can tie your character to the room device, which makes you unable to leave the
+				Again a reminder that some of the more kinky furniture can tie your character to the room device. This makes you unable to leave the
 				space and can trap the character in it, if you are in a private space with no one there to help.
 				Therefore it is advised to be mindful of that when giving someone the permission to make you enter a character slot of a
 				room-level item. Kinky furniture is therefore maybe not the best tool to use in a first roleplaying scene at a "first date".
-				If you find yourself stuck in an empty public space, you can ask a friend for help with a direct message
-				by <Link to='/wiki/spaces#SP_Space_invites'>inviting them</Link> to the space.
-				Entering "safemode" can still free you of course as well, so the worst-case consequences are not necessarily severe.
+				If you find yourself stuck then entering "safemode" can still free you, so the worst-case consequences are not necessarily severe.
 			</p>
 
 			<h3>Creating your own chatroom space</h3>
 
 			<p>
 				Trying out things in your personal space is nice and cozy, but eventually you may want to either join a space with other users or
-				even host your own space. You can do that by clicking the "List of spaces" button, and then press the last row
+				even host your own space. You can do that by clicking the "List of spaces" button, and then pressing the last row
 				"Create a new space". This brings you to a screen where you can enter the properties of your new space, such as name, description,
 				and background image.<br />
 				The default setting of a new space is private, so if you want it to be public, you need to switch this default setting
 				to "Yes".
 			</p>
 			<p>
-				Spaces in Pandora are persistent. This means that all settings, the items in the room inventory, and all deployed furniture
-				stays like it was, after you left the space. So the next time you log in you will still see your space in the list of spaces
-				and everything will be like you set it up before.<br />
+				Spaces in Pandora are persistent. This means that all settings, items in the room inventory, and all deployed furniture
+				stays like it is, even after everyone leaves the space. So the next time you log in you will still see your space in the list of spaces
+				and everything inside will be like you set it up before (unless, of course, someone else changes it).<br />
 				You can find out more about how spaces work under the <Link to='/wiki/spaces'>spaces-tab</Link> in the wiki. For now we recommend you
 				to continue reading about the <Link to='/wiki/introduction'>core features of Pandora</Link> to get an impression of what you can expect,
 				in case reading about this interests you.

--- a/pandora-client-web/src/components/wiki/pages/spaces.tsx
+++ b/pandora-client-web/src/components/wiki/pages/spaces.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { MESSAGE_EDIT_TIMEOUT } from '../../gameContext/gameStateContextProvider';
-import { LIMIT_SPACE_BOUND_INVITES } from 'pandora-common';
+import { LIMIT_SPACE_BOUND_INVITES, LIMIT_SPACE_MAX_CHARACTER_NUMBER } from 'pandora-common';
 import { Link } from 'react-router-dom';
 
 export function WikiSpaces(): ReactElement {
@@ -12,7 +12,8 @@ export function WikiSpaces(): ReactElement {
 
 			<p>
 				A space in Pandora always exists in the state it was set up, even when it was empty for a long time.
-				You can decorate every room inside a space with room items/furniture and it can theoretically be joined by up to 100 characters at the same time.<br />
+				You can decorate every room inside a space with room items/furniture and it can theoretically be joined by up
+				to { LIMIT_SPACE_MAX_CHARACTER_NUMBER } characters at the same time.<br />
 				The "Chat"-tab next to the room view can also be switched to:
 			</p>
 			<ul>

--- a/pandora-client-web/src/components/wiki/pages/spaces.tsx
+++ b/pandora-client-web/src/components/wiki/pages/spaces.tsx
@@ -237,7 +237,7 @@ export function WikiSpaces(): ReactElement {
 				<li>
 					There are also shortcuts to write one-off messages while in the default, normal chat mode.<br />
 					These shortcuts are<br />
-					"((" - double round brackets - usage: (( ooc message )) <br />
+					"((" - double round brackets - usage: (( OOC message )) <br />
 					"*"  - single asterisk/star - usage: *me-emote that gets prefixed with your character's name*<br />
 					"**" - double asterisk/star - usage: **generic emote that doesn't get prefixed**<br />
 					<i>Note</i>: A single message can have multiple different syntax parts, so the above shortcut types can be mixed in a single message if
@@ -268,6 +268,7 @@ export function WikiSpaces(): ReactElement {
 				<li>You can click on the "Whisper"-button next to a character name in the "Room"-tab.</li>
 				<li>You can use the chat command "/w [target]" using either the character name or the character ID as whisper target argument.</li>
 				<li>Chat-related commands while in whisper mode (e.g., "/me") will be executed normally and not be whispered.</li>
+				<li>You can whisper an OOC message though, if you start a whispered message with "((".</li>
 				<li>If your whisper target leaves the room or space, your whisper message cannot be sent.</li>
 				<li>If your whisper target goes offline, your whisper message will still be sent, but currently it will not be delivered.</li>
 			</ul>

--- a/pandora-client-web/src/components/wiki/wiki.tsx
+++ b/pandora-client-web/src/components/wiki/wiki.tsx
@@ -13,6 +13,7 @@ import { WikiSpaces } from './pages/spaces';
 import { WikiItems } from './pages/items';
 import { WikiCharacters } from './pages/characters';
 import { WikiSafety } from './pages/safety';
+import { WikiNew } from './pages/new';
 
 export default function Wiki(): ReactElement {
 	const navigate = useNavigate();
@@ -25,6 +26,9 @@ export default function Wiki(): ReactElement {
 					<WikiIntroduction />
 				</WikiContent>
 			</UrlTab>
+			<WikiContentTab name='New User Guide' urlChunk='new'>
+				<WikiNew />
+			</WikiContentTab>
 			<WikiContentTab name='Spaces' urlChunk='spaces'>
 				<WikiSpaces />
 			</WikiContentTab>

--- a/pandora-client-web/src/styles/_constants.scss
+++ b/pandora-client-web/src/styles/_constants.scss
@@ -20,7 +20,7 @@ $grey-lightest: #e4e4e4;
 
 $theme-error: #b60000;
 $theme-warning: #fd0;
-$theme-link: #032a64;
+$theme-link: #349;
 $theme-notification: #d00;
 
 $drop-shadow: rgb(5,5,5, 0.2);

--- a/pandora-client-web/src/ui/screens/room/roomControls.tsx
+++ b/pandora-client-web/src/ui/screens/room/roomControls.tsx
@@ -68,7 +68,7 @@ export function PersonalSpaceControls(): ReactElement {
 					<p>
 						Every character has their own personal space, which functions as a singleplayer lobby.<br />
 						It cannot be deleted or given up. You will automatically end up in this space when your<br />
-						selected character is not in any multiplayer space.
+						selected character is not in any other space.
 					</p>
 					<span>
 						The personal space functions the same as any other space.<br />

--- a/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.tsx
+++ b/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.tsx
@@ -191,7 +191,7 @@ export function SpaceConfiguration({ creation = false }: { creation?: boolean; }
 				{ canEdit && !IsValidName(currentConfig.name) ? (<div className='error'>Invalid name</div>) : null }
 			</div>
 			<div className='input-container'>
-				<label>Space size (maximum number of characters allowed inside - from 1 to 100)</label>
+				<label>Space size (maximum number of characters allowed inside - from 1 to { LIMIT_SPACE_MAX_CHARACTER_NUMBER })</label>
 				<input autoComplete='none' type='number' value={ currentConfig.maxUsers } min={ 1 } max={ LIMIT_SPACE_MAX_CHARACTER_NUMBER } readOnly={ !canEdit }
 					onChange={ (event) => setModifiedData({ maxUsers: Number.parseInt(event.target.value, 10) }) } />
 			</div>

--- a/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.tsx
+++ b/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.tsx
@@ -191,7 +191,7 @@ export function SpaceConfiguration({ creation = false }: { creation?: boolean; }
 				{ canEdit && !IsValidName(currentConfig.name) ? (<div className='error'>Invalid name</div>) : null }
 			</div>
 			<div className='input-container'>
-				<label>Space size (maximum number of characters allowed inside)</label>
+				<label>Space size (maximum number of characters allowed inside - from 1 to 100)</label>
 				<input autoComplete='none' type='number' value={ currentConfig.maxUsers } min={ 1 } max={ LIMIT_SPACE_MAX_CHARACTER_NUMBER } readOnly={ !canEdit }
 					onChange={ (event) => setModifiedData({ maxUsers: Number.parseInt(event.target.value, 10) }) } />
 			</div>

--- a/pandora-common/src/character/speech.ts
+++ b/pandora-common/src/character/speech.ts
@@ -22,7 +22,7 @@ export type MuffleSettings = {
 	jawMove: number;
 
 	/**
-	 * Speaking: Muffle tongue related sounds (`r`, `re`, `k`, `c`,...)
+	 * Speaking: Muffle tongue related sounds (`r`, `re`, `k`, `c`, `q`, ...)
 	 *
 	 * Effective value range:
 	 * - 0 = no effect
@@ -30,7 +30,7 @@ export type MuffleSettings = {
 	 */
 	tongueRoof: number;
 	/**
-	 * Speaking: Muffle air breath sounds (`th`, `tph`, `ch`,...)
+	 * Speaking: Muffle air breath sounds (`th`, `ch`,...)
 	 *
 	 * Effective value range:
 	 * - 0 = no effect
@@ -46,7 +46,7 @@ export type MuffleSettings = {
 	 */
 	throatBreath: number;
 	/**
-	 * Speaking: Muffle hinting letters (h, j, l, r, v, w, x, y, q)
+	 * Speaking: Muffle hinting letters (h, j, l, r, v, w, x, y)
 	 *
 	 * Effective value range:
 	 * - 0 = no effect
@@ -94,21 +94,21 @@ export class Muffler {
 
 		let muffled: string[] = word.split('').map((c) => {
 			if (/t/ig.test(c)) {
-				return this.roll(['th', 'tph'], tongueRoof, r, c);
-			} else if (/[kc]/ig.test(c)) {
+				return this.roll(['th'], tongueRoof, r, c);
+			} else if (/[kcq]/ig.test(c)) {
 				return this.roll(['ch', 'gh'], tongueRoof, r, c);
 			} else if (/[z]/ig.test(c)) {
 				return this.roll(['gi'], jawMove, r, c);
 			} else if (/[bdgp]/ig.test(c)) {
-				return this.roll(['ch', 'gh'], lipsTouch, r, c);
+				return this.roll(['gh'], lipsTouch, r, c);
 			} else if (/[s]/ig.test(c)) {
-				return this.roll(['sh', 'ss'], jawMove, r, c);
+				return this.roll(['sh'], jawMove, r, c);
 			} else if (/[f]/ig.test(c)) {
 				return this.roll(['ph'], lipsTouch, r, c);
-			} else if (/[hjlrwxyq]/ig.test(c)) {
+			} else if (/[hjlrwxy]/ig.test(c)) {
 				return this.roll(['w', 'm', 'h', 'n'], coherency, r, c);
 			} else if (/[aeiou]/ig.test(c)) {
-				return this.roll(['m', 'n', 'w', 'h'], jawMove, r, c);
+				return this.roll(['m', 'n', 'w'], jawMove, r, c);
 			} else {
 				return c;
 			}
@@ -116,7 +116,7 @@ export class Muffler {
 
 		if (mouthBreath > 0) {
 			muffled = muffled.map((c) => {
-				if (/(th|tph|ch|c)/ig.test(c)) {
+				if (/(th|ch|c)/ig.test(c)) {
 					return this.roll(['gh'], mouthBreath, r, c);
 				} else if (/(ph)/ig.test(c)) {
 					return this.roll(['mh', 'nh'], mouthBreath, r, c);

--- a/pandora-common/src/chat/chat.ts
+++ b/pandora-common/src/chat/chat.ts
@@ -146,7 +146,7 @@ export const ChatTypeDetails: Record<IChatType, IChatTypeDetails> = {
 	'ooc': {
 		commandKeywords: ['ooc', 'o'],
 		description: 'out-of-character (OOC) message',
-		longDescription: 'Sends an (( OOC )) message which ignores effects like muffling/deafening and is used for communicating as an aside from the main activity/discussion.' + LONGDESC_TOGGLE_MODE,
+		longDescription: 'Sends an (( OOC )) message which ignores effects like muffling/deafening and is used for communicating as the user in front of the screen.' + LONGDESC_TOGGLE_MODE,
 	},
 	'me': {
 		commandKeywords: ['me', 'm', 'action'],


### PR DESCRIPTION
This PR contains:

- a new tab in the wiki with a new user guide and embedding it in other intro pages
- improvements and small updates to most other wiki pages
- few small text improvements in the space admin view, the ooc command description, and the personal space help text
- minor change of the garbling method to be slightly more accurate