### PR TITLE
[CHANGE] Standardize ColorInput Component

### DIFF
--- a/pandora-client-web/src/components/common/colorInput/colorInput.tsx
+++ b/pandora-client-web/src/components/common/colorInput/colorInput.tsx
@@ -12,7 +12,7 @@ export function ColorInput({
 	throttle = 0,
 	disabled = false,
 	hideTextInput = false,
-	inputColorTitle,
+	title,
 }: {
 	initialValue: HexColorString;
 	resetValue?: HexColorString;
@@ -20,9 +20,10 @@ export function ColorInput({
 	throttle?: number;
 	disabled?: boolean;
 	hideTextInput?: boolean;
-	inputColorTitle?: string;
+	title: string;
 }): ReactElement {
 	const [value, setInput] = useState<HexColorString>(initialValue.toUpperCase() as HexColorString);
+	const [showEditor, setShowEditor] = useState(false);
 
 	const onChangeCaller = useCallback((color: HexColorString) => onChange?.(color), [onChange]);
 	const onChangeCallerThrottled = useMemo(() => throttle <= 0 ? onChangeCaller : _.throttle(onChangeCaller, throttle), [onChangeCaller, throttle]);
@@ -36,15 +37,29 @@ export function ColorInput({
 		}
 	}, [setInput, onChangeCallerThrottled]);
 
+	const onEdit = useCallback((color: HexRGBAColorString) => {
+		onChangeCallerThrottled(color);
+		setInput(color);
+	}, [onChangeCallerThrottled]);
+	const onClick = useCallback((ev: React.MouseEvent) => {
+		ev.stopPropagation();
+		ev.preventDefault();
+		setShowEditor(true);
+	}, [setShowEditor]);
+
 	const onInputChange = (ev: ChangeEvent<HTMLInputElement>) => changeCallback(ev.target.value);
 
 	return (
 		<>
 			{ !hideTextInput && <input type='text' value={ value } onChange={ onInputChange } disabled={ disabled } maxLength={ 7 } /> }
-			<input type='color' value={ value } onChange={ onInputChange } disabled={ disabled } title={ inputColorTitle } />
+			<input type='color' value={ value } onChange={ onInputChange } onClick={ onClick } disabled={ disabled } title={ title } />
 			{
 				resetValue != null &&
 				<Button className='slim' onClick={ () => changeCallback(resetValue) }>↺</Button>
+			}
+			{
+				showEditor &&
+				<ColorEditor initialValue={ value } onChange={ onEdit } minAlpha={ Color.maxAlpha } close={ () => setShowEditor(false) } title={ title } />
 			}
 		</>
 	);

--- a/pandora-client-web/src/components/common/colorInput/colorInput.tsx
+++ b/pandora-client-web/src/components/common/colorInput/colorInput.tsx
@@ -26,7 +26,7 @@ type ColorInputRGBAProps = ColorInputProps<HexRGBAColorString> & {
 };
 
 export function ColorInputRGBA({
-	initialValue, resetValue, onChange, throttle = 0, disabled = false, minAlpha = 255, title,
+	title, initialValue, resetValue, onChange, throttle = 0, disabled = false, hideTextInput = false, minAlpha = 255,
 }: ColorInputRGBAProps): ReactElement {
 	const [value, setInput] = useState<HexRGBAColorString>(initialValue.toUpperCase() as HexRGBAColorString);
 	const [showEditor, setShowEditor] = useState(false);
@@ -57,11 +57,14 @@ export function ColorInputRGBA({
 
 	return (
 		<>
-			<input type='text' value={ value } onChange={ onInputChange } disabled={ disabled } maxLength={ minAlpha === Color.maxAlpha ? 7 : 9 } />
+			{
+				!hideTextInput &&
+				<input type='text' value={ value } onChange={ onInputChange } disabled={ disabled } maxLength={ minAlpha === Color.maxAlpha ? 7 : 9 } />
+			}
 			<input type='color' value={ value.substring(0, 7) } disabled={ disabled } onClick={ onClick } readOnly />
 			{
 				resetValue != null &&
-				<Button className='slim' onClick={ () => changeCallback(resetValue) }>↺</Button>
+				<Button className='slim' onClick={ () => changeCallback(resetValue) } disabled={ disabled }>↺</Button>
 			}
 			{
 				showEditor &&

--- a/pandora-client-web/src/components/common/colorInput/colorInput.tsx
+++ b/pandora-client-web/src/components/common/colorInput/colorInput.tsx
@@ -5,77 +5,29 @@ import { Button } from '../button/button';
 import './colorInput.scss';
 import { DraggableDialog } from '../../dialog/dialog';
 
-export function ColorInput({
-	initialValue,
-	resetValue,
-	onChange,
-	throttle = 0,
-	disabled = false,
-	hideTextInput = false,
-	title,
-}: {
-	initialValue: HexColorString;
-	resetValue?: HexColorString;
-	onChange?: (value: HexColorString) => void;
+type ColorInputProps<THexString extends `#${string}`> = {
+	title: string;
+	initialValue: THexString;
+	resetValue?: THexString;
+	onChange?: (value: THexString) => void;
 	throttle?: number;
 	disabled?: boolean;
 	hideTextInput?: boolean;
-	title: string;
-}): ReactElement {
-	const [value, setInput] = useState<HexColorString>(initialValue.toUpperCase() as HexColorString);
-	const [showEditor, setShowEditor] = useState(false);
+};
 
-	const onChangeCaller = useCallback((color: HexColorString) => onChange?.(color), [onChange]);
-	const onChangeCallerThrottled = useMemo(() => throttle <= 0 ? onChangeCaller : _.throttle(onChangeCaller, throttle), [onChangeCaller, throttle]);
-
-	const changeCallback = useCallback((input: string) => {
-		input = '#' + input.replace(/[^0-9a-f]/gi, '').toUpperCase();
-		setInput(input as HexColorString);
-		const valid = HexColorStringSchema.safeParse(input).success;
-		if (valid) {
-			onChangeCallerThrottled(input as HexColorString);
-		}
-	}, [setInput, onChangeCallerThrottled]);
-
-	const onEdit = useCallback((color: HexRGBAColorString) => {
-		onChangeCallerThrottled(color);
-		setInput(color);
-	}, [onChangeCallerThrottled]);
-	const onClick = useCallback((ev: React.MouseEvent) => {
-		ev.stopPropagation();
-		ev.preventDefault();
-		setShowEditor(true);
-	}, [setShowEditor]);
-
-	const onInputChange = (ev: ChangeEvent<HTMLInputElement>) => changeCallback(ev.target.value);
-
+export function ColorInput(props: ColorInputProps<HexColorString>): ReactElement {
 	return (
-		<>
-			{ !hideTextInput && <input type='text' value={ value } onChange={ onInputChange } disabled={ disabled } maxLength={ 7 } /> }
-			<input type='color' value={ value } onChange={ onInputChange } onClick={ onClick } disabled={ disabled } title={ title } />
-			{
-				resetValue != null &&
-				<Button className='slim' onClick={ () => changeCallback(resetValue) }>↺</Button>
-			}
-			{
-				showEditor &&
-				<ColorEditor initialValue={ value } onChange={ onEdit } minAlpha={ Color.maxAlpha } close={ () => setShowEditor(false) } title={ title } />
-			}
-		</>
+		<ColorInputRGBA { ...props } minAlpha={ Color.maxAlpha } />
 	);
 }
 
+type ColorInputRGBAProps = ColorInputProps<HexRGBAColorString> & {
+	minAlpha?: number;
+};
+
 export function ColorInputRGBA({
 	initialValue, resetValue, onChange, throttle = 0, disabled = false, minAlpha = 255, title,
-}: {
-	initialValue: HexRGBAColorString;
-	resetValue?: HexRGBAColorString;
-	onChange?: (value: HexRGBAColorString) => void;
-	throttle?: number;
-	disabled?: boolean;
-	minAlpha?: number;
-	title: string;
-}): ReactElement {
+}: ColorInputRGBAProps): ReactElement {
 	const [value, setInput] = useState<HexRGBAColorString>(initialValue.toUpperCase() as HexRGBAColorString);
 	const [showEditor, setShowEditor] = useState(false);
 
@@ -85,11 +37,11 @@ export function ColorInputRGBA({
 	const changeCallback = useCallback((input: string) => {
 		input = '#' + input.replace(/[^0-9a-f]/gi, '').toUpperCase();
 		setInput(input as HexRGBAColorString);
-		const valid = HexRGBAColorStringSchema.safeParse(input).success;
+		const valid = (minAlpha === Color.maxAlpha) ? HexColorStringSchema.safeParse(input).success : HexRGBAColorStringSchema.safeParse(input).success;
 		if (valid) {
 			onChangeCallerThrottled(input as HexRGBAColorString);
 		}
-	}, [setInput, onChangeCallerThrottled]);
+	}, [minAlpha, setInput, onChangeCallerThrottled]);
 
 	const onEdit = useCallback((color: HexRGBAColorString) => {
 		onChangeCallerThrottled(color);

--- a/pandora-client-web/src/components/common/colorInput/colorInput.tsx
+++ b/pandora-client-web/src/components/common/colorInput/colorInput.tsx
@@ -90,7 +90,7 @@ export function ColorInputRGBA({
 
 	return (
 		<>
-			<input type='text' value={ value } onChange={ onInputChange } disabled={ disabled } maxLength={ minAlpha === 255 ? 7 : 9 } />
+			<input type='text' value={ value } onChange={ onInputChange } disabled={ disabled } maxLength={ minAlpha === Color.maxAlpha ? 7 : 9 } />
 			<input type='color' value={ value.substring(0, 7) } disabled={ disabled } onClick={ onClick } readOnly />
 			{
 				resetValue != null &&
@@ -317,7 +317,7 @@ class Color {
 
 	public toHex(): HexRGBAColorString {
 		const [r, g, b] = this.rbg;
-		if (this.alpha === 255) {
+		if (this.alpha === Color.maxAlpha) {
 			return `#${Color.toHexPart(r)}${Color.toHexPart(g)}${Color.toHexPart(b)}` as HexColorString;
 		}
 		return `#${Color.toHexPart(r)}${Color.toHexPart(g)}${Color.toHexPart(b)}${Color.toHexPart(Math.round(this.alpha))}` as HexRGBAColorString;

--- a/pandora-client-web/src/components/settings/accountSettings.tsx
+++ b/pandora-client-web/src/components/settings/accountSettings.tsx
@@ -196,7 +196,7 @@ function LabelColor({ account }: { account: IDirectoryAccountInfo; }): ReactElem
 			<legend>Name color</legend>
 			<div className='input-row'>
 				<label>Color</label>
-				<ColorInput initialValue={ color } onChange={ setColor } />
+				<ColorInput initialValue={ color } onChange={ setColor } title='Name' />
 				<Button
 					className='slim fadeDisabled'
 					onClick={ () => {

--- a/pandora-client-web/src/components/settings/characterSettings.tsx
+++ b/pandora-client-web/src/components/settings/characterSettings.tsx
@@ -52,7 +52,7 @@ function LabelColor({ playerData }: { playerData: Readonly<ICharacterPrivateData
 			<legend>Name color</legend>
 			<div className='input-row'>
 				<label>Color</label>
-				<ColorInput initialValue={ color } onChange={ setColor } />
+				<ColorInput initialValue={ color } onChange={ setColor } title='Name' />
 				<Button
 					className='slim fadeDisabled'
 					onClick={ () => shardConnector?.sendMessage('updateSettings', { labelColor: color }) }

--- a/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.tsx
+++ b/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.tsx
@@ -249,6 +249,7 @@ export function SpaceConfiguration({ creation = false }: { creation?: boolean; }
 										initialValue={ currentConfigBackground.image.startsWith('#') ? currentConfigBackground.image : '#FFFFFF' }
 										onChange={ (color) => setModifiedData({ background: { ...currentConfigBackground, image: color } }) }
 										disabled={ !canEdit }
+										title='Background'
 									/>
 								</div>
 							</div>


### PR DESCRIPTION
Closes #669 

This changes the input style for the basic `ColorInput` component to use the internal `ColorEditor` created for the `ColorInputRGBA` component. Because of this `ColorInput` has a new parameter required `title` which was retroactively included in the 3 locations the component was already used. 
Two magic numbers for representing max alpha inside the `colorinput.tsx` file were also converted to use the static global variable `Color.maxAlpha` instead of a hardcoded `255` like all other references in the file.

I chose to keep the `ColorInput` component instead of combining and converting them all into `ColorInputRGBA` across all use cases as I feel there could be good semantic reasons for having both as not all color fields should support alpha channels and it might become less clear if both use cases shared the same component. This could be changed upon request though to reduce code reusage.