### PR TITLE
[FEATURE] better parse when pasting color values

### DIFF
--- a/pandora-client-web/package.json
+++ b/pandora-client-web/package.json
@@ -27,6 +27,7 @@
 		"bowser": "2.11.0",
 		"classnames": "2.5.1",
 		"client-zip": "2.4.4",
+		"color-parse": "^2.0.2",
 		"delaunator": "5.0.1",
 		"history": "5.3.0",
 		"immer": "10.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
       client-zip:
         specifier: 2.4.4
         version: 2.4.4
+      color-parse:
+        specifier: ^2.0.2
+        version: 2.0.2
       delaunator:
         specifier: 5.0.1
         version: 5.0.1
@@ -3267,6 +3270,13 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  color-name@2.0.0:
+    resolution: {integrity: sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==}
+    engines: {node: '>=12.20'}
+
+  color-parse@2.0.2:
+    resolution: {integrity: sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==}
 
   colord@2.9.3:
     resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
@@ -10656,6 +10666,12 @@ snapshots:
   color-name@1.1.3: {}
 
   color-name@1.1.4: {}
+
+  color-name@2.0.0: {}
+
+  color-parse@2.0.2:
+    dependencies:
+      color-name: 2.0.0
 
   colord@2.9.3: {}
 


### PR DESCRIPTION
Do best effort to parse RGBA color on paste from:
- `RGB[A]`
- `#RGB[A]`
- `RRGGBB[AA]`
- `#RRGGBB[AA]`
- `rgb[a](R, G, B[, A])`
- `rgb(R G B[ / A])`
- `R:10 G:20 B:30`
- `(R10 / G20 / B30)`
- `[10, 20, 20]`
- `10,20,20`
- `0x00ff00`

Expandable to other color spaces if converter functions added in the future