### PR TITLE
[FEATURE] change email for not activated accounts

### DIFF
--- a/pandora-client-web/src/components/login/forms/resendVerificationAdvancedForm.tsx
+++ b/pandora-client-web/src/components/login/forms/resendVerificationAdvancedForm.tsx
@@ -6,7 +6,8 @@ import { useDirectoryResendVerificationAdvanced } from '../../../networking/acco
 import { Button } from '../../common/button/button';
 import { Form, FormCreateStringValidator, FormErrorMessage, FormField, FormFieldCaptcha, FormFieldError, FormLink } from '../../common/form/form';
 import { toast } from 'react-toastify';
-import { TOAST_OPTIONS_ERROR } from '../../../persistentToast';
+import { TOAST_OPTIONS_ERROR, TOAST_OPTIONS_SUCCESS } from '../../../persistentToast';
+import { Row } from '../../common/container/container';
 
 export interface ResendVerificationAdvancedFormData {
 	username: string;
@@ -39,13 +40,17 @@ export function ResendVerificationAdvancedForm(): ReactElement {
 		const result = await resendVerificationAdvanced(username, password, email, overrideEmail, captchaToken);
 
 		switch (result.result) {
-			case 'ok':
-				navigate('/login', {
-					state: {
-						message: 'An email with a verification code has been sent to the submitted email address, if there is an account registered using it.',
-					},
-				});
+			case 'ok': {
+				let message: string;
+				if (overrideEmail) {
+					message = 'The account email has been changed, verification email has been sent to the new email address';
+				} else {
+					message = 'An email with a verification code has been successfully sent to the account email address';
+				}
+				toast(message, TOAST_OPTIONS_SUCCESS);
+				navigate('/login', { state: { message } });
 				return;
+			}
 			case 'unknownCredentials':
 				showError('Invalid username or password');
 				break;
@@ -109,14 +114,17 @@ export function ResendVerificationAdvancedForm(): ReactElement {
 				<FormFieldError error={ errors.email } />
 			</FormField>
 			<FormField>
-				<label htmlFor='forgot-activation-override-email'>Override email</label>
-				<input
-					type='checkbox'
-					id='forgot-activation-override-email'
-					checked={ overrideEmail }
-					onChange={ (e) => setOverrideEmail(e.target.checked) }
-				/>
+				<Row>
+					<input
+						type='checkbox'
+						id='forgot-activation-override-email'
+						checked={ overrideEmail }
+						onChange={ (e) => setOverrideEmail(e.target.checked) }
+					/>
+					<label htmlFor='forgot-activation-override-email'>Override email</label>
+				</Row>
 			</FormField>
+			<br />
 			<FormFieldCaptcha setCaptchaToken={ setCaptchaToken } invalidCaptcha={ captchaFailed } />
 			{ errorMessage && <FormErrorMessage>{ errorMessage }</FormErrorMessage> }
 			<Button type='submit' className='fadeDisabled' disabled={ isSubmitting }>

--- a/pandora-client-web/src/components/login/forms/resendVerificationAdvancedForm.tsx
+++ b/pandora-client-web/src/components/login/forms/resendVerificationAdvancedForm.tsx
@@ -1,4 +1,4 @@
-import { AssertNever, IsEmail, UserNameSchema } from 'pandora-common';
+import { AssertNever, FormatTimeInterval, IsEmail, UserNameSchema } from 'pandora-common';
 import React, { ReactElement, useCallback, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
@@ -67,7 +67,7 @@ export function ResendVerificationAdvancedForm(): ReactElement {
 				showError('Account is already activated');
 				break;
 			case 'rateLimited':
-				showError('Rate limited');
+				showError('Rate limited, please try again in: ' + FormatTimeInterval(result.time, 'two-most-significant'));
 				break;
 			default:
 				AssertNever(result);

--- a/pandora-client-web/src/components/login/forms/resendVerificationAdvancedForm.tsx
+++ b/pandora-client-web/src/components/login/forms/resendVerificationAdvancedForm.tsx
@@ -1,0 +1,128 @@
+import { AssertNever, IsEmail, UserNameSchema } from 'pandora-common';
+import React, { ReactElement, useCallback, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import { useDirectoryResendVerificationAdvanced } from '../../../networking/account_manager';
+import { Button } from '../../common/button/button';
+import { Form, FormCreateStringValidator, FormErrorMessage, FormField, FormFieldCaptcha, FormFieldError, FormLink } from '../../common/form/form';
+import { toast } from 'react-toastify';
+import { TOAST_OPTIONS_ERROR } from '../../../persistentToast';
+
+export interface ResendVerificationAdvancedFormData {
+	username: string;
+	password: string;
+	email: string;
+}
+
+export function ResendVerificationAdvancedForm(): ReactElement {
+	const navigate = useNavigate();
+	const resendVerificationAdvanced = useDirectoryResendVerificationAdvanced();
+	const [errorMessage, setErrorMessage] = useState('');
+	const [captchaToken, setCaptchaToken] = useState('');
+	const [captchaFailed, setCaptchaFailed] = useState(false);
+	const [overrideEmail, setOverrideEmail] = useState(false);
+
+	const {
+		formState: { errors, submitCount, isSubmitting },
+		handleSubmit,
+		register,
+	} = useForm<ResendVerificationAdvancedFormData>({ shouldUseNativeValidation: true, progressive: true });
+
+	const showError = useCallback((error: string) => {
+		toast(error, TOAST_OPTIONS_ERROR);
+		setErrorMessage(error);
+	}, []);
+
+	const onSubmit = handleSubmit(async ({ username, password, email }) => {
+		setCaptchaFailed(false);
+
+		const result = await resendVerificationAdvanced(username, password, email, overrideEmail, captchaToken);
+
+		switch (result.result) {
+			case 'ok':
+				navigate('/login', {
+					state: {
+						message: 'An email with a verification code has been sent to the submitted email address, if there is an account registered using it.',
+					},
+				});
+				return;
+			case 'unknownCredentials':
+				showError('Invalid username or password');
+				break;
+			case 'invalidCaptcha':
+				setCaptchaFailed(true);
+				break;
+			case 'invalidEmail':
+				showError('Email address does not match the account');
+				break;
+			case 'emailTaken':
+				showError('Email address is already in use');
+				break;
+			case 'alreadyActivated':
+				showError('Account is already activated');
+				break;
+			case 'rateLimited':
+				showError('Rate limited');
+				break;
+			default:
+				AssertNever(result);
+		}
+	});
+
+	return (
+		<Form className='ForgotPasswordForm' dirty={ submitCount > 0 } onSubmit={ onSubmit }>
+			<h1>Resend activation email</h1>
+			<FormField>
+				<label htmlFor='forgot-activation-username'>Username</label>
+				<input
+					type='text'
+					id='forgot-activation-username'
+					autoComplete='username'
+					{ ...register('username', {
+						required: 'Username is required',
+						validate: FormCreateStringValidator(UserNameSchema, 'username'),
+					}) }
+				/>
+				<FormFieldError error={ errors.username } />
+			</FormField>
+			<FormField>
+				<label htmlFor='forgot-activation-password'>Password</label>
+				<input
+					type='password'
+					id='forgot-activation-password'
+					autoComplete='current-password'
+					{ ...register('password', { required: 'Password is required' }) }
+				/>
+				<FormFieldError error={ errors.password } />
+			</FormField>
+			<FormField>
+				<label htmlFor='forgot-activation-email'>Enter your email</label>
+				<input
+					type='email'
+					id='forgot-activation-email'
+					autoComplete='email'
+					{ ...register('email', {
+						required: 'Email is required',
+						validate: (email) => IsEmail(email) || 'Invalid email format',
+					}) }
+				/>
+				<FormFieldError error={ errors.email } />
+			</FormField>
+			<FormField>
+				<label htmlFor='forgot-activation-override-email'>Override email</label>
+				<input
+					type='checkbox'
+					id='forgot-activation-override-email'
+					checked={ overrideEmail }
+					onChange={ (e) => setOverrideEmail(e.target.checked) }
+				/>
+			</FormField>
+			<FormFieldCaptcha setCaptchaToken={ setCaptchaToken } invalidCaptcha={ captchaFailed } />
+			{ errorMessage && <FormErrorMessage>{ errorMessage }</FormErrorMessage> }
+			<Button type='submit' className='fadeDisabled' disabled={ isSubmitting }>
+				{ overrideEmail ? 'Change account email' : 'Resend verification email' }
+			</Button>
+			<FormLink to='/login'>◄ Return to login</FormLink>
+		</Form>
+	);
+}

--- a/pandora-client-web/src/components/login/forms/resendVerificationForm.tsx
+++ b/pandora-client-web/src/components/login/forms/resendVerificationForm.tsx
@@ -59,6 +59,7 @@ export function ResendVerificationForm(): ReactElement {
 			</FormField>
 			<FormFieldCaptcha setCaptchaToken={ setCaptchaToken } invalidCaptcha={ captchaFailed } />
 			<Button type='submit' className='fadeDisabled' disabled={ isSubmitting }>Resend verification email</Button>
+			<FormLink to='/override_verification'>Advanced form with feedback</FormLink>
 			<FormLink to='/login'>◄ Return to login</FormLink>
 		</Form>
 	);

--- a/pandora-client-web/src/networking/account_manager.ts
+++ b/pandora-client-web/src/networking/account_manager.ts
@@ -1,4 +1,4 @@
-import { EMPTY, GetLogger } from 'pandora-common';
+import { EMPTY, GetLogger, type IClientDirectoryPromiseResult } from 'pandora-common';
 import { useCallback } from 'react';
 import { toast } from 'react-toastify';
 import { useDirectoryConnector } from '../components/gameContext/directoryConnectorContextProvider';
@@ -51,6 +51,16 @@ type RegisterCallback = (
  * @returns Promise of response from the directory
  */
 type ResendVerificationCallback = (email: string, captchaToken?: string) => Promise<'maybeSent' | 'invalidCaptcha'>;
+
+/**
+ * Attempt to request a new verification email
+ * @param username - Account username
+ * @param password - Account password
+ * @param email - Account email
+ * @param overrideEmail - Override email
+ * @param captchaToken - Captcha token, if required
+ */
+type ResendVerificationAdvancedCallback = (username: string, password: string, email: string, overrideEmail: boolean, captchaToken?: string) => IClientDirectoryPromiseResult['resendVerificationEmailAdvanced'];
 
 /**
  * Attempt to request a password reset
@@ -116,6 +126,14 @@ export function useDirectoryResendVerification(): ResendVerificationCallback {
 	return useCallback(async (email, captchaToken) => {
 		const result = await directoryConnector.awaitResponse('resendVerificationEmail', { email, captchaToken });
 		return result.result;
+	}, [directoryConnector]);
+}
+
+export function useDirectoryResendVerificationAdvanced(): ResendVerificationAdvancedCallback {
+	const directoryConnector = useDirectoryConnector();
+	return useCallback(async (username, password, email, overrideEmail, captchaToken) => {
+		const passwordSha512 = await PrehashPassword(password);
+		return await directoryConnector.awaitResponse('resendVerificationEmailAdvanced', { username, passwordSha512, email, overrideEmail, captchaToken });
 	}, [directoryConnector]);
 }
 

--- a/pandora-client-web/src/routing/authRoutingData.ts
+++ b/pandora-client-web/src/routing/authRoutingData.ts
@@ -5,6 +5,7 @@ import { LoginForm } from '../components/login/forms/loginForm';
 import { RegistrationForm } from '../components/login/forms/registrationForm';
 import { ResendVerificationForm } from '../components/login/forms/resendVerificationForm';
 import { ResetPasswordForm } from '../components/login/forms/resetPasswordForm';
+import { ResendVerificationAdvancedForm } from '../components/login/forms/resendVerificationAdvancedForm';
 
 export enum AuthPagePath {
 	LOGIN = '/login',
@@ -12,6 +13,7 @@ export enum AuthPagePath {
 	REGISTER = '/register',
 	FORGOT_PASSWORD = '/forgot_password',
 	RESEND_EMAIL = '/resend_verification_email',
+	OVERRIDE_VERIFICATION = '/override_verification',
 	RESET_PASSWORD = '/reset_password',
 }
 
@@ -21,9 +23,9 @@ const authPageComponentMap: Record<AuthPagePath, ComponentType<Record<string, ne
 	[AuthPagePath.REGISTER]: RegistrationForm,
 	[AuthPagePath.FORGOT_PASSWORD]: ForgotPasswordForm,
 	[AuthPagePath.RESEND_EMAIL]: ResendVerificationForm,
+	[AuthPagePath.OVERRIDE_VERIFICATION]: ResendVerificationAdvancedForm,
 	[AuthPagePath.RESET_PASSWORD]: ResetPasswordForm,
 };
 
 export const authPagePathsAndComponents = Object.entries(authPageComponentMap);
 export const authPageComponents = Object.values(authPageComponentMap);
-

--- a/pandora-common/src/networking/client_directory.ts
+++ b/pandora-common/src/networking/client_directory.ts
@@ -148,6 +148,19 @@ export const ClientDirectorySchema = {
 		}),
 		response: ZodCast<{ result: 'maybeSent' | 'invalidCaptcha'; }>(),
 	},
+	resendVerificationEmailAdvanced: {
+		request: z.object({
+			username: UserNameSchema,
+			passwordSha512: PasswordSha512Schema,
+			email: EmailAddressSchema,
+			captchaToken: z.string().optional(),
+			overrideEmail: z.boolean(),
+		}),
+		response: ZodCast<{ result: 'ok' | 'unknownCredentials' | 'emailTaken' | 'alreadyActivated' | 'invalidCaptcha' | 'invalidEmail'; } | {
+			result: 'rateLimited';
+			time: number;
+		}>(),
+	},
 	passwordReset: {
 		request: z.object({
 			email: EmailAddressSchema,

--- a/pandora-server-directory/src/config.ts
+++ b/pandora-server-directory/src/config.ts
@@ -38,6 +38,8 @@ export const EnvParser = CreateEnvParser({
 	ACTIVATION_TOKEN_EXPIRATION: EnvTimeInterval().default('1w'),
 	/** Time (in ms) for how long is a password reset token valid */
 	PASSWORD_RESET_TOKEN_EXPIRATION: EnvTimeInterval().default('1d'),
+	/** Time (in ms) for rate limiting email change for not activated accounts */
+	RATE_LIMIT_EMAIL_CHANGE_NOT_ACTIVATED: EnvTimeInterval().default('10m'),
 
 	//#endregion
 

--- a/pandora-server-directory/src/database/databaseProvider.ts
+++ b/pandora-server-directory/src/database/databaseProvider.ts
@@ -52,6 +52,13 @@ export interface PandoraDatabase extends Service {
 	createAccount(data: DatabaseAccountWithSecure): Promise<DatabaseAccountWithSecure | 'usernameTaken' | 'emailTaken'>;
 
 	/**
+	 * Update account's email hash
+	 * @param id - Account id
+	 * @param emailHash - Email hash to set
+	 */
+	updateAccountEmailHash(id: AccountId, emailHash: string): Promise<'ok' | 'notFound' | 'emailTaken'>;
+
+	/**
 	 * Sets account data
 	 * @param id - Account id
 	 * @param data - data to set

--- a/pandora-server-directory/src/database/mockDb.ts
+++ b/pandora-server-directory/src/database/mockDb.ts
@@ -135,6 +135,18 @@ export class MockDatabase implements PandoraDatabase {
 		return Promise.resolve(_.cloneDeep(acc));
 	}
 
+	public updateAccountEmailHash(id: AccountId, emailHash: string): Promise<'ok' | 'notFound' | 'emailTaken'> {
+		const acc = this.accountDbView.find((dbAccount) => dbAccount.id === id);
+		if (!acc)
+			return Promise.resolve('notFound');
+
+		if (this.accountDbView.find((dbAccount) => dbAccount.secure.emailHash === emailHash))
+			return Promise.resolve('emailTaken');
+
+		acc.secure.emailHash = emailHash;
+		return Promise.resolve('ok');
+	}
+
 	public updateAccountData(id: AccountId, data: DatabaseAccountUpdate): Promise<void> {
 		data = DatabaseAccountSchema
 			.pick(ArrayToRecordKeys(DATABASE_ACCOUNT_UPDATEABLE_PROPERTIES, true))


### PR DESCRIPTION
Add new form that requires username, password and email, instead of `maybeSent` user gets a detailed result if the email was incorrect

Optional checkbox to override the current account's email address

tested it locally just not quite sure if the UI texts are the best