### PR TITLE
[CHANGE] Change color scheme of profile editor

### DIFF
--- a/pandora-client-web/src/components/profileScreens/profileScreens.scss
+++ b/pandora-client-web/src/components/profileScreens/profileScreens.scss
@@ -49,7 +49,8 @@
 	}
 
 	.profileDescriptionContent {
-		background-color: $grey-lightest;
+		background-color: #303030;
+		color: $white;
 		padding: 0.5em;
 		border: 1px solid black;
 		font-family: Arial, Helvetica, sans-serif;
@@ -57,6 +58,8 @@
 	}
 
 	.profileEdit {
+		background-color: $grey-lightest;
+		color: $black;
 		border: 2px dashed $red-dark;
 	}
 }


### PR DESCRIPTION
The new color scheme is closer to the one used in other places e.g. chat and allows for easier distinguishing of edit and display mode.

__This is a change based on a conversation on https://github.com/Project-Pandora-Game/pandora/pull/694 that did not make it into  that pullrequest before merge__