### PR TITLE
[ADD] Beta registration pruning

### DIFF
--- a/pandora-common/src/utility.ts
+++ b/pandora-common/src/utility.ts
@@ -278,8 +278,9 @@ const AsyncSynchronizedObjectLocks = new WeakMap<object, AsyncLock>();
  *
  * Only one call per instance runs at a time, other calls waiting in queue for the first call to finish (either resolve or reject)
  * @param options - Options passed directly to the `async-lock` library, or if `object` that the method synchronizes with all 'object' synchronized methods within instance
+ * @param lockOptions - Options applied when this function acquires the lock (useful mainly in combination with the `object` target)
  */
-export function AsyncSynchronized(options?: AsyncLockOptions | 'object') {
+export function AsyncSynchronized(options?: AsyncLockOptions | 'object', lockOptions?: AsyncLockOptions) {
 	if (options === 'object') {
 		return function <Args extends unknown[], Return, This extends object>(method: (...args: Args) => Promise<Return>, _context: ClassMethodDecoratorContext<This>) {
 			return function (this: This, ...args: Args) {
@@ -291,7 +292,7 @@ export function AsyncSynchronized(options?: AsyncLockOptions | 'object') {
 					AsyncSynchronizedObjectLocks.set(this, lock);
 				}
 
-				return lock.acquire<Return>('', () => method.apply(this, args));
+				return lock.acquire<Return>('', () => method.apply(this, args), lockOptions);
 			};
 		};
 	}
@@ -308,7 +309,7 @@ export function AsyncSynchronized(options?: AsyncLockOptions | 'object') {
 				locks.set(this, lock);
 			}
 
-			return lock.acquire<Return>('', () => method.apply(this, args));
+			return lock.acquire<Return>('', () => method.apply(this, args), lockOptions);
 		};
 	};
 }

