### PR TITLE
[FIX] Start database process detached to prevent killing it too early

### DIFF
--- a/pandora-server-directory/src/database/mongoDb.ts
+++ b/pandora-server-directory/src/database/mongoDb.ts
@@ -276,6 +276,8 @@ export default class MongoDatabase implements PandoraDatabase {
 		if (this._inMemoryServer) {
 			await this._inMemoryServer.stop();
 		}
+
+		logger.info(`Database closed`);
 	}
 
 	public get nextAccountId(): number {
@@ -749,6 +751,9 @@ async function CreateInMemoryMongo({
 			dbPath,
 			storageEngine: dbPath ? 'wiredTiger' : 'ephemeralForTest',
 			args: ['--setParameter', 'diagnosticDataCollectionEnabled=false'],
+		},
+		spawn: {
+			detached: true,
 		},
 	});
 }

--- a/pandora-server-directory/src/lifecycle.ts
+++ b/pandora-server-directory/src/lifecycle.ts
@@ -21,7 +21,7 @@ const logger = GetLogger('Lifecycle');
 
 let destroying: string | undefined;
 let stopping: Promise<void> | undefined;
-const STOP_TIMEOUT = 10_000;
+const STOP_TIMEOUT = 15_000;
 
 function DestroyService(service: Service): Promise<void> | void {
 	destroying = service.constructor.name;


### PR DESCRIPTION
The way terminal works is, that if user does Ctrl+C in the terminal, the signal is sent to the whole _process group_.
This means that Mongo was receiving the signal too, and shutting down before Pandora itself had chance to.
By detaching it this doesn't happen.

Also note, that the `mongodb-memory-server` has a killer script that periodically checks if parent process is still running, so the database will get killed even if the main process dies on the spot, even if detached.