### PR TITLE
[CHANGE] Several database migrations

### DIFF
--- a/pandora-client-web/src/ui/screens/spaceJoin/spaceJoin.tsx
+++ b/pandora-client-web/src/ui/screens/spaceJoin/spaceJoin.tsx
@@ -8,7 +8,7 @@ import './spaceJoin.scss';
 export function SpaceJoin(): ReactElement {
 	const { pathname, search } = useLocation();
 	const { spaceId, invite } = React.useMemo(() => {
-		const spaceResult = SpaceIdSchema.safeParse(`r/${pathname.split('/').pop()}`);
+		const spaceResult = SpaceIdSchema.safeParse(`s/${pathname.split('/').pop()}`);
 		const inviteResult = SpaceInviteIdSchema.safeParse(new URLSearchParams(search).get('invite'));
 
 		return {
@@ -50,7 +50,7 @@ function QuerySpaceInfo({ spaceId, invite }: { spaceId: SpaceId; invite?: SpaceI
 export function SpaceInviteEmbed({ spaceId, invite }: { spaceId: string; invite?: string; }): ReactElement {
 	const inviteResult = SpaceInviteIdSchema.safeParse(invite);
 	const [open, setOpen] = React.useState(false);
-	const info = useSpaceExtendedInfo(`r/${spaceId}`, inviteResult.success ? inviteResult.data : undefined);
+	const info = useSpaceExtendedInfo(`s/${spaceId}`, inviteResult.success ? inviteResult.data : undefined);
 
 	if (info?.result !== 'success') {
 		return (

--- a/pandora-common/src/space/space.ts
+++ b/pandora-common/src/space/space.ts
@@ -14,8 +14,7 @@ import type { } from '../assets/item/base';
 export const ShardFeatureSchema = z.enum(['development']);
 export type ShardFeature = z.infer<typeof ShardFeatureSchema>;
 
-// TODO(spaces): Consider updating this pattern to reflect that it is now called a "space"
-export const SpaceIdSchema = ZodTemplateString<`r/${string}`>(z.string(), /^r\//);
+export const SpaceIdSchema = ZodTemplateString<`s/${string}`>(z.string(), /^s\//);
 export type SpaceId = z.infer<typeof SpaceIdSchema>;
 
 export const SpaceFeatureSchema = z.enum([

--- a/pandora-server-directory/src/database/databaseStructure.ts
+++ b/pandora-server-directory/src/database/databaseStructure.ts
@@ -151,7 +151,17 @@ export const DatabaseBetaRegistrationSchema = z.object({
 });
 export type DatabaseBetaRegistration = z.infer<typeof DatabaseBetaRegistrationSchema>;
 
+export const DatabaseConfigCreationCountersSchema = z.object({
+	nextAccountId: z.number(),
+	nextCharacterId: z.number(),
+});
+export type DatabaseConfigCreationCounters = z.infer<typeof DatabaseConfigCreationCountersSchema>;
+
 export const DatabaseConfigSchema = z.discriminatedUnion('type', [
+	z.object({
+		type: z.literal('creationCounters'),
+		data: DatabaseConfigCreationCountersSchema,
+	}),
 	z.object({
 		type: z.literal('shardTokens'),
 		data: ZodCast<(IShardTokenInfo & { token: string; })[]>(),

--- a/pandora-server-directory/src/database/dbHelper.ts
+++ b/pandora-server-directory/src/database/dbHelper.ts
@@ -47,7 +47,7 @@ export interface SpaceCreationData {
 
 export function CreateSpace(data: SpaceCreationData, id?: SpaceId): SpaceData {
 	return {
-		id: id ?? `r/${nanoid()}`,
+		id: id ?? `s/${nanoid()}`,
 		accessId: '',
 		inventory: ROOM_INVENTORY_BUNDLE_DEFAULT,
 		invites: [],

--- a/pandora-server-directory/src/database/dbHelper.ts
+++ b/pandora-server-directory/src/database/dbHelper.ts
@@ -6,7 +6,6 @@ import {
 	CHARACTER_DEFAULT_PUBLIC_SETTINGS,
 	CharacterId,
 	ICharacterData,
-	IsNumber,
 	ROOM_INVENTORY_BUNDLE_DEFAULT,
 	SpaceData,
 	SpaceDirectoryConfig,
@@ -14,18 +13,16 @@ import {
 } from 'pandora-common';
 import type { DatabaseCharacterSelfInfo } from './databaseStructure';
 
-export function CreateCharacter<Id extends number | CharacterId>(accountId: number, id: Id): [DatabaseCharacterSelfInfo, Omit<ICharacterData, 'id'> & { id: Id; }] {
-	const infoId: CharacterId = IsNumber(id) ? `c${id}` as const : id;
-
+export function CreateCharacter(accountId: number, id: CharacterId): [DatabaseCharacterSelfInfo, ICharacterData] {
 	const info: DatabaseCharacterSelfInfo = {
 		inCreation: true,
-		id: infoId,
+		id,
 		name: '',
 		preview: '',
 		currentSpace: null,
 	};
 
-	const char: Omit<ICharacterData, 'id'> & { id: Id; } = {
+	const char: ICharacterData = {
 		inCreation: true,
 		id,
 		accountId,

--- a/pandora-server-directory/src/database/mongoDb.ts
+++ b/pandora-server-directory/src/database/mongoDb.ts
@@ -378,15 +378,8 @@ export default class MongoDatabase implements PandoraDatabase {
 	public async getCharactersForAccount(accountId: number): Promise<DatabaseCharacterSelfInfo[]> {
 		const result: DatabaseCharacterSelfInfo[] = await this._characters
 			.find({ accountId })
-			.project<Pick<ICharacterData, 'id' | 'name' | 'preview' | 'currentSpace' | 'inCreation'>>({ id: 1, name: 1, preview: 1, currentSpace: 1, inCreation: 1 })
-			.toArray()
-			.then((p) => p.map((c): DatabaseCharacterSelfInfo => ({
-				id: c.id,
-				name: c.name,
-				preview: c.preview,
-				currentSpace: c.currentSpace,
-				inCreation: c.inCreation,
-			})));
+			.project<Pick<ICharacterData, 'id' | 'name' | 'preview' | 'currentSpace' | 'inCreation'>>({ _id: 0, id: 1, name: 1, preview: 1, currentSpace: 1, inCreation: 1 })
+			.toArray();
 
 		return result;
 	}

--- a/pandora-server-directory/src/database/mongoDb.ts
+++ b/pandora-server-directory/src/database/mongoDb.ts
@@ -671,7 +671,7 @@ export default class MongoDatabase implements PandoraDatabase {
 		let requireFullMigration = false;
 		// Add manual migrations here
 
-		//#region Migrate character self info from accounts to characters
+		//#region Migrate character self info from accounts to characters (03/2024)
 		const charactersToMigrate = new Map<CharacterId, { account: AccountId; character: DatabaseCharacterSelfInfo; }>();
 
 		// Gather data about characters
@@ -747,7 +747,7 @@ export default class MongoDatabase implements PandoraDatabase {
 
 		//#endregion
 
-		//#region Generate explicit registration/character creation counters
+		//#region Generate explicit registration/character creation counters (04/2024)
 
 		await configCollection.doManualMigration(this._client, this._db, {
 			oldSchema: DatabaseConfigSchema,

--- a/pandora-server-directory/src/database/validatedCollection.ts
+++ b/pandora-server-directory/src/database/validatedCollection.ts
@@ -1,9 +1,8 @@
-import type { ZodType, ZodTypeDef } from 'zod';
-import type { ConditionalKeys } from 'type-fest';
 import { diffString } from 'json-diff';
 import { isEqual, omit } from 'lodash';
-import { Collection, Db, Document, IndexDescription, ObjectId, WithId, CollationOptions, MongoClient } from 'mongodb';
+import { CollationOptions, Collection, Db, Document, IndexDescription, MongoClient, ObjectId } from 'mongodb';
 import { ArrayToRecordKeys, Assert, IsObject, KnownObject, Logger } from 'pandora-common';
+import type { ZodType, ZodTypeDef } from 'zod';
 
 export interface DbAutomaticMigration {
 	readonly dryRun: boolean;
@@ -77,12 +76,6 @@ export class ValidatedCollection<T extends Document> {
 		};
 
 		await migration.migrate(process);
-	}
-
-	public async max<TKey extends ConditionalKeys<WithId<T>, number> & string>(key: TKey, fallback: WithId<T>[TKey]): Promise<WithId<T>[TKey]> {
-		const max = await this.collection.find().sort({ [key]: -1 }).limit(1).toArray();
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-		return max.length > 0 ? max[0][key] : fallback;
 	}
 
 	public async create(db: Db, migration?: DbAutomaticMigration): Promise<Collection<T>> {

--- a/pandora-server-directory/test/database/db.ts
+++ b/pandora-server-directory/test/database/db.ts
@@ -484,18 +484,18 @@ export default function RunDbTests(initDb: () => Promise<PandoraDatabase>, close
 			const result1 = await db.createSpace({
 				config: TEST_SPACE,
 				owners: TEST_SPACE_PANDORA_OWNED.slice(),
-			}, 'r/id1');
+			}, 's/id1');
 
 			// Correct result
 			expect(result1.config).toEqual(TEST_SPACE);
 			expect(result1.owners).toEqual(TEST_SPACE_PANDORA_OWNED);
-			expect(result1.id).toEqual('r/id1');
+			expect(result1.id).toEqual('s/id1');
 
 			// Fails to make space with same id
 			await expect(db.createSpace({
 				config: TEST_SPACE2,
 				owners: [0],
-			}, 'r/id1')).rejects.toEqual(expect.anything());
+			}, 's/id1')).rejects.toEqual(expect.anything());
 		});
 	});
 
@@ -581,7 +581,7 @@ export default function RunDbTests(initDb: () => Promise<PandoraDatabase>, close
 			expect(result).not.toBeNull();
 
 			// Wrong id fails
-			await expect(db.setSpaceAccessId('r/invalid')).resolves.toBeNull();
+			await expect(db.setSpaceAccessId('s/invalid')).resolves.toBeNull();
 
 			// Old space not affected
 			await expect(db.getSpaceById(space.id, result)).resolves.not.toBeNull();

--- a/pandora-server-directory/test/spaces/spaceManager.test.ts
+++ b/pandora-server-directory/test/spaces/spaceManager.test.ts
@@ -84,7 +84,7 @@ describe('SpaceManager', () => {
 		});
 
 		it('Returns undefined with unknown space', () => {
-			const space = SpaceManager.getLoadedSpace('r/NonexistentSpace');
+			const space = SpaceManager.getLoadedSpace('s/NonexistentSpace');
 			expect(space).toBe(null);
 		});
 	});

--- a/pandora-server-shard/src/database/mongoDb.ts
+++ b/pandora-server-shard/src/database/mongoDb.ts
@@ -17,8 +17,7 @@ import type { Db, Collection } from 'mongodb';
 const logger = GetLogger('db');
 
 const CHARACTERS_COLLECTION_NAME = 'characters';
-// TODO(spaces): Consider migrating this
-const SPACES_COLLECTION_NAME = 'chatrooms';
+const SPACES_COLLECTION_NAME = 'spaces';
 
 export default class MongoDatabase implements ShardDatabase {
 	private readonly _client: MongoClient;

--- a/pandora-server-shard/src/database/mongoDb.ts
+++ b/pandora-server-shard/src/database/mongoDb.ts
@@ -23,7 +23,7 @@ const SPACES_COLLECTION_NAME = 'chatrooms';
 export default class MongoDatabase implements ShardDatabase {
 	private readonly _client: MongoClient;
 	private _db!: Db;
-	private _characters!: Collection<Omit<ICharacterData, 'id'> & { id: number; }>;
+	private _characters!: Collection<ICharacterData>;
 	private _spaces!: Collection<SpaceData>;
 
 	constructor() {
@@ -54,15 +54,15 @@ export default class MongoDatabase implements ShardDatabase {
 	}
 
 	public async getCharacter(id: CharacterId, accessId: string): Promise<ICharacterData | null | false> {
-		const character = await this._characters.findOne({ id: PlainId(id), accessId });
+		const character = await this._characters.findOne({ id, accessId });
 		if (!character)
 			return null;
 
-		return Id(character);
+		return character;
 	}
 
 	public async setCharacter(id: CharacterId, data: ICharacterDataShardUpdate, accessId: string): Promise<boolean> {
-		const { matchedCount } = await this._characters.updateOne({ id: PlainId(id), accessId }, { $set: data });
+		const { matchedCount } = await this._characters.updateOne({ id, accessId }, { $set: data });
 		return matchedCount === 1;
 	}
 
@@ -79,15 +79,4 @@ export default class MongoDatabase implements ShardDatabase {
 		const { matchedCount } = await this._spaces.updateOne({ id, accessId }, { $set: data });
 		return matchedCount === 1;
 	}
-}
-
-function Id(obj: Omit<ICharacterData, 'id'> & { id: number; }): ICharacterData {
-	return {
-		...obj,
-		id: `c${obj.id}` as const,
-	};
-}
-
-function PlainId(id: CharacterId): number {
-	return parseInt(id.slice(1));
 }


### PR DESCRIPTION
This PR adds several migrations to the database for old data (we really want to migrate before beta to be safe). All added migrations are idempotent.
- Store account/character id counters explicitly in a config document instead of generating them by scraping account and character collections
- Change the character collection to use string CharacterId instead of translating it to number and back
- Rename `chatrooms` collection to `spaces`
- Change space id format from r/abc to s/abc
- Minor cleanup of no longer needed utilities after these migrations