### PR TITLE
[FIX] color input mouse up should be handled even outside

### DIFF
--- a/pandora-client-web/src/components/common/colorInput/colorInput.tsx
+++ b/pandora-client-web/src/components/common/colorInput/colorInput.tsx
@@ -185,11 +185,13 @@ function ColorEditor({
 	const onPointerDown = useCallback((ev: React.PointerEvent) => {
 		ev.preventDefault();
 		ev.stopPropagation();
+		ev.currentTarget.setPointerCapture(ev.pointerId);
 		setDragging(true);
 	}, [setDragging]);
 	const onPointerUp = useCallback((ev: React.PointerEvent) => {
 		ev.preventDefault();
 		ev.stopPropagation();
+		ev.currentTarget.releasePointerCapture(ev.pointerId);
 		setDragging(false);
 	}, [setDragging]);
 	const onPointerMove = useCallback((ev: React.PointerEvent) => {
@@ -209,7 +211,7 @@ function ColorEditor({
 			<div className='color-editor' ref={ ref }>
 				<div className='color-editor__rect'>
 					<div className='color-editor__rect__color'
-						onPointerDown={ onPointerDown } onPointerUp={ onPointerUp } onPointerMove={ onPointerMove } onPointerCancel={ onPointerUp }>
+						onPointerDown={ onPointerDown } onPointerUp={ onPointerUp } onPointerMove={ onPointerMove } onPointerCancel={ onPointerUp } onLostPointerCapture={ onPointerUp }>
 						<div className='color-editor__rect__color__pointer' />
 					</div>
 				</div>


### PR DESCRIPTION
capture felt the best solution, this slightly change the behavior dragging the pointer out will still continue the change (I feel this is a bit better)

tried adding `onPointerOut` but it wasn't stable so capture is over all the better

(tested with multiple color inputs at the same time could not get it to stuck or broken in any way)