### PR TITLE
[FIX] Don't insert a space for `/me` messages that start with `'s`

### DIFF
--- a/pandora-client-web/src/ui/components/chat/chat.tsx
+++ b/pandora-client-web/src/ui/components/chat/chat.tsx
@@ -232,7 +232,7 @@ function DisplayName({ message, color }: { message: IChatMessageChat; color: str
 			default:
 				return ['', ''];
 		}
-	}, [message.type]);
+	}, [message.type, message.parts]);
 
 	const onClick = useCallback((event: React.MouseEvent<HTMLSpanElement>) => {
 		event.stopPropagation();

--- a/pandora-client-web/src/ui/components/chat/chat.tsx
+++ b/pandora-client-web/src/ui/components/chat/chat.tsx
@@ -226,7 +226,9 @@ function DisplayName({ message, color }: { message: IChatMessageChat; color: str
 			case 'chat':
 				return ['', ': '];
 			case 'me':
-				return ['', ' '];
+				// For /me messages that start with 's we don't insert a space, so the displayed message becomes "Name's"
+				// This works for both `*'s thing` and `/me 's thing`, which both display as `Name's thing`
+				return ['', message.parts.length > 0 && message.parts[0][1].startsWith('\'s') ? '' : ' '];
 			default:
 				return ['', ''];
 		}


### PR DESCRIPTION
Fixes #683 

I'm not sure _at all_ what I'm doing here, so do let me know if there is a better way or place to do this, I'm slowly picking my way around this codebase. This should implement the rendering of said messages only on receiving on the client, and only for `'s`

### Questions

- Is this the right place for this formatting?
- Are there other situations in which the space should be elided? (Right now it's only messages prefixed with precisely `'s`)
- All of `*'s thing` and `* 's thing`, and `/me 's thing` produce `Name's thing` in chat, however note that `/me's` is invalid (as it fails to parse as a command). Intentional?

Testing various weird chat messages (including those with bold/italic, and multiline emote / non-emote parts all seems to be working as intended (although that's just the chat parser being very robust, nothing to do with this change)