### PR TITLE
[CHANGE] renamed errFull to spaceFull and improved permission dialog

### DIFF
--- a/pandora-client-web/src/components/settings/permissionsSettings.tsx
+++ b/pandora-client-web/src/components/settings/permissionsSettings.tsx
@@ -528,8 +528,8 @@ function PermissionPromptDialog({ prompt: { source, requiredPermissions, message
 				}
 			</Column>
 			<Row padding='medium' alignX='space-between' alignY='center'>
-				<Button onClick={ dismiss }>Dismiss</Button>
-				<Button onClick={ acceptAll } disabled={ !allowAccept } className='fadeDisabled'>Allow all</Button>
+				<Button onClick={ dismiss }>Deny unchosen once</Button>
+				<Button onClick={ acceptAll } disabled={ !allowAccept } className='fadeDisabled'>Allow all above always</Button>
 			</Row>
 		</DraggableDialog>
 	);
@@ -621,7 +621,7 @@ function PermissionPromptButton({ setYes, setNo, isAllowed }: { setYes: () => vo
 					}
 				} }
 			>
-				Allow
+				Allow always
 			</Button>
 			<Button
 				className='slim'
@@ -632,7 +632,7 @@ function PermissionPromptButton({ setYes, setNo, isAllowed }: { setYes: () => vo
 					}
 				} }
 			>
-				Deny
+				Deny always
 			</Button>
 		</>
 	);

--- a/pandora-client-web/src/components/wiki/pages/new.tsx
+++ b/pandora-client-web/src/components/wiki/pages/new.tsx
@@ -97,6 +97,7 @@ export function WikiNew(): ReactElement {
 				<li>You can click on a character's name under the character on the room graphics to open a context menu and select "Whisper" there.</li>
 				<li>You can click on the "Whisper"-button next to a character name in the "Room"-tab.</li>
 				<li>You can use the chat command "/whisper target" (or "/w target") using either the character's name or the character's ID as the whisper target argument.</li>
+				<li>You can use the chat command "/whisper" (or "/w") without anything afterwards to cancel the state of whispering someone.</li>
 			</ul>
 
 			<p>

--- a/pandora-client-web/src/components/wiki/pages/spaces.tsx
+++ b/pandora-client-web/src/components/wiki/pages/spaces.tsx
@@ -291,6 +291,7 @@ export function WikiSpaces(): ReactElement {
 				<li>You can use the chat command "/w [target]" using either the character name or the character ID as whisper target argument.</li>
 				<li>Chat-related commands while in whisper mode (e.g., "/me") will be executed normally and not be whispered.</li>
 				<li>You can whisper an OOC message though, if you start a whispered message with "((".</li>
+				<li>You can use the chat command "/whisper" (or "/w") without anything afterwards to cancel the state of whispering someone.</li>
 				<li>If your whisper target leaves the room or space, your whisper message cannot be sent.</li>
 				<li>If your whisper target goes offline, your whisper message will still be sent, but currently it will not be delivered.</li>
 			</ul>

--- a/pandora-common/src/gameLogic/interactions/_interactionConfig.ts
+++ b/pandora-common/src/gameLogic/interactions/_interactionConfig.ts
@@ -7,7 +7,7 @@ import { KnownObject, ParseArrayNotEmpty } from '../../utility';
 
 export const INTERACTION_CONFIG = {
 	interact: {
-		visibleName: 'Interact with this character',
+		visibleName: 'Interact and to use other allowed permissions',
 		icon: 'on-off',
 		defaultPermissions: {
 			allowOthers: 'prompt',

--- a/pandora-common/src/networking/client_directory.ts
+++ b/pandora-common/src/networking/client_directory.ts
@@ -333,7 +333,7 @@ export const ClientDirectorySchema = {
 			id: SpaceIdSchema,
 			invite: SpaceInviteIdSchema.optional(),
 		}),
-		response: ZodCast<{ result: 'ok' | 'failed' | 'errFull' | 'notFound' | 'noAccess' | 'invalidInvite'; }>(),
+		response: ZodCast<{ result: 'ok' | 'failed' | 'spaceFull' | 'notFound' | 'noAccess' | 'invalidInvite'; }>(),
 	},
 	spaceLeave: {
 		request: z.object({}),

--- a/pandora-server-directory/src/account/character.ts
+++ b/pandora-server-directory/src/account/character.ts
@@ -701,7 +701,7 @@ export class Character {
 	}
 
 	@AsyncSynchronized('object')
-	public async joinSpace(space: Space, invite?: SpaceInviteId): Promise<'failed' | 'ok' | 'errFull' | 'noAccess' | 'invalidInvite'> {
+	public async joinSpace(space: Space, invite?: SpaceInviteId): Promise<'failed' | 'ok' | 'spaceFull' | 'noAccess' | 'invalidInvite'> {
 		// Only loaded characters can request join into a space
 		if (!this.isOnline())
 			return 'failed';

--- a/pandora-server-directory/src/networking/manager_client.ts
+++ b/pandora-server-directory/src/networking/manager_client.ts
@@ -455,7 +455,7 @@ export const ConnectionManagerClient = new class ConnectionManagerClient impleme
 
 		// Only developers can create rooms with development mode enabled
 		if (spaceConfig.features.includes('development') && !connection.account.roles.isAuthorized('developer')) {
-			logger.verbose(`${connection.id} attempted to create a development space witout being a developer`);
+			logger.verbose(`${connection.id} attempted to create a development space without being a developer`);
 			return {
 				result: 'failed',
 			};
@@ -477,7 +477,7 @@ export const ConnectionManagerClient = new class ConnectionManagerClient impleme
 
 		const result = await character.joinSpace(space);
 		Assert(result !== 'noAccess');
-		Assert(result !== 'errFull');
+		Assert(result !== 'spaceFull');
 		Assert(result !== 'invalidInvite');
 
 		return { result };

--- a/pandora-server-directory/src/spaces/space.ts
+++ b/pandora-server-directory/src/spaces/space.ts
@@ -372,10 +372,10 @@ export class Space {
 		// Ignore those - the requests will fail and once the space is not requestest for a bit, it will be unloaded from the directory too, actually vanishing
 	}
 
-	public checkAllowEnter(character: Character, inviteId?: SpaceInviteId, ignore: { characterLimit?: boolean; } = {}): 'ok' | 'errFull' | 'noAccess' | 'invalidInvite' {
+	public checkAllowEnter(character: Character, inviteId?: SpaceInviteId, ignore: { characterLimit?: boolean; } = {}): 'ok' | 'spaceFull' | 'noAccess' | 'invalidInvite' {
 		// No-one can enter if the space is in an invalid state
 		if (!this.isValid) {
-			return 'errFull';
+			return 'spaceFull';
 		}
 
 		// If you are already in this space, then you have rights to enter it
@@ -389,7 +389,7 @@ export class Space {
 				maxUsers += LIMIT_SPACE_MAX_CHARACTER_EXTRA_OWNERS;
 			}
 			if (this.characterCount >= maxUsers)
-				return 'errFull';
+				return 'spaceFull';
 		}
 
 		// If you are an owner or admin, you can enter the space (owner implies admin)


### PR DESCRIPTION
Renamed a string value, because as a user, it is very confusing when you try to join a space and get an error toast about `errFull`.

These messages were clearly not made end user friendly, but I at least wanted to make it a little bit better by calling it `spaceFull` instead of `errFull`.


Also improves the permission dialog clarity, as it was reported to be an issue and I can see why.