### PR TITLE
[ADD] Metrics for beta registrations

### DIFF
--- a/pandora-server-directory/src/services/betaRegistration/betaRegistration.ts
+++ b/pandora-server-directory/src/services/betaRegistration/betaRegistration.ts
@@ -28,6 +28,8 @@ export const BetaRegistrationService = new class BetaRegistrationService impleme
 		Assert(this._betaRegistrations == null);
 
 		this._betaRegistrations = await GetDatabase().getConfig('betaRegistrations') ?? [];
+		betaRegistrationPending.set(this._getPendingRegistrations().length);
+		betaRegistrationTotal.set(this._betaRegistrations.length);
 		this.logger.info(`${this._betaRegistrations.length} registrations loaded, ${this._getPendingRegistrations().length} pending.`);
 	}
 


### PR DESCRIPTION
Adds three Prometheus metrics:
- Two gauges for beta registrations (total and pending)
- One counter for processed Discord bot commands