### PR TITLE
[FIX] Drop invalid direct message edit time

### DIFF
--- a/pandora-server-directory/src/database/databaseStructure.ts
+++ b/pandora-server-directory/src/database/databaseStructure.ts
@@ -64,7 +64,7 @@ export const DatabaseDirectMessageSchema = z.object({
 	content: z.string(),
 	source: z.number(),
 	time: z.number(),
-	edited: z.number().optional(),
+	edited: z.number().optional().catch(undefined),
 });
 export type DatabaseDirectMessage = z.infer<typeof DatabaseDirectMessageSchema>;
 export const DatabaseDirectMessageAccountsSchema = z.object({


### PR DESCRIPTION
It appears in the past we used `null` for `edited` instead of having it optional as it is now. This causes the edited time to be dropped when it is invalid.