### PR TITLE
[CHANGE] gate development mode and document space effects

### DIFF
--- a/pandora-client-web/src/components/wiki/pages/characters.tsx
+++ b/pandora-client-web/src/components/wiki/pages/characters.tsx
@@ -112,7 +112,11 @@ export function WikiCharacters(): ReactElement {
 					what is inside the <Link to='/wiki/spaces#SP_Room_inventory'>room inventory</Link> on the right.
 					You can create and wear a new item under the "create new item"-tab there.
 				</li>
-				<li>There is a maximum amount of items your character can wear or hold (also counting all items inside worn storage items)</li>
+				<li>
+					There is a maximum amount of items your character can wear or hold. This number is the sum
+					of all <Link to='/wiki/items#IT_Body_parts'>body parts</Link>, all items worn on the body, and all
+					items inside worn items with <Link to='/wiki/items#IT_Storage_modules'>storage modules</Link>, e.g. a bag.
+				</li>
 			</ul>
 
 			<h4 id='CH_Character_permissions'>Character permissions</h4>

--- a/pandora-client-web/src/components/wiki/pages/characters.tsx
+++ b/pandora-client-web/src/components/wiki/pages/characters.tsx
@@ -114,7 +114,8 @@ export function WikiCharacters(): ReactElement {
 				</li>
 				<li>
 					There is a maximum amount of items your character can wear or hold. This number is the sum
-					of all <Link to='/wiki/items#IT_Body_parts'>body parts</Link>, all items worn on the body, and all
+					of all <Link to='/wiki/items#IT_Body_parts'>body parts</Link>, all items worn on the body, special
+					items, e.g. locks, and all
 					items inside worn items with <Link to='/wiki/items#IT_Storage_modules'>storage modules</Link>, e.g. a bag.
 				</li>
 			</ul>

--- a/pandora-client-web/src/components/wiki/pages/history.tsx
+++ b/pandora-client-web/src/components/wiki/pages/history.tsx
@@ -94,7 +94,7 @@ export function WikiHistory(): ReactElement {
 				</ul>
 				<strong>Developers</strong>
 				<ul>
-					<li>Kane</li>
+					<li>Kane (Hareo)</li>
 					<li>Nina</li>
 					<li>Nythaleath</li>
 					<li>Sandrine</li>
@@ -113,7 +113,7 @@ export function WikiHistory(): ReactElement {
 					<li>Eve</li>
 					<li>Jenn</li>
 					<li>Jomshir (Clare)</li>
-					<li>Kane</li>
+					<li>Kane  (Hareo)</li>
 					<li>Kimei Nishimura</li>
 					<li>Natsuki</li>
 					<li>Nina</li>

--- a/pandora-client-web/src/components/wiki/pages/history.tsx
+++ b/pandora-client-web/src/components/wiki/pages/history.tsx
@@ -113,7 +113,7 @@ export function WikiHistory(): ReactElement {
 					<li>Eve</li>
 					<li>Jenn</li>
 					<li>Jomshir (Clare)</li>
-					<li>Kane  (Hareo)</li>
+					<li>Kane (Hareo)</li>
 					<li>Kimei Nishimura</li>
 					<li>Natsuki</li>
 					<li>Nina</li>

--- a/pandora-client-web/src/components/wiki/pages/spaces.tsx
+++ b/pandora-client-web/src/components/wiki/pages/spaces.tsx
@@ -31,7 +31,7 @@ export function WikiSpaces(): ReactElement {
 				<li><Link to='#SP_Space_visibility'>Space visibility</Link></li>
 				<li><Link to='#SP_Space_access'>Space access</Link></li>
 				<li><Link to='#SP_Space_invites'>Space invites</Link></li>
-				<li><Link to='#SP_Space_modifier'>Space modifier</Link></li>
+				<li><Link to='#SP_Space_features'>Space features</Link></li>
 				<li><Link to='#SP_Space_administration'>Space administration</Link></li>
 				<li><Link to='#SP_Leaving_a_space'>Leaving a space</Link></li>
 				<li><Link to='#SP_Personal_space'>Personal space</Link></li>
@@ -159,9 +159,9 @@ export function WikiSpaces(): ReactElement {
 				<li>Space owners, admins and the invite's author can delete these invites at any point in time, after which they can no longer be used.</li>
 			</ul>
 
-			<h4 id='SP_Space_modifier'>Space modifier</h4>
+			<h4 id='SP_Space_features'>Space features</h4>
 			<p>
-				While creating a room, you can set several space modifier check boxes at the end of the space creation screen. These cannot be changed after the space creation.
+				While creating a room, you can set several space features check boxes at the end of the space creation screen. These cannot be changed after the space creation.
 			</p>
 			<ul>
 				<li>

--- a/pandora-client-web/src/components/wiki/pages/spaces.tsx
+++ b/pandora-client-web/src/components/wiki/pages/spaces.tsx
@@ -174,10 +174,8 @@ export function WikiSpaces(): ReactElement {
 				</li>
 				<li>
 					Development mode: On a development server, spaces can be created in development mode. This enables use of many development tools, such as
-					room background calibration tool. Those can however break things when used incorrectly. Because of that
-					<strong>
-						this option is not available on the public server for non-developers.
-					</strong>
+					room background calibration tool. Those can however break things when used incorrectly. Because of
+					that <strong>this option is not available on the public server for non-developers</strong>.
 				</li>
 			</ul>
 

--- a/pandora-client-web/src/components/wiki/pages/spaces.tsx
+++ b/pandora-client-web/src/components/wiki/pages/spaces.tsx
@@ -31,6 +31,7 @@ export function WikiSpaces(): ReactElement {
 				<li><Link to='#SP_Space_visibility'>Space visibility</Link></li>
 				<li><Link to='#SP_Space_access'>Space access</Link></li>
 				<li><Link to='#SP_Space_invites'>Space invites</Link></li>
+				<li><Link to='#SP_Space_modifier'>Space modifier</Link></li>
 				<li><Link to='#SP_Space_administration'>Space administration</Link></li>
 				<li><Link to='#SP_Leaving_a_space'>Leaving a space</Link></li>
 				<li><Link to='#SP_Personal_space'>Personal space</Link></li>
@@ -156,6 +157,27 @@ export function WikiSpaces(): ReactElement {
 				<li>The invite details cannot be edited by the one creating it. The purpose of "join-me" invites is to be simple and quick to use.</li>
 				<li>Banned accounts cannot be invited this way.</li>
 				<li>Space owners, admins and the invite's author can delete these invites at any point in time, after which they can no longer be used.</li>
+			</ul>
+
+			<h4 id='SP_Space_modifier'>Space modifier</h4>
+			<p>
+				While creating a room, you can set several space modifier check boxes at the end of the space creation screen. These cannot be changed after the space creation.
+			</p>
+			<ul>
+				<li>
+					Allow changes to character bodies: Determines if any character inside the space can change their body, for example changing the shape/size of their body,
+					or swapping different eyes, nose, genitals.
+				</li>
+				<li>
+					Allow changes to character pronouns: Determines if any character inside the space can change their pronouns, so with which gender they are mentioned,
+					while inside the space.
+				</li>
+				<li>
+					Development mode: On a development server, spaces can be created in development mode, which inhibits some checks, for example bounds checking
+					for room backgrounds, and enables development tools such as room background calibration tool, which are inaccessible without this turned on,
+					as they cause everyone in the space to see things differently based on their development settings.<br />
+					On the deployed production version of Pandora, spaces shall not be created in development mode!
+				</li>
 			</ul>
 
 			<h4 id='SP_Space_administration'>Space administration</h4>

--- a/pandora-client-web/src/components/wiki/pages/spaces.tsx
+++ b/pandora-client-web/src/components/wiki/pages/spaces.tsx
@@ -161,22 +161,23 @@ export function WikiSpaces(): ReactElement {
 
 			<h4 id='SP_Space_features'>Space features</h4>
 			<p>
-				While creating a room, you can set several space features check boxes at the end of the space creation screen. These cannot be changed after the space creation.
+				While creating a room, you can set several space feature check boxes at the bottom of the space creation screen. These cannot be changed after the space creation.
 			</p>
 			<ul>
 				<li>
 					Allow changes to character bodies: Determines if any character inside the space can change their body, for example changing the shape/size of their body,
-					or swapping different eyes, nose, genitals.
+					or swapping to different eyes, nose, genitals.
 				</li>
 				<li>
 					Allow changes to character pronouns: Determines if any character inside the space can change their pronouns, so with which gender they are mentioned,
 					while inside the space.
 				</li>
 				<li>
-					Development mode: On a development server, spaces can be created in development mode, which inhibits some checks, for example bounds checking
-					for room backgrounds, and enables development tools such as room background calibration tool, which are inaccessible without this turned on,
-					as they cause everyone in the space to see things differently based on their development settings.<br />
-					On the deployed production version of Pandora, spaces shall not be created in development mode!
+					Development mode: On a development server, spaces can be created in development mode. This enables use of many development tools, such as
+					room background calibration tool. Those can however break things when used incorrectly. Because of that
+					<strong>
+						this option is not available on the public server for non-developers.
+					</strong>
 				</li>
 			</ul>
 

--- a/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.tsx
+++ b/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.tsx
@@ -292,7 +292,7 @@ export function SpaceConfiguration({ creation = false }: { creation?: boolean; }
 										}
 									} }
 								/>
-								<label htmlFor={ `${idPrefix}-feature-${feature.id}` }>{ ' ' + feature.name }</label>
+								<label htmlFor={ `${idPrefix}-feature-${feature.id}` }> { feature.name }</label>
 							</div>
 						))
 					}

--- a/pandora-server-directory/src/config.ts
+++ b/pandora-server-directory/src/config.ts
@@ -77,7 +77,7 @@ export const EnvParser = CreateEnvParser({
 		.split(',')
 		.map((x) => x.trim())
 		.filter(Boolean)
-		.map(parseInt), z.array(z.number())).default([]),
+		.map((x) => parseInt(x, 10)), z.array(z.number())).default([]),
 
 	//#endregion
 

--- a/pandora-server-directory/src/networking/manager_client.ts
+++ b/pandora-server-directory/src/networking/manager_client.ts
@@ -423,7 +423,14 @@ export const ConnectionManagerClient = new class ConnectionManagerClient impleme
 
 		const character = connection.character;
 
-		const space = await SpaceManager.createSpace(spaceConfig, [connection.account.id], connection.account);
+		// Only developers can create rooms with development mode enabled
+		if (spaceConfig.features.includes('development') && !connection.account.roles.isAuthorized('developer')) {
+			return {
+				result: 'failed',
+			};
+		}
+
+		const space = await SpaceManager.createSpace(spaceConfig, [connection.account.id]);
 
 		if (typeof space === 'string') {
 			return { result: space };

--- a/pandora-server-directory/src/networking/manager_client.ts
+++ b/pandora-server-directory/src/networking/manager_client.ts
@@ -423,7 +423,7 @@ export const ConnectionManagerClient = new class ConnectionManagerClient impleme
 
 		const character = connection.character;
 
-		const space = await SpaceManager.createSpace(spaceConfig, [connection.account.id]);
+		const space = await SpaceManager.createSpace(spaceConfig, [connection.account.id], connection.account);
 
 		if (typeof space === 'string') {
 			return { result: space };

--- a/pandora-server-directory/src/networking/manager_client.ts
+++ b/pandora-server-directory/src/networking/manager_client.ts
@@ -429,6 +429,12 @@ export const ConnectionManagerClient = new class ConnectionManagerClient impleme
 				result: 'failed',
 			};
 		}
+		// No development options allowed if the development feature is not in use
+		if (spaceConfig.development != null && !spaceConfig.features.includes('development')) {
+			return {
+				result: 'failed',
+			};
+		}
 
 		const space = await SpaceManager.createSpace(spaceConfig, [connection.account.id]);
 

--- a/pandora-server-directory/src/spaces/spaceManager.ts
+++ b/pandora-server-directory/src/spaces/spaceManager.ts
@@ -175,6 +175,13 @@ export const SpaceManager = new class SpaceManagerClass implements Service {
 			logger.error(`Failed to load space ${data.id} due to invalid data`, result.error);
 			return null;
 		}
+
+		// Drop development data if development feature is disabled
+		// This is done before the equality check to also purge it from DB
+		if (result.data.config.development != null && !result.data.config.features.includes('development')) {
+			delete result.data.config.development;
+		}
+
 		{
 			const validated = pick(result.data, ...SPACE_DIRECTORY_PROPERTIES);
 			const original = pick(data, ...SPACE_DIRECTORY_PROPERTIES);

--- a/pandora-server-directory/src/spaces/spaceManager.ts
+++ b/pandora-server-directory/src/spaces/spaceManager.ts
@@ -128,12 +128,8 @@ export const SpaceManager = new class SpaceManagerClass implements Service {
 	}
 
 	@AsyncSynchronized()
-	public async createSpace(config: SpaceDirectoryConfig, owners: AccountId[], creator: Account): Promise<Space | 'failed' | 'spaceOwnershipLimitReached'> {
+	public async createSpace(config: SpaceDirectoryConfig, owners: AccountId[]): Promise<Space | 'failed' | 'spaceOwnershipLimitReached'> {
 		Assert(owners.length > 0, 'Space must be created with some owners');
-
-		if (config.features.includes('development') && !creator.roles.isAuthorized('developer')) {
-			return 'failed';
-		}
 
 		// Check, that owners are within limits
 		for (const ownerId of owners) {

--- a/pandora-server-directory/src/spaces/spaceManager.ts
+++ b/pandora-server-directory/src/spaces/spaceManager.ts
@@ -128,8 +128,12 @@ export const SpaceManager = new class SpaceManagerClass implements Service {
 	}
 
 	@AsyncSynchronized()
-	public async createSpace(config: SpaceDirectoryConfig, owners: AccountId[]): Promise<Space | 'failed' | 'spaceOwnershipLimitReached'> {
+	public async createSpace(config: SpaceDirectoryConfig, owners: AccountId[], creator: Account): Promise<Space | 'failed' | 'spaceOwnershipLimitReached'> {
 		Assert(owners.length > 0, 'Space must be created with some owners');
+
+		if (config.features.includes('development') && !creator.roles.isAuthorized('developer')) {
+			return 'failed';
+		}
 
 		// Check, that owners are within limits
 		for (const ownerId of owners) {


### PR DESCRIPTION
This PR hides the option to create a space in development mode if you are not having the role of a developer or higher.

Following things need improvement, which are beyond my level of knowledge:

- Make the directory reject a space creation if it includes the effect "development" but the creator is not having the developer role
- Make it so that the space background image or solid color has a large (slightly transparent?) text overlayed "Development mode"