### PR TITLE
[FIX] Color Input Mobile Compatability Improvements

### DIFF
--- a/pandora-client-web/src/components/common/colorInput/colorInput.scss
+++ b/pandora-client-web/src/components/common/colorInput/colorInput.scss
@@ -107,3 +107,18 @@
 		font-size: 14px;
 	}
 }
+
+.color-input-button{
+	border: 2px solid black;
+	border-radius: 0;
+	display: flex;
+	padding: 0;
+	background-color: #aaa;
+}
+
+.color-view{
+	margin: 4px;
+	width: 40px;
+	height: 20px;
+	border: 1px solid gray;
+}

--- a/pandora-client-web/src/components/common/colorInput/colorInput.tsx
+++ b/pandora-client-web/src/components/common/colorInput/colorInput.tsx
@@ -58,7 +58,6 @@ export function ColorInputRGBA({
 	const onInputChange = useCallback((ev: ChangeEvent<HTMLInputElement>) => changeCallback(ev.target.value), [changeCallback]);
 	const onClick = useCallback((ev: React.MouseEvent) => {
 		ev.stopPropagation();
-		ev.preventDefault();
 		setShowEditor(true);
 	}, [setShowEditor]);
 
@@ -68,7 +67,9 @@ export function ColorInputRGBA({
 				!hideTextInput &&
 				<input type='text' value={ value } onChange={ onInputChange } disabled={ disabled } maxLength={ minAlpha === Color.maxAlpha ? 7 : 9 } onPaste={ onPaste } />
 			}
-			<input type='color' value={ value.substring(0, 7) } disabled={ disabled } onClick={ onClick } readOnly />
+			<button className='color-input-button' disabled={ disabled } onClick={ onClick } >
+				<div className='color-view' style={ { backgroundColor: value } } />
+			</button>
 			{
 				resetValue != null &&
 				<Button className='slim' onClick={ () => changeCallback(resetValue) } disabled={ disabled }>↺</Button>

--- a/pandora-client-web/src/components/dialog/dialog.scss
+++ b/pandora-client-web/src/components/dialog/dialog.scss
@@ -64,19 +64,26 @@
 
 	>header {
 		@include center-flex;
-		padding: 0.2em 1em;
+		padding: 0.2em 0.2em 0.2em 1em;
 		background-color: $grey-light;
 		position: relative;
 		cursor: move;
 
 		.dialog-close {
-			position: absolute;
-			right: 0.6em;
+			flex: 1;
 			cursor: pointer;
 
 			&:hover {
 				color: red;
 			}
+		}
+	}
+
+	>.dialog-header {
+		display: flex;
+
+		>.drag-handle{
+			flex: 12
 		}
 	}
 
@@ -92,3 +99,5 @@
 .dialog-confirm {
 	max-width: min(95vw, 50em);
 }
+
+

--- a/pandora-client-web/src/components/dialog/dialog.scss
+++ b/pandora-client-web/src/components/dialog/dialog.scss
@@ -67,7 +67,6 @@
 		padding: 0.2em 0.2em 0.2em 1em;
 		background-color: $grey-light;
 		position: relative;
-		cursor: move;
 
 		.dialog-close {
 			flex: 1;
@@ -83,7 +82,8 @@
 		display: flex;
 
 		>.drag-handle{
-			flex: 12
+			flex: 12;
+			cursor: move;
 		}
 	}
 

--- a/pandora-client-web/src/components/dialog/dialog.tsx
+++ b/pandora-client-web/src/components/dialog/dialog.tsx
@@ -141,12 +141,14 @@ export function DraggableDialog({ children, title, rawContent, close, hiddenClos
 					} }
 					bounds='parent'
 				>
-					<header className='drag-handle'>
-						{ title }
+					<header className='dialog-header'>
+						<div className='drag-handle'>
+							{ title }
+						</div>
 						{ hiddenClose !== true ? (
-							<span className='dialog-close' onClick={ close }>
+							<div className='dialog-close' onClick={ close }>
 								×
-							</span>
+							</div>
 						) : null }
 					</header>
 					{


### PR DESCRIPTION
Fixes #709 

When using mobile devices due to the way event propagation works and the lack of precision of how touch events are handled, the drag handling event always took precedence over the click even for closing the pop-up dialogs when using mobile devices as the two layers overlapped one another. Because of this I split the header into a two part flex with them handling their own events independently with the dragable portion taking a bulk of the header but no longer overlapping with the close button. (Because of this the title is currently left-aligned as well instead of trying to handle relative positioning to center it once more)

Converted the `<input type=color>` tag to a normal button to remove weird mobile event handling that was not preventing the default action from performing on click for the input. Now that it's just a standard button there is no default action to be triggered, only the hooked in function will trigger so `ev.preventDefault()` was also removed as being frivolous. Also by embedding the background color style directly into the JSX component, a `useRef` hook isn't necessary as the style will update in real time as the color is modified. 

Graphic to show flex boundaries representing the event areas:
![image](https://github.com/Project-Pandora-Game/pandora/assets/11225158/e29378bd-38c2-4cf7-a3ec-c795cfc6204c)

Graphic showing the new input button:
![image](https://github.com/Project-Pandora-Game/pandora/assets/11225158/1c65a561-f017-4845-9d14-24f82977931d)

Edit: Updated to include fix for bug 1 in the same issue