### PR TITLE
[FIX] Fix Direct messages getting squished on Chrome

### DIFF
--- a/pandora-client-web/src/components/directMessage/directMessage.scss
+++ b/pandora-client-web/src/components/directMessage/directMessage.scss
@@ -7,11 +7,9 @@
 	background-color: $grey-darker;
 
 	.direct-message-list {
-		display: flex;
-		flex-flow: column;
+		position: relative;
 		flex: 1;
-		overflow-x: hidden;
-		overflow-y: scroll;
+		overflow: hidden;
 		user-select: text;
 	}
 

--- a/pandora-client-web/src/components/directMessage/directMessage.tsx
+++ b/pandora-client-web/src/components/directMessage/directMessage.tsx
@@ -7,7 +7,7 @@ import { DirectMessage } from '../../networking/directMessageManager';
 import { useObservable } from '../../observable';
 import { TOAST_OPTIONS_ERROR } from '../../persistentToast';
 import { RenderChatPart } from '../../ui/components/chat/chatMessages';
-import { Scrollbar } from '../common/scrollbar/scrollbar';
+import { Scrollable } from '../common/scrollbar/scrollbar';
 import { DirectMessageChannelProvider, useDirectMessageChannel } from '../gameContext/directMessageChannelProvieder';
 import { useCurrentAccount, useDirectoryConnector, useAccountSettings } from '../gameContext/directoryConnectorContextProvider';
 import './directMessage.scss';
@@ -20,6 +20,7 @@ import { useGameStateOptional } from '../gameContext/gameStateContextProvider';
 import { useNavigate } from 'react-router';
 import { AutocompleteDisplayData, COMMAND_KEY, CommandAutocomplete, CommandAutocompleteCycle, ICommandInvokeContext, RunCommand } from '../../ui/components/chat/commandsProcessor';
 import { useInputAutofocus } from '../../common/userInteraction/inputAutofocus';
+import { Column } from '../common/container/container';
 
 export function DirectMessage({ accountId }: { accountId: number; }): ReactElement {
 	const ref = React.useRef<HTMLTextAreaElement>(null);
@@ -71,18 +72,25 @@ function DirectMessageList(): ReactElement | null {
 	}
 
 	return (
-		<Scrollbar
-			ref={ ref }
-			color='dark'
+		<div
 			className={ classNames(
 				'direct-message-list',
 				`fontSize-${interfaceChatroomChatFontSize}`,
 			) }
 		>
-			{ messages.map((message) => (
-				<DirectMessageElement key={ message.time } message={ message } channel={ channelAccount } account={ account } />
-			)) }
-		</Scrollbar>
+			<Scrollable
+				ref={ ref }
+				color='dark'
+				className='fill'
+				tabIndex={ 1 }
+			>
+				<Column gap='none'>
+					{ messages.map((message) => (
+						<DirectMessageElement key={ message.time } message={ message } channel={ channelAccount } account={ account } />
+					)) }
+				</Column>
+			</Scrollable>
+		</div>
 	);
 }
 


### PR DESCRIPTION
fixes #682 

It appears Chrome prefers squishing flex children over scrolling under some specific conditions, involving the children having overflow hidden. This can cause current styling of DMs to squish messages when there are more than fit on a screen.

This PR updates the DM rendering implementation to use the same layout as chat is:
- A root bounding element with `relative` position - used for correctly positioning the `/` commands help overlay
- A `Scrollable` element that adds the scrollbar if the content gets bigger than it
- A single containing flex (in this case `Column`) for all the messages. It is important that this element is different than the one adding scrollbar to avoid the bug - it must be nested inside the scrollable element.
- The actual messages