### PR TITLE
[FEATURE] Discord beta registrations and invites

### DIFF
--- a/pandora-server-directory/src/account/account.ts
+++ b/pandora-server-directory/src/account/account.ts
@@ -9,6 +9,7 @@ import {
 	AsyncSynchronized,
 	CharacterId,
 	CharacterSelfInfo,
+	GetLogger,
 	IDirectoryAccountInfo,
 	IDirectoryClient,
 	IShardAccountDefinition,
@@ -18,24 +19,24 @@ import {
 	LIMIT_SPACE_OWNED_COUNT,
 	OutfitMeasureCost,
 	ServerRoom,
+	TimeSpanMs,
 	type AccountSettings,
 	type AccountSettingsKeys,
-	GetLogger,
-	TimeSpanMs,
 	type Logger,
 } from 'pandora-common';
 import { GetDatabase } from '../database/databaseProvider';
 import { DatabaseAccount, DatabaseAccountUpdate, DatabaseAccountWithSecure, DirectMessageAccounts, type DatabaseCharacterSelfInfo } from '../database/databaseStructure';
 import type { ClientConnection } from '../networking/connection_client';
+import { AsyncInterval } from '../utility';
 import { AccountContacts } from './accountContacts';
 import { AccountDirectMessages } from './accountDirectMessages';
 import { AccountRoles } from './accountRoles';
 import AccountSecure, { GenerateAccountSecureData } from './accountSecure';
+import type { ActorIdentity } from './actorIdentity';
 import { CharacterInfo } from './character';
-import { AsyncInterval } from '../utility';
 
 /** Currently logged in or recently used account */
-export class Account {
+export class Account implements ActorIdentity {
 	private readonly logger: Logger;
 	private readonly cleanupInterval: AsyncInterval;
 

--- a/pandora-server-directory/src/account/accountRoles.ts
+++ b/pandora-server-directory/src/account/accountRoles.ts
@@ -1,15 +1,15 @@
-import { AccountRole, ACCOUNT_ROLES_CONFIG, GetLogger, IAccountRoleInfo, IAccountRoleManageInfo, IsAuthorized, Logger } from 'pandora-common';
-import { GetDatabase } from '../database/databaseProvider';
-import type { Account } from './account';
-import { ENV } from '../config';
-import { GitHubInfo } from '../database/databaseStructure';
-const { AUTO_ADMIN_ACCOUNTS } = ENV;
-
 import _ from 'lodash';
+import { ACCOUNT_ROLES_CONFIG, AccountRole, GetLogger, IAccountRoleInfo, IAccountRoleManageInfo, IsAuthorized, Logger } from 'pandora-common';
+import { ENV } from '../config';
+import { GetDatabase } from '../database/databaseProvider';
+import { GitHubInfo } from '../database/databaseStructure';
+import type { Account } from './account';
+import type { ActorRoles } from './actorIdentity';
+const { AUTO_ADMIN_ACCOUNTS } = ENV;
 
 const logger = GetLogger('AccountRoles');
 
-export class AccountRoles {
+export class AccountRoles implements ActorRoles {
 	private readonly _account: Account;
 	private readonly _logger: Logger;
 	/** Roles saved persistently into database */

--- a/pandora-server-directory/src/account/actorIdentity.ts
+++ b/pandora-server-directory/src/account/actorIdentity.ts
@@ -1,0 +1,11 @@
+import type { AccountId, AccountRole } from 'pandora-common';
+
+export interface ActorIdentity {
+	readonly id: AccountId;
+	readonly username: string;
+	readonly roles: ActorRoles;
+}
+
+export interface ActorRoles {
+	isAuthorized(role: AccountRole): boolean;
+}

--- a/pandora-server-directory/src/account/actorPandora.ts
+++ b/pandora-server-directory/src/account/actorPandora.ts
@@ -1,0 +1,16 @@
+import type { AccountRole } from 'pandora-common';
+import type { ActorIdentity, ActorRoles } from './actorIdentity';
+
+class PandoraRoles implements ActorRoles {
+	public isAuthorized(_role: AccountRole): boolean {
+		// Pandora itself can do anything
+		return true;
+	}
+}
+
+export const ACTOR_PANDORA = new class PandoraActor implements ActorIdentity {
+	public readonly id: number = 0;
+	public readonly username: string = '[[Pandora]]';
+
+	public readonly roles = new PandoraRoles();
+};

--- a/pandora-server-directory/src/config.ts
+++ b/pandora-server-directory/src/config.ts
@@ -90,6 +90,10 @@ export const EnvParser = CreateEnvParser({
 	/** Discord bot character status channel ID */
 	DISCORD_BOT_CHARACTER_STATUS_CHANNEL_ID: z.string().default(''),
 
+	// Beta registration roles
+	DISCORD_BETA_REGISTRATION_PENDING_ROLE_ID: z.string().default(''),
+	DISCORD_BETA_ACCESS_ROLE_ID: z.string().default(''),
+
 	//#endregion
 
 	//#region Captcha

--- a/pandora-server-directory/src/database/databaseStructure.ts
+++ b/pandora-server-directory/src/database/databaseStructure.ts
@@ -139,6 +139,13 @@ export const DatabaseAccountWithSecureSchema = DatabaseAccountSchema.extend({
 /** Representation of account stored in database */
 export type DatabaseAccountWithSecure = z.infer<typeof DatabaseAccountWithSecureSchema>;
 
+export const DatabaseBetaRegistrationSchema = z.object({
+	discordId: z.string(),
+	registeredAt: z.number(),
+	assignedKey: z.string().nullable(),
+});
+export type DatabaseBetaRegistration = z.infer<typeof DatabaseBetaRegistrationSchema>;
+
 export const DatabaseConfigSchema = z.discriminatedUnion('type', [
 	z.object({
 		type: z.literal('shardTokens'),
@@ -147,6 +154,10 @@ export const DatabaseConfigSchema = z.discriminatedUnion('type', [
 	z.object({
 		type: z.literal('betaKeys'),
 		data: ZodCast<(IBetaKeyInfo & { token: string; })[]>(),
+	}),
+	z.object({
+		type: z.literal('betaRegistrations'),
+		data: DatabaseBetaRegistrationSchema.array(),
 	}),
 ]);
 export type DatabaseConfig = z.infer<typeof DatabaseConfigSchema>;

--- a/pandora-server-directory/src/database/databaseStructure.ts
+++ b/pandora-server-directory/src/database/databaseStructure.ts
@@ -139,10 +139,17 @@ export const DatabaseAccountWithSecureSchema = DatabaseAccountSchema.extend({
 /** Representation of account stored in database */
 export type DatabaseAccountWithSecure = z.infer<typeof DatabaseAccountWithSecureSchema>;
 
-export type DatabaseConfig = {
-	shardTokens: (IShardTokenInfo & { token: string; })[];
-	betaKeys: (IBetaKeyInfo & { token: string; })[];
-};
+export const DatabaseConfigSchema = z.discriminatedUnion('type', [
+	z.object({
+		type: z.literal('shardTokens'),
+		data: ZodCast<(IShardTokenInfo & { token: string; })[]>(),
+	}),
+	z.object({
+		type: z.literal('betaKeys'),
+		data: ZodCast<(IBetaKeyInfo & { token: string; })[]>(),
+	}),
+]);
+export type DatabaseConfig = z.infer<typeof DatabaseConfigSchema>;
 
-export type DatabaseConfigType = keyof DatabaseConfig;
-export type DatabaseConfigData<T extends DatabaseConfigType> = DatabaseConfig[T];
+export type DatabaseConfigType = DatabaseConfig['type'];
+export type DatabaseConfigData<T extends DatabaseConfigType> = (DatabaseConfig & { type: T; })['data'];

--- a/pandora-server-directory/src/database/mongoDb.ts
+++ b/pandora-server-directory/src/database/mongoDb.ts
@@ -624,8 +624,21 @@ export default class MongoDatabase implements PandoraDatabase {
 	}
 
 	public async setConfig<T extends DatabaseConfigType>(type: T, data: DatabaseConfigData<T>): Promise<void> {
-		// @ts-expect-error data is unique to each config type
-		await this._config.updateOne({ type }, { $set: { data } }, { upsert: true });
+		await this._config.updateOne(
+			{
+				type,
+			},
+			{
+				$set: {
+					// @ts-expect-error data is unique to each config type
+					data,
+				},
+				$setOnInsert: {
+					type,
+				},
+			},
+			{ upsert: true },
+		);
 	}
 
 	/**

--- a/pandora-server-directory/src/database/mongoDb.ts
+++ b/pandora-server-directory/src/database/mongoDb.ts
@@ -27,7 +27,27 @@ import {
 import { z } from 'zod';
 import { ENV } from '../config';
 import type { PandoraDatabase } from './databaseProvider';
-import { DATABASE_ACCOUNT_UPDATEABLE_PROPERTIES, DatabaseAccount, DatabaseAccountContact, DatabaseAccountContactType, DatabaseAccountSchema, DatabaseAccountSecure, DatabaseAccountUpdate, DatabaseAccountWithSecure, DatabaseAccountWithSecureSchema, DatabaseConfigData, DatabaseConfigType, DatabaseDirectMessageAccountsSchema, DatabaseDirectMessageInfo, DirectMessageAccounts, type DatabaseCharacterSelfInfo, type DatabaseDirectMessage, type DatabaseDirectMessageAccounts, DatabaseCharacterSelfInfoSchema } from './databaseStructure';
+import {
+	DATABASE_ACCOUNT_UPDATEABLE_PROPERTIES,
+	DatabaseAccount,
+	DatabaseAccountContact,
+	DatabaseAccountContactType,
+	DatabaseAccountSchema,
+	DatabaseAccountSecure,
+	DatabaseAccountUpdate,
+	DatabaseAccountWithSecure,
+	DatabaseAccountWithSecureSchema,
+	DatabaseCharacterSelfInfoSchema,
+	DatabaseConfigData,
+	DatabaseConfigSchema,
+	DatabaseConfigType,
+	DatabaseDirectMessageAccountsSchema,
+	DatabaseDirectMessageInfo,
+	DirectMessageAccounts,
+	type DatabaseCharacterSelfInfo,
+	type DatabaseDirectMessage,
+	type DatabaseDirectMessageAccounts,
+} from './databaseStructure';
 import { CreateCharacter, CreateSpace, SpaceCreationData } from './dbHelper';
 import { DbAutomaticMigration, ValidatedCollection, ValidatedCollectionType } from './validatedCollection';
 
@@ -131,7 +151,7 @@ const spaceCollection = new ValidatedCollection(
 const configCollection = new ValidatedCollection(
 	logger,
 	'config',
-	ZodCast<{ type: DatabaseConfigType; data: DatabaseConfigData<DatabaseConfigType>; }>(), // TODO: This needs a proper schema!
+	DatabaseConfigSchema,
 	[
 		{
 			name: 'id',
@@ -598,11 +618,13 @@ export default class MongoDatabase implements PandoraDatabase {
 		if (!result?.data)
 			return null;
 
+		Assert(result.type === type);
 		// @ts-expect-error data is unique to each config type
 		return result.data;
 	}
 
 	public async setConfig<T extends DatabaseConfigType>(type: T, data: DatabaseConfigData<T>): Promise<void> {
+		// @ts-expect-error data is unique to each config type
 		await this._config.updateOne({ type }, { $set: { data } }, { upsert: true });
 	}
 

--- a/pandora-server-directory/src/index.ts
+++ b/pandora-server-directory/src/index.ts
@@ -1,19 +1,20 @@
 import { mkdirSync } from 'fs';
+import { GetLogger, LogLevel, ServiceInit, SetConsoleOutput } from 'pandora-common';
 import { accountManager } from './account/accountManager';
 import { ENV } from './config';
-const { APP_NAME, LOG_DIR, LOG_DISCORD_WEBHOOK_URL, LOG_PRODUCTION } = ENV;
 import { GetDatabaseService } from './database/databaseProvider';
-import { AddDiscordLogOutput, AddFileOutput } from './logging';
-import { GetLogger, LogLevel, ServiceInit, SetConsoleOutput } from 'pandora-common';
-import { HttpServer } from './networking/httpServer';
-import GetEmailSender from './services/email';
 import { SetupSignalHandling } from './lifecycle';
+import { AddDiscordLogOutput, AddFileOutput } from './logging';
+import { HttpServer } from './networking/httpServer';
 import { ConnectionManagerClient } from './networking/manager_client';
-import { GitHubVerifier } from './services/github/githubVerify';
-import { ShardTokenStore } from './shard/shardTokenStore';
+import { BetaRegistrationService } from './services/betaRegistration/betaRegistration';
 import { DiscordBot } from './services/discord/discordBot';
+import GetEmailSender from './services/email';
+import { GitHubVerifier } from './services/github/githubVerify';
 import { BetaKeyStore } from './shard/betaKeyStore';
+import { ShardTokenStore } from './shard/shardTokenStore';
 import { SpaceManager } from './spaces/spaceManager';
+const { APP_NAME, LOG_DIR, LOG_DISCORD_WEBHOOK_URL, LOG_PRODUCTION } = ENV;
 
 const logger = GetLogger('init');
 
@@ -30,7 +31,6 @@ async function Start(): Promise<void> {
 	await SetupLogging();
 	logger.info(`${APP_NAME} starting...`);
 	await ServiceInit(GetEmailSender());
-	await ServiceInit(DiscordBot);
 	logger.verbose('Initializing database...');
 	await ServiceInit(GetDatabaseService());
 	await ServiceInit(ShardTokenStore);
@@ -39,8 +39,10 @@ async function Start(): Promise<void> {
 	await ServiceInit(accountManager);
 	await ServiceInit(SpaceManager);
 	await ServiceInit(ConnectionManagerClient);
+	await ServiceInit(BetaRegistrationService);
 	logger.verbose('Initializing APIs...');
 	await ServiceInit(GitHubVerifier);
+	await ServiceInit(DiscordBot);
 	logger.verbose('Starting HTTP server...');
 	await ServiceInit(HttpServer);
 	logger.alert('Ready!');

--- a/pandora-server-directory/src/lifecycle.ts
+++ b/pandora-server-directory/src/lifecycle.ts
@@ -1,11 +1,13 @@
 import { GetLogger, Service, logConfig } from 'pandora-common';
+import wtfnode from 'wtfnode';
 import { accountManager } from './account/accountManager';
 import { GetDatabaseService } from './database/databaseProvider';
 import { HttpServer } from './networking/httpServer';
 import { ConnectionManagerClient } from './networking/manager_client';
-import { ShardManager } from './shard/shardManager';
-import wtfnode from 'wtfnode';
+import { BetaRegistrationService } from './services/betaRegistration/betaRegistration';
 import { DiscordBot } from './services/discord/discordBot';
+import { GitHubVerifier } from './services/github/githubVerify';
+import { ShardManager } from './shard/shardManager';
 import { SpaceManager } from './spaces/spaceManager';
 
 const logger = GetLogger('Lifecycle');
@@ -29,8 +31,10 @@ function DestroyService(service: Service): Promise<void> | void {
 async function StopGracefully(): Promise<void> {
 	// Stop HTTP server
 	await DestroyService(HttpServer);
-	// Stop discord bot
+	// Stop APIs
 	await DestroyService(DiscordBot);
+	await DestroyService(GitHubVerifier);
+	await DestroyService(BetaRegistrationService);
 	// Stop sending status updates
 	await DestroyService(ConnectionManagerClient);
 	// Unload all shards

--- a/pandora-server-directory/src/networking/manager_client.ts
+++ b/pandora-server-directory/src/networking/manager_client.ts
@@ -659,7 +659,8 @@ export const ConnectionManagerClient = new class ConnectionManagerClient impleme
 
 		return {
 			result: 'ok',
-			...result,
+			info: result.info,
+			token: result.token,
 		};
 	}
 
@@ -686,7 +687,8 @@ export const ConnectionManagerClient = new class ConnectionManagerClient impleme
 
 		return {
 			result: 'ok',
-			...result,
+			info: result.info,
+			token: result.token,
 		};
 	}
 

--- a/pandora-server-directory/src/services/betaRegistration/betaRegistration.ts
+++ b/pandora-server-directory/src/services/betaRegistration/betaRegistration.ts
@@ -1,0 +1,55 @@
+import { Assert, AsyncSynchronized, type Service } from 'pandora-common';
+import { GetDatabase } from '../../database/databaseProvider';
+import type { DatabaseBetaRegistration } from '../../database/databaseStructure';
+
+export const BetaRegistrationService = new class BetaRegistrationService implements Service {
+	private _betaRegistrations: DatabaseBetaRegistration[] | null = null;
+
+	@AsyncSynchronized('object')
+	public async init(): Promise<void> {
+		Assert(this._betaRegistrations == null);
+
+		this._betaRegistrations = await GetDatabase().getConfig('betaRegistrations') ?? [];
+	}
+
+	@AsyncSynchronized('object')
+	public async onDestroy(): Promise<void> {
+		Assert(this._betaRegistrations != null);
+
+		// Skip save if there is nothing to save (this avoids getting stuck on timeouts if something goes wrong)
+		if (this._betaRegistrations.length > 0) {
+			await this._save();
+		}
+
+		this._betaRegistrations = null;
+	}
+
+	/**
+	 * Adds a new user into the registration queue
+	 * @param discordId - Discord ID of the user to register
+	 * @returns - If the user was actually added, or `false` if they already had a pending registration
+	 */
+	@AsyncSynchronized('object')
+	public async registerUser(discordId: string): Promise<'added' | 'pending' | 'betaAccess'> {
+		Assert(this._betaRegistrations != null);
+
+		const entry = this._betaRegistrations.find((r) => r.discordId === discordId);
+		if (entry != null)
+			return entry.assignedKey != null ? 'betaAccess' : 'pending';
+
+		this._betaRegistrations.push({
+			discordId,
+			registeredAt: Date.now(),
+			assignedKey: null,
+		});
+		await this._save();
+
+		return 'added';
+	}
+
+	private async _save(): Promise<void> {
+		Assert(this._betaRegistrations != null);
+
+		await GetDatabase().setConfig('betaRegistrations', this._betaRegistrations);
+	}
+};

--- a/pandora-server-directory/src/services/discord/commands/_common.ts
+++ b/pandora-server-directory/src/services/discord/commands/_common.ts
@@ -1,7 +1,7 @@
-import { SlashCommandBuilder, CommandInteraction, GuildMember } from 'discord.js';
+import { SlashCommandBuilder, CommandInteraction, GuildMember, type ButtonInteraction } from 'discord.js';
 import type { Promisable } from 'type-fest';
 
-export function GetInteractionMember(interaction: CommandInteraction): GuildMember | null {
+export function GetInteractionMember(interaction: CommandInteraction | ButtonInteraction): GuildMember | null {
 	if (interaction.member instanceof GuildMember) {
 		return interaction.member;
 	}
@@ -9,6 +9,11 @@ export function GetInteractionMember(interaction: CommandInteraction): GuildMemb
 }
 
 export type DiscordCommandDescriptor = {
-	config: SlashCommandBuilder;
+	config: Pick<SlashCommandBuilder, 'toJSON' | 'name'>;
 	execute: (interaction: CommandInteraction) => Promisable<void>;
+};
+
+export type DiscordButtonDescriptor = {
+	id: string;
+	execute: (interaction: ButtonInteraction) => Promisable<void>;
 };

--- a/pandora-server-directory/src/services/discord/commands/_common.ts
+++ b/pandora-server-directory/src/services/discord/commands/_common.ts
@@ -1,0 +1,14 @@
+import { SlashCommandBuilder, CommandInteraction, GuildMember } from 'discord.js';
+import type { Promisable } from 'type-fest';
+
+export function GetInteractionMember(interaction: CommandInteraction): GuildMember | null {
+	if (interaction.member instanceof GuildMember) {
+		return interaction.member;
+	}
+	return null;
+}
+
+export type DiscordCommandDescriptor = {
+	config: SlashCommandBuilder;
+	execute: (interaction: CommandInteraction) => Promisable<void>;
+};

--- a/pandora-server-directory/src/services/discord/commands/ping.ts
+++ b/pandora-server-directory/src/services/discord/commands/ping.ts
@@ -1,15 +1,16 @@
-import { SlashCommandBuilder } from 'discord.js';
-import { GetInteractionMember, type DiscordCommandDescriptor } from './_common';
+import { SlashCommandBuilder, userMention } from 'discord.js';
+import { type DiscordCommandDescriptor } from './_common';
 
 export const DISCORD_COMMAND_PING: DiscordCommandDescriptor = {
 	config: new SlashCommandBuilder()
 		.setName('wave')
 		.setDescription('Wave to the Pandora\'s bot!'),
 	async execute(interaction) {
-		const nickname = GetInteractionMember(interaction)?.nickname ?? interaction.user.displayName;
-
 		await interaction.reply({
-			content: `\\**Waves back at ${nickname}*\\* :wave:`,
+			content: `\\**Waves back at ${userMention(interaction.user.id)}*\\* :wave:`,
+			allowedMentions: {
+				users: [interaction.user.id],
+			},
 		});
 	},
 };

--- a/pandora-server-directory/src/services/discord/commands/ping.ts
+++ b/pandora-server-directory/src/services/discord/commands/ping.ts
@@ -1,0 +1,15 @@
+import { SlashCommandBuilder } from 'discord.js';
+import { GetInteractionMember, type DiscordCommandDescriptor } from './_common';
+
+export const DISCORD_COMMAND_PING: DiscordCommandDescriptor = {
+	config: new SlashCommandBuilder()
+		.setName('wave')
+		.setDescription('Wave to the Pandora\'s bot!'),
+	async execute(interaction) {
+		const nickname = GetInteractionMember(interaction)?.nickname ?? interaction.user.displayName;
+
+		await interaction.reply({
+			content: `\\**Waves back at ${nickname}*\\* :wave:`,
+		});
+	},
+};

--- a/pandora-server-directory/src/services/discord/commands/registration.ts
+++ b/pandora-server-directory/src/services/discord/commands/registration.ts
@@ -1,6 +1,14 @@
-import { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, PermissionFlagsBits, SlashCommandBuilder, SlashCommandSubcommandBuilder, type MessageActionRowComponentBuilder, userMention } from 'discord.js';
-import { Assert } from 'pandora-common';
-import { GetInteractionMember, type DiscordCommandDescriptor, type DiscordButtonDescriptor } from './_common';
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, PermissionFlagsBits, SlashCommandBuilder, SlashCommandSubcommandBuilder, type MessageActionRowComponentBuilder } from 'discord.js';
+import { Assert, AssertNever } from 'pandora-common';
+import { ENV } from '../../../config';
+import { BetaRegistrationService } from '../../betaRegistration/betaRegistration';
+import { GetInteractionMember, type DiscordButtonDescriptor, type DiscordCommandDescriptor } from './_common';
+
+const {
+	BETA_KEY_ENABLED,
+	DISCORD_BETA_REGISTRATION_PENDING_ROLE_ID,
+	DISCORD_BETA_ACCESS_ROLE_ID,
+} = ENV;
 
 export const DISCORD_COMMAND_ADMIN: DiscordCommandDescriptor = {
 	config: new SlashCommandBuilder()
@@ -62,11 +70,60 @@ export const DISCORD_COMMAND_ADMIN: DiscordCommandDescriptor = {
 export const DISCORD_BUTTON_REGISTER: DiscordButtonDescriptor = {
 	id: 'button-register',
 	async execute(interaction) {
-		await interaction.reply({
-			content: `Everyone look! ${userMention(interaction.user.id)} managed to press a button!!`,
-			allowedMentions: {
-				users: [interaction.user.id],
-			},
-		});
+		if (!BETA_KEY_ENABLED || !DISCORD_BETA_REGISTRATION_PENDING_ROLE_ID || !DISCORD_BETA_ACCESS_ROLE_ID) {
+			await interaction.reply({
+				ephemeral: true,
+				content: `Error: Beta registrations are not enabled.`,
+			});
+			return;
+		}
+
+		const member = GetInteractionMember(interaction);
+
+		if (!member) {
+			await interaction.reply({
+				ephemeral: true,
+				content: `Error: This action can only be done from inside Project Pandora's server.`,
+			});
+			return;
+		}
+
+		const hasBetaAccessRole = member.roles.cache.has(DISCORD_BETA_ACCESS_ROLE_ID);
+		if (hasBetaAccessRole) {
+			await interaction.reply({
+				ephemeral: true,
+				content: `You already have access to Project Pandora's beta. Check direct messages from me to find your beta key.\n` +
+					`If you have problems getting into the beta or if you lost your key, please contact any \`@Host\`.`,
+			});
+			return;
+		}
+
+		const registerResult = await BetaRegistrationService.registerUser(interaction.user.id);
+
+		if (registerResult === 'betaAccess') {
+			await member.roles.remove(DISCORD_BETA_REGISTRATION_PENDING_ROLE_ID, 'Automatic beta handout');
+			await member.roles.add(DISCORD_BETA_ACCESS_ROLE_ID, 'Automatic beta handout');
+			await interaction.reply({
+				ephemeral: true,
+				content: `You already have access to Project Pandora's beta. Check direct messages from me to find your beta key.\n` +
+					`If you have problems getting into the beta or if you lost your key, please contact any \`@Host\`.`,
+			});
+		} else if (registerResult === 'added') {
+			await member.roles.add(DISCORD_BETA_REGISTRATION_PENDING_ROLE_ID, 'Automatic beta registration');
+			await interaction.reply({
+				ephemeral: true,
+				content: `You have been successfully registered for Project Pandora's beta. You will receive ` +
+					`a direct message with a beta key when you are selected.`,
+			});
+		} else if (registerResult === 'pending') {
+			await member.roles.add(DISCORD_BETA_REGISTRATION_PENDING_ROLE_ID, 'Automatic beta registration');
+			await interaction.reply({
+				ephemeral: true,
+				content: `You are already registered for Project Pandora's beta. You will receive ` +
+					`a direct message with a beta key when you are selected.`,
+			});
+		} else {
+			AssertNever(registerResult);
+		}
 	},
 };

--- a/pandora-server-directory/src/services/discord/commands/registration.ts
+++ b/pandora-server-directory/src/services/discord/commands/registration.ts
@@ -38,7 +38,7 @@ export const DISCORD_COMMAND_ADMIN: DiscordCommandDescriptor = {
 
 			const registerButton = new ButtonBuilder()
 				.setCustomId('button-register')
-				.setLabel('Press me!')
+				.setLabel('Register for the beta test')
 				.setStyle(ButtonStyle.Primary);
 
 			const row = new ActionRowBuilder<MessageActionRowComponentBuilder>()
@@ -48,7 +48,7 @@ export const DISCORD_COMMAND_ADMIN: DiscordCommandDescriptor = {
 				embeds: [
 					new EmbedBuilder()
 						.setColor('Aqua')
-						.setDescription(`I'm a bot message with a button! (at least I hope there is one...)`)
+						.setDescription(`To register for the upcoming closed beta test of Project Pandora press the following button. We will send out beta keys in waves while the beta test is ongoing.`)
 						.toJSON(),
 				],
 				components: [row.toJSON()],

--- a/pandora-server-directory/src/services/discord/commands/registration.ts
+++ b/pandora-server-directory/src/services/discord/commands/registration.ts
@@ -1,0 +1,72 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, PermissionFlagsBits, SlashCommandBuilder, SlashCommandSubcommandBuilder, type MessageActionRowComponentBuilder, userMention } from 'discord.js';
+import { Assert } from 'pandora-common';
+import { GetInteractionMember, type DiscordCommandDescriptor, type DiscordButtonDescriptor } from './_common';
+
+export const DISCORD_COMMAND_ADMIN: DiscordCommandDescriptor = {
+	config: new SlashCommandBuilder()
+		.setName('admin')
+		.setDescription('Administrative tasks for Pandora')
+		.setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
+		.addSubcommand(
+			new SlashCommandSubcommandBuilder()
+				.setName('add-registration-form')
+				.setDescription('Send a registration form message'),
+		),
+	async execute(interaction) {
+		const member = GetInteractionMember(interaction);
+
+		if (!member || !member.permissions.has(PermissionFlagsBits.Administrator)) {
+			await interaction.reply({
+				ephemeral: true,
+				content: `Error: Only administrators can use this inside the server. Sorry.`,
+			});
+			return;
+		}
+
+		const subcommand = interaction.isChatInputCommand() ? interaction.options.getSubcommand() : null;
+
+		if (subcommand === 'add-registration-form') {
+			Assert(interaction.channel != null);
+
+			const registerButton = new ButtonBuilder()
+				.setCustomId('button-register')
+				.setLabel('Press me!')
+				.setStyle(ButtonStyle.Primary);
+
+			const row = new ActionRowBuilder<MessageActionRowComponentBuilder>()
+				.addComponents(registerButton);
+
+			await interaction.channel.send({
+				embeds: [
+					new EmbedBuilder()
+						.setColor('Aqua')
+						.setDescription(`I'm a bot message with a button! (at least I hope there is one...)`)
+						.toJSON(),
+				],
+				components: [row.toJSON()],
+			});
+
+			await interaction.reply({
+				ephemeral: true,
+				content: `Done! :white_check_mark:`,
+			});
+		} else {
+			await interaction.reply({
+				ephemeral: true,
+				content: `Error: Unknown subcommand.`,
+			});
+		}
+	},
+};
+
+export const DISCORD_BUTTON_REGISTER: DiscordButtonDescriptor = {
+	id: 'button-register',
+	async execute(interaction) {
+		await interaction.reply({
+			content: `Everyone look! ${userMention(interaction.user.id)} managed to press a button!!`,
+			allowedMentions: {
+				users: [interaction.user.id],
+			},
+		});
+	},
+};


### PR DESCRIPTION
This adds mechanism for Discord commands, and flow to create a beta registration prompt, let users register for beta, and finally automatic sending of beta invites where each user gets their own single-use beta key via DM. Also handles role assignment for each of these actions.

For now I lazily store all beta registrations in single config document (beta keys are done this way too after all). If we get over about 131 thousand registrations it will need a rework, but oh well.