### PR TITLE
[ADD] a shortcut from the device context menu to the inventory view

### DIFF
--- a/pandora-client-web/src/components/wardrobe/views/wardrobeItemView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobeItemView.tsx
@@ -14,7 +14,7 @@ import {
 	ITEM_LIMIT_ROOM_INVENTORY,
 	AppearanceItemsCalculateTotalCount,
 } from 'pandora-common';
-import React, { ReactElement, useEffect, useMemo } from 'react';
+import React, { ReactElement, useEffect, useMemo, useRef } from 'react';
 import { useObservable } from '../../../observable';
 import { isEqual } from 'lodash';
 import { IItemModule } from 'pandora-common/dist/assets/modules/common';
@@ -252,9 +252,17 @@ function InventoryItemViewList({ item, selected = false, setFocus, singleItemCon
 	setFocus?: (newFocus: WardrobeFocus) => void;
 	singleItemContainer?: boolean;
 }): ReactElement {
-	const { targetSelector, target, extraItemActions, heldItem, setHeldItem } = useWardrobeContext();
+	const { targetSelector, target, extraItemActions, heldItem, setHeldItem, scrollToItem, setScrollToItem } = useWardrobeContext();
 	const wornItem = useWardrobeTargetItem(target, item);
 	const extraActions = useObservable(extraItemActions);
+
+	const ref = useRef<HTMLDivElement>(null);
+	useEffect(() => {
+		if (scrollToItem === item.itemId) {
+			ref.current?.scrollIntoView({ behavior: 'smooth' });
+			setScrollToItem(null);
+		}
+	});
 
 	const ribbonColor = useItemColorRibbon([], wornItem ?? null);
 
@@ -274,7 +282,7 @@ function InventoryItemViewList({ item, selected = false, setFocus, singleItemCon
 	const asset = wornItem.asset;
 
 	return (
-		<div tabIndex={ 0 } className={ classNames('inventoryViewItem', 'listMode', selected && 'selected', singleItemContainer ? 'static' : 'allowed') } onClick={ () => {
+		<div ref={ ref } tabIndex={ 0 } className={ classNames('inventoryViewItem', 'listMode', selected && 'selected', singleItemContainer ? 'static' : 'allowed') } onClick={ () => {
 			if (singleItemContainer)
 				return;
 			setFocus?.({

--- a/pandora-client-web/src/components/wardrobe/views/wardrobeItemView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobeItemView.tsx
@@ -262,7 +262,7 @@ function InventoryItemViewList({ item, selected = false, setFocus, singleItemCon
 			ref.current?.scrollIntoView({ behavior: 'smooth' });
 			setScrollToItem(null);
 		}
-	});
+	}, [item.itemId, scrollToItem, setScrollToItem]);
 
 	const ribbonColor = useItemColorRibbon([], wornItem ?? null);
 

--- a/pandora-client-web/src/components/wardrobe/wardrobe.scss
+++ b/pandora-client-web/src/components/wardrobe/wardrobe.scss
@@ -37,6 +37,7 @@ $header-height: 2em;
 			canvas {
 				height: 100%;
 				width: 100%;
+				display: block;
 			}
 
 			.overlay {

--- a/pandora-client-web/src/components/wardrobe/wardrobeContext.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobeContext.tsx
@@ -8,6 +8,7 @@ import {
 	AssetFrameworkGlobalState,
 	EMPTY_ARRAY,
 	GetLogger,
+	ItemId,
 	Nullable,
 	ActionTargetSelector,
 } from 'pandora-common';
@@ -48,6 +49,7 @@ export function WardrobeContextProvider({ target, player, children }: { target: 
 	const actionPreviewState = useMemo(() => new Observable<AssetFrameworkGlobalState | null>(null), []);
 
 	const [heldItem, setHeldItem] = useState<WardrobeHeldItem>({ type: 'nothing' });
+	const [scrollToItem, setScrollToItem] = useState<ItemId | null>(null);
 
 	const actions = useMemo<AppearanceActionContext>(() => ({
 		player: player.gameLogicCharacter,
@@ -97,6 +99,8 @@ export function WardrobeContextProvider({ target, player, children }: { target: 
 		assetList,
 		heldItem,
 		setHeldItem,
+		scrollToItem,
+		setScrollToItem,
 		focus,
 		extraItemActions,
 		actions,
@@ -104,7 +108,7 @@ export function WardrobeContextProvider({ target, player, children }: { target: 
 		actionPreviewState,
 		showExtraActionButtons: settings.wardrobeExtraActionButtons,
 		showHoverPreview: settings.wardrobeHoverPreview,
-	}), [target, targetSelector, player, globalState, assetList, heldItem, focus, extraItemActions, actions, shardConnector, actionPreviewState, settings]);
+	}), [target, targetSelector, player, globalState, assetList, heldItem, scrollToItem, focus, extraItemActions, actions, shardConnector, actionPreviewState, settings]);
 
 	return (
 		<wardrobeContext.Provider value={ context }>

--- a/pandora-client-web/src/components/wardrobe/wardrobeItems.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobeItems.tsx
@@ -2,13 +2,16 @@ import classNames from 'classnames';
 import {
 	AssertNever,
 	Asset,
+	IsObject,
 	Item,
+	ItemId,
 	type ActionTargetSelector,
 } from 'pandora-common';
 import { SplitContainerPath } from 'pandora-common/dist/assets/appearanceHelpers';
 import { IItemModule } from 'pandora-common/dist/assets/modules/common';
 import { ItemModuleLockSlot } from 'pandora-common/dist/assets/modules/lockSlot';
 import React, { ReactElement, useCallback, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useAssetManager } from '../../assets/assetManager';
 import { useObservable } from '../../observable';
 import { Tab, TabContainer } from '../common/tabs/tabs';
@@ -98,8 +101,18 @@ export function useWardrobeItems(currentFocus: WardrobeFocus): {
 }
 
 export function WardrobeItemManipulation(): ReactElement {
-	const { target, targetSelector, assetList, heldItem, setHeldItem, focus } = useWardrobeContext();
+	const { target, targetSelector, assetList, heldItem, setHeldItem, focus, setScrollToItem } = useWardrobeContext();
+
+	const location = useLocation();
+	if (IsObject(location.state) && 'deviceId' in location.state) {
+		const focusItemId: ItemId = location.state.deviceId as ItemId;
+
+		focus.value = { container: [], itemId: focusItemId };
+		setScrollToItem(focusItemId);
+		location.state = {};
+	}
 	const currentFocus = useObservable(focus);
+
 	const { preFilter, containerContentsFilter, assetFilterAttributes } = useWardrobeItems(currentFocus);
 
 	const appearance = useWardrobeTargetItems(target);

--- a/pandora-client-web/src/components/wardrobe/wardrobeItems.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobeItems.tsx
@@ -10,7 +10,7 @@ import {
 import { SplitContainerPath } from 'pandora-common/dist/assets/appearanceHelpers';
 import { IItemModule } from 'pandora-common/dist/assets/modules/common';
 import { ItemModuleLockSlot } from 'pandora-common/dist/assets/modules/lockSlot';
-import React, { ReactElement, useCallback, useMemo } from 'react';
+import React, { ReactElement, useCallback, useEffect, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useAssetManager } from '../../assets/assetManager';
 import { useObservable } from '../../observable';
@@ -104,13 +104,15 @@ export function WardrobeItemManipulation(): ReactElement {
 	const { target, targetSelector, assetList, heldItem, setHeldItem, focus, setScrollToItem } = useWardrobeContext();
 
 	const location = useLocation();
-	if (IsObject(location.state) && 'deviceId' in location.state) {
-		const focusItemId: ItemId = location.state.deviceId as ItemId;
+	useEffect(() => {
+		if (IsObject(location.state) && 'deviceId' in location.state) {
+			const focusItemId: ItemId = location.state.deviceId as ItemId;
 
-		focus.value = { container: [], itemId: focusItemId };
-		setScrollToItem(focusItemId);
-		location.state = {};
-	}
+			focus.value = { container: [], itemId: focusItemId };
+			setScrollToItem(focusItemId);
+			location.state = {};
+		}
+	}, [focus, location, setScrollToItem]);
 	const currentFocus = useObservable(focus);
 
 	const { preFilter, containerContentsFilter, assetFilterAttributes } = useWardrobeItems(currentFocus);

--- a/pandora-client-web/src/components/wardrobe/wardrobeTypes.ts
+++ b/pandora-client-web/src/components/wardrobe/wardrobeTypes.ts
@@ -40,6 +40,8 @@ export interface WardrobeContext {
 	assetList: readonly Asset[];
 	heldItem: WardrobeHeldItem;
 	setHeldItem: (newHeldItem: WardrobeHeldItem) => void;
+	scrollToItem: ItemId | null;
+	setScrollToItem: (newScrollToItem: ItemId | null) => void;
 	focus: Observable<Immutable<WardrobeFocus>>;
 	extraItemActions: Observable<readonly WardrobeContextExtraItemActionComponent[]>;
 	actions: AppearanceActionContext;

--- a/pandora-client-web/src/editor/components/wardrobe/wardrobe.tsx
+++ b/pandora-client-web/src/editor/components/wardrobe/wardrobe.tsx
@@ -4,6 +4,7 @@ import {
 	AssetFrameworkGlobalState,
 	DoAppearanceAction,
 	EMPTY_ARRAY,
+	ItemId,
 } from 'pandora-common';
 import React, { ReactElement, ReactNode, useEffect, useMemo, useState } from 'react';
 import { useAssetManager } from '../../../assets/assetManager';
@@ -49,6 +50,7 @@ export function EditorWardrobeContextProvider({ children }: { children: ReactNod
 	const extraItemActions = useMemo(() => new Observable<readonly WardrobeContextExtraItemActionComponent[]>([]), []);
 	const actionPreviewState = useMemo(() => new Observable<AssetFrameworkGlobalState | null>(null), []);
 	const [heldItem, setHeldItem] = useState<WardrobeHeldItem>({ type: 'nothing' });
+	const [scrollToItem, setScrollToItem] = useState<ItemId | null>(null);
 
 	const actions = useMemo<AppearanceActionContext>(() => ({
 		player: character.gameLogicCharacter,
@@ -83,6 +85,8 @@ export function EditorWardrobeContextProvider({ children }: { children: ReactNod
 		assetList,
 		heldItem,
 		setHeldItem,
+		scrollToItem,
+		setScrollToItem,
 		focus,
 		extraItemActions,
 		actions,
@@ -107,7 +111,7 @@ export function EditorWardrobeContextProvider({ children }: { children: ReactNod
 		},
 		showExtraActionButtons: true,
 		showHoverPreview: true,
-	}), [character, globalState, assetList, heldItem, focus, extraItemActions, actions, actionPreviewState, assetManager, editor]);
+	}), [character, globalState, assetList, heldItem, scrollToItem, focus, extraItemActions, actions, actionPreviewState, assetManager, editor]);
 
 	return (
 		<wardrobeContext.Provider value={ context }>

--- a/pandora-client-web/src/graphics/room/contextMenus/deviceContextMenu.tsx
+++ b/pandora-client-web/src/graphics/room/contextMenus/deviceContextMenu.tsx
@@ -1,6 +1,7 @@
 import { nanoid } from 'nanoid';
 import { ItemRoomDevice, AppearanceAction, ItemId, ICharacterRoomData } from 'pandora-common';
 import React, { useMemo, useState, ReactElement, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router';
 import { Character, ICharacter, useCharacterData } from '../../../character/character';
 import { ChildrenProps } from '../../../common/reactTypes';
 import { PointLike } from '../../../graphics/graphicsCharacter';
@@ -262,6 +263,12 @@ function DeviceContextMenuCurrent({ device, position, setRoomSceneMode, onClose 
 	const player = usePlayer();
 	const gameState = useGameStateOptional();
 	const [menu, setMenu] = useState<'main' | 'slots'>('main');
+	const navigate = useNavigate();
+
+	const onCloseActual = useCallback(() => {
+		setMenu('main');
+		onClose();
+	}, [onClose]);
 
 	if (!player || !gameState) {
 		return null;
@@ -269,10 +276,13 @@ function DeviceContextMenuCurrent({ device, position, setRoomSceneMode, onClose 
 
 	return (
 		<div className='context-menu' ref={ ref } onPointerDown={ (e) => e.stopPropagation() }>
-			<span>
-				{ device.asset.definition.name }
-			</span>
 			<WardrobeContextProvider target={ WARDROBE_TARGET_ROOM } player={ player }>
+				<button onClick={ () => {
+					onCloseActual();
+					navigate('/wardrobe/room-inventory', { state: { deviceId: device.id } });
+				} }>
+					{ device.asset.definition.name }
+				</button>
 				{ menu === 'main' && (
 					<>
 						<LeaveDeviceMenu device={ device } close={ onClose } />


### PR DESCRIPTION
This adds a shortcut from room devices' context menus to their menus in the room inventory view.

It is fully working as far as I know, but this is my first contribution to pandora and first time working with react, so there are a few design decisions and technical points I'm unsure of and I'd like to get opinions on:

**Design decision:**
- I turned the menu's header with the device name into the button to reach the inventory in order to save space, but maybe you'd prefer having a different button lower in the menu?

**Technical points:**
- Is the location state the right tool to pass the information to the inventory page? Or would it be better to use something else, e.g an optional route parameter.
- If so, is it the right way to clear the location state after use?
- I wanted the list of room items to scroll to the item we're focusing. I added a state in the wardrobe context for that. Is there a better way to pass the information?