### PR TITLE
[FIX] Fix DM chat scrollbar missing

### DIFF
--- a/pandora-client-web/src/components/directMessage/directMessage.scss
+++ b/pandora-client-web/src/components/directMessage/directMessage.scss
@@ -7,7 +7,6 @@
 	background-color: $grey-darker;
 
 	.direct-message-list {
-		display: flex;
 		flex-flow: column;
 		flex: 1;
 		overflow-x: hidden;


### PR DESCRIPTION
Fixes #682

The current situation is that the scroll bar never appears, and DM elements all shrink to fit (with flexbox's not-helpful "hover over message to make it larger"). The root container is still flex (and so shares with the text entry area), but the messages is a block which lets inner messages stack + overflow to a scrollbar properly.

I tried various different solutions, the ultimate problem is that "fixed size elements, scroll if overflow" doesn't seem to be an optimal use case for a flex container, which seems to have two main options: (1) min size elements (i.e. using `flex-shrink: 0`) that don't scroll, or (2) elements that shrink to fit (current behavior)

Even when shrinking the viewport this seemed to maintain behavior, and enabled scrolling in the list. The chat entry area is fine in both a larger and smaller viewport.

## Before

![before 1](https://github.com/Project-Pandora-Game/pandora/assets/97317398/2edafee5-6b1d-413c-826c-f4f1aa8064e1)
![before 2](https://github.com/Project-Pandora-Game/pandora/assets/97317398/95be24f0-188a-4818-ac0a-c629665bd5a9)

## After

![after 1](https://github.com/Project-Pandora-Game/pandora/assets/97317398/18fc9d6a-e461-4272-9153-9e2e70bdfbd4)
![after 2](https://github.com/Project-Pandora-Game/pandora/assets/97317398/07ed87e7-becb-4e89-9e1d-14cc0a7728aa)