### PR TITLE
[FIX] directory action message target property

### DIFF
--- a/pandora-server-shard/src/spaces/space.ts
+++ b/pandora-server-shard/src/spaces/space.ts
@@ -32,6 +32,7 @@ import {
 	CloneDeepMutable,
 	IsValidRoomPosition,
 	GenerateInitialRoomPosition,
+	type IChatMessageAction,
 } from 'pandora-common';
 import type { Character } from '../character/character';
 import _, { isEqual, omit } from 'lodash';
@@ -488,8 +489,8 @@ export abstract class Space extends ServerRoom<IShardClient> {
 				time: this.nextMessageTime(),
 				data: m.data ? {
 					character: this._getCharacterActionInfo(m.data.character),
-					targetCharacter: this._getCharacterActionInfo(m.data.targetCharacter),
-				} : undefined,
+					target: this._getCharacterActionInfo(m.data.targetCharacter),
+				} satisfies IChatMessageAction['data'] : undefined,
 			})));
 		this.lastDirectoryMessageTime = _(messages)
 			.map((m) => m.directoryTime)


### PR DESCRIPTION
fixes #654

add `satisfies` to prevent further errors


test:
![image](https://github.com/Project-Pandora-Game/pandora/assets/17586581/c03d3d9f-a128-4dd0-87aa-a85440f9891b)