--- a/pandora-server-directory/src/database/databaseStructure.ts
+++ b/pandora-server-directory/src/database/databaseStructure.ts
@@ -140,9 +140,14 @@ export const DatabaseAccountWithSecureSchema = DatabaseAccountSchema.extend({
 export type DatabaseAccountWithSecure = z.infer<typeof DatabaseAccountWithSecureSchema>;
 
 export const DatabaseBetaRegistrationSchema = z.object({
+	/** The Discord ID of the person that signed up for beta access */
 	discordId: z.string(),
+	/** Timestamp of the initial registration */
 	registeredAt: z.number(),
+	/** Assigned beta key (if any) */
 	assignedKey: z.string().nullable(),
+	/** If the invitation succeeded. If set this person is no longer just a candidate. */
+	invited: z.literal(true).optional(),
 });
 export type DatabaseBetaRegistration = z.infer<typeof DatabaseBetaRegistrationSchema>;
 

--- a/pandora-server-directory/src/services/betaRegistration/betaRegistration.ts
+++ b/pandora-server-directory/src/services/betaRegistration/betaRegistration.ts
@@ -127,7 +127,7 @@ export const BetaRegistrationService = new class BetaRegistrationService impleme
 	 * @param check - The check function. Should return `true` if the candidate is still valid
 	 * @param dryRun - If set the pruning doesn't actually happen
 	 */
-	@AsyncSynchronized('object')
+	@AsyncSynchronized('object', { maxExecutionTime: 60 * 60_000 })
 	public async pruneCandidates(check: (candidate: Readonly<DatabaseBetaRegistration>) => Promise<boolean>, dryRun: boolean = false): Promise<void> {
 		Assert(this._betaRegistrations != null);
 

--- a/pandora-server-directory/src/services/discord/commands/registration.ts
+++ b/pandora-server-directory/src/services/discord/commands/registration.ts
@@ -1,4 +1,19 @@
-import { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, PermissionFlagsBits, SlashCommandBuilder, SlashCommandSubcommandBuilder, type MessageActionRowComponentBuilder, SlashCommandIntegerOption, ApplicationCommandOptionType, userMention } from 'discord.js';
+import {
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	EmbedBuilder,
+	PermissionFlagsBits,
+	SlashCommandBuilder,
+	SlashCommandSubcommandBuilder,
+	type MessageActionRowComponentBuilder,
+	SlashCommandIntegerOption,
+	SlashCommandBooleanOption,
+	ApplicationCommandOptionType,
+	userMention,
+	DiscordAPIError,
+	type GuildMember,
+} from 'discord.js';
 import { Assert, AssertNever, GetLogger, TimeSpanMs } from 'pandora-common';
 import { ENV } from '../../../config';
 import { BetaRegistrationService } from '../../betaRegistration/betaRegistration';
@@ -24,6 +39,16 @@ export const DISCORD_COMMAND_ADMIN: DiscordCommandDescriptor = {
 			new SlashCommandSubcommandBuilder()
 				.setName('add-registration-form')
 				.setDescription('Send a registration form message'),
+		)
+		.addSubcommand(
+			new SlashCommandSubcommandBuilder()
+				.setName('registration-prune')
+				.setDescription('Prune the registered people, removing anyone without role or no longer in the server')
+				.addBooleanOption(
+					new SlashCommandBooleanOption()
+						.setName('dry-run')
+						.setDescription('Perform a dry run'),
+				),
 		)
 		.addSubcommand(
 			new SlashCommandSubcommandBuilder()
@@ -75,6 +100,62 @@ export const DISCORD_COMMAND_ADMIN: DiscordCommandDescriptor = {
 			await interaction.reply({
 				ephemeral: true,
 				content: `Done! :white_check_mark:`,
+			});
+		} else if (subcommand === 'registration-prune') {
+			const dryRunOption = interaction.options.get('dry-run');
+			Assert(dryRunOption == null || typeof dryRunOption.value === 'boolean');
+			const dryRun = dryRunOption?.value === true;
+
+			logger.verbose(`Running registration prune${dryRun ? ' (dry run)' : ''}`);
+			await interaction.reply({
+				content: `:hourglass_flowing_sand: Running registration prune${dryRun ? ' (dry run)' : ''}`,
+			});
+
+			await BetaRegistrationService.pruneCandidates(async (candidate) => {
+				Assert(interaction.guild != null);
+
+				// Sleep not to run into any throttling (hopefully)
+				await Sleep(120);
+
+				let candidateMember: GuildMember;
+				// Check membership
+				try {
+					candidateMember = await interaction.guild.members.fetch({ user: candidate.discordId, force: true });
+				} catch (err) {
+					if (err instanceof DiscordAPIError) {
+						if (err.code === 10_007) {
+							logger.verbose(`Candidate ${candidate.discordId} not found in the guild, removing.`);
+							return false;
+						} else {
+							logger.warning(`Failed to get candidate member status for ${candidate.discordId}, unknown Discord error:`, err.code, err.message);
+						}
+					} else {
+						logger.warning(`Failed to get candidate member status for ${candidate.discordId}, unknown error:`, err);
+					}
+					return true;
+				}
+
+				// Check beta role
+				const betaAccessRole = candidateMember.roles.resolve(DISCORD_BETA_ACCESS_ROLE_ID);
+				if (betaAccessRole != null) {
+					// This shouldn't happen: People that already have access shouldn't be candidates
+					logger.warning(`Candidate ${candidate.discordId} already has beta access role; skip.`);
+					return true;
+				}
+
+				// Check candidate role
+				const betaCandidateRole = candidateMember.roles.resolve(DISCORD_BETA_REGISTRATION_PENDING_ROLE_ID);
+				if (betaCandidateRole == null) {
+					logger.debug(`Candidate ${candidate.discordId} doesn't have candidate role, removing.`);
+					return false;
+				}
+
+				// A valid candidate
+				return true;
+			}, dryRun);
+
+			await interaction.followUp({
+				content: `:white_check_mark: Prune completed, check server log for details.`,
 			});
 		} else if (subcommand === 'mass-invite') {
 			const count = interaction.options.get('count', true);


### PR DESCRIPTION
Adds an admin command to prune users registered for beta (based on guild membership and missing roles).
Also makes the code generally more robust by differentiating user with generated beta key and user for which Discord confirmed that they actually received the key - allowing us to easily resend the keys if there is a problem with mass-sending.
Also increased the delay to take 1.5 seconds per invited user, so we hopefully don't run into Discord's DM rate limiting.