### PR TITLE
[FIX] Fix buttons getting pushed to new lines

### DIFF
--- a/pandora-client-web/src/components/common/button/button.scss
+++ b/pandora-client-web/src/components/common/button/button.scss
@@ -32,6 +32,7 @@ $button-themes: (
 
 .Button {
 	@include center-flex;
+	display: inline-flex;
 	gap: 0.5em;
 
 	border-radius: 0.2em;


### PR DESCRIPTION
Fixes a regression introduced in #629, which pushed some buttons (most notably those on whispering/chat mode indicator) to a new line instead of keeping them in-line.