### PR TITLE
[FEATURE] Autokick of ghost characters

### DIFF
--- a/pandora-client-web/.eslintrc.json
+++ b/pandora-client-web/.eslintrc.json
@@ -14,7 +14,12 @@
 		{
 			"files": ["*.ts", "*.tsx"],
 			"parserOptions": {
-				"project": ["./tsconfig.json", "./test/tsconfig.json", "./tsconfig.webpack.json"],
+				"project": [
+					"./tsconfig.json",
+					"./test/tsconfig.json",
+					"./test/tsconfig.setup.json",
+					"./tsconfig.webpack.json"
+				],
 				"sourceType": "module"
 			},
 			"rules": {

--- a/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.tsx
+++ b/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.tsx
@@ -412,7 +412,11 @@ export function SpaceConfiguration({ creation = false }: { creation?: boolean; }
 										checked={ currentConfig.ghostManagement != null }
 										onChange={ (event) => {
 											setModifiedData({
-												ghostManagement: event.target.checked ? { ignore: 'admin', timer: 2 } : null,
+												ghostManagement: event.target.checked ? {
+													ignore: 'admin',
+													timer: 2,
+													affectCharactersInRoomDevice: false,
+												} : null,
 											});
 										} }
 										readOnly={ !canEdit }
@@ -448,6 +452,8 @@ function GhostManagement({ config, setConfig, canEdit }: {
 	setConfig: (newConfig: SpaceGhostManagementConfig) => void;
 	canEdit: boolean;
 }): ReactElement {
+	const idPrefix = useId();
+
 	return (
 		<>
 			<Column>
@@ -483,6 +489,21 @@ function GhostManagement({ config, setConfig, canEdit }: {
 					allowed: 'Owner, Admin, or on the Allowlist',
 				} }
 			/>
+			<Row>
+				<input
+					id={ `${idPrefix}-ghostmanagement-room-devices` }
+					type='checkbox'
+					checked={ config.affectCharactersInRoomDevice }
+					onChange={ (event) => {
+						setConfig({
+							...config,
+							affectCharactersInRoomDevice: event.target.checked,
+						});
+					} }
+					readOnly={ !canEdit }
+				/>
+				<label htmlFor={ `${idPrefix}-ghostmanagement-room-devices` }>Also affect characters in the slots of room-level items</label>
+			</Row>
 		</>
 	);
 }

--- a/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.tsx
+++ b/pandora-client-web/src/ui/screens/spaceConfiguration/spaceConfiguration.tsx
@@ -1,59 +1,62 @@
+import { Immutable } from 'immer';
 import { noop, uniq } from 'lodash';
 import {
-	SpaceFeature,
-	EMPTY,
-	GetLogger,
-	SpaceDirectoryConfig,
-	IDirectoryShardInfo,
-	SpaceBaseInfoSchema,
-	ZodMatcher,
-	DEFAULT_BACKGROUND,
-	IsObject,
 	AccountId,
-	AssertNotNullable,
-	SpaceId,
-	RoomBackgroundTagDefinition,
-	AssetManager,
-	RoomBackgroundInfo,
-	LIMIT_SPACE_DESCRIPTION_LENGTH,
-	LIMIT_SPACE_NAME_LENGTH,
-	LIMIT_SPACE_MAX_CHARACTER_NUMBER,
-	CloneDeepMutable,
-	SpaceInvite,
-	FormatTimeInterval,
 	AssertNever,
+	AssertNotNullable,
+	AssetManager,
+	CloneDeepMutable,
+	DEFAULT_BACKGROUND,
+	EMPTY,
+	FormatTimeInterval,
+	GetLogger,
+	IDirectoryShardInfo,
 	IsAuthorized,
+	IsObject,
+	LIMIT_SPACE_DESCRIPTION_LENGTH,
+	LIMIT_SPACE_MAX_CHARACTER_NUMBER,
+	LIMIT_SPACE_NAME_LENGTH,
+	RoomBackgroundInfo,
+	RoomBackgroundTagDefinition,
+	SpaceBaseInfoSchema,
+	SpaceDirectoryConfig,
+	SpaceFeature,
+	SpaceGhostManagementConfigSchema,
+	SpaceId,
+	SpaceInvite,
+	ZodMatcher,
+	type SpaceGhostManagementConfig,
 } from 'pandora-common';
 import React, { ReactElement, ReactNode, useCallback, useEffect, useId, useMemo, useReducer, useRef, useState } from 'react';
 import { Link, Navigate, useNavigate } from 'react-router-dom';
-import { DirectoryConnector } from '../../../networking/directoryConnector';
-import { PersistentToast, TOAST_OPTIONS_ERROR } from '../../../persistentToast';
+import { toast } from 'react-toastify';
+import { GetAssetsSourceUrl, useAssetManager } from '../../../assets/assetManager';
+import { CopyToClipboard } from '../../../common/clipboard';
+import { useCurrentTime } from '../../../common/useCurrentTime';
+import { useAsyncEvent } from '../../../common/useEvent';
+import { useInputAutofocus } from '../../../common/userInteraction/inputAutofocus';
 import { Button } from '../../../components/common/button/button';
+import { ColorInput } from '../../../components/common/colorInput/colorInput';
+import { Column, Row } from '../../../components/common/container/container';
+import { FieldsetToggle } from '../../../components/common/fieldsetToggle';
+import { Scrollbar } from '../../../components/common/scrollbar/scrollbar';
+import { Select } from '../../../components/common/select/select';
+import { SelectionIndicator } from '../../../components/common/selectionIndicator/selectionIndicator';
+import { Tab, TabContainer } from '../../../components/common/tabs/tabs';
+import { ModalDialog, useConfirmDialog } from '../../../components/dialog/dialog';
 import {
 	useCurrentAccount,
 	useDirectoryChangeListener,
 	useDirectoryConnector,
 } from '../../../components/gameContext/directoryConnectorContextProvider';
 import { CurrentSpaceInfo, IsSpaceAdmin, useSpaceInfo } from '../../../components/gameContext/gameStateContextProvider';
-import { GetAssetsSourceUrl, useAssetManager } from '../../../assets/assetManager';
-import { Select } from '../../../components/common/select/select';
-import { ModalDialog, useConfirmDialog } from '../../../components/dialog/dialog';
-import { Column, Row } from '../../../components/common/container/container';
+import { SelectSettingInput } from '../../../components/settings/helpers/settingsInputs';
 import bodyChange from '../../../icons/body-change.svg';
 import devMode from '../../../icons/developer.svg';
 import pronounChange from '../../../icons/male-female.svg';
-import { FieldsetToggle } from '../../../components/common/fieldsetToggle';
+import { DirectoryConnector } from '../../../networking/directoryConnector';
+import { PersistentToast, TOAST_OPTIONS_ERROR } from '../../../persistentToast';
 import './spaceConfiguration.scss';
-import { ColorInput } from '../../../components/common/colorInput/colorInput';
-import { SelectionIndicator } from '../../../components/common/selectionIndicator/selectionIndicator';
-import { Scrollbar } from '../../../components/common/scrollbar/scrollbar';
-import { Immutable } from 'immer';
-import { useAsyncEvent } from '../../../common/useEvent';
-import { useCurrentTime } from '../../../common/useCurrentTime';
-import { toast } from 'react-toastify';
-import { CopyToClipboard } from '../../../common/clipboard';
-import { useInputAutofocus } from '../../../common/userInteraction/inputAutofocus';
-import { Tab, TabContainer } from '../../../components/common/tabs/tabs';
 
 const IsValidName = ZodMatcher(SpaceBaseInfoSchema.shape.name);
 const IsValidDescription = ZodMatcher(SpaceBaseInfoSchema.shape.description);
@@ -69,6 +72,7 @@ function DefaultConfig(): SpaceDirectoryConfig {
 		public: false,
 		features: [],
 		background: CloneDeepMutable(DEFAULT_BACKGROUND),
+		ghostManagement: null,
 	};
 }
 
@@ -399,6 +403,35 @@ export function SpaceConfiguration({ creation = false }: { creation?: boolean; }
 								<NumberListArea values={ currentConfig.allow } setValues={ (allow) => setModifiedData({ allow }) } readOnly={ !canEdit } invalid={ invalidAllow } />
 							</div>
 						</FieldsetToggle>
+						<FieldsetToggle legend='Offline character management'>
+							<Column>
+								<Row>
+									<input
+										id={ `${idPrefix}-ghostmanagement-enable` }
+										type='checkbox'
+										checked={ currentConfig.ghostManagement != null }
+										onChange={ (event) => {
+											setModifiedData({
+												ghostManagement: event.target.checked ? { ignore: 'admin', timer: 2 } : null,
+											});
+										} }
+										readOnly={ !canEdit }
+									/>
+									<label htmlFor={ `${idPrefix}-ghostmanagement-enable` }>Enable automatic offline character removal</label>
+								</Row>
+								{
+									currentConfig.ghostManagement != null ? (
+										<GhostManagement
+											config={ currentConfig.ghostManagement }
+											setConfig={ (newConfig) => {
+												setModifiedData({ ghostManagement: newConfig });
+											} }
+											canEdit={ canEdit }
+										/>
+									) : null
+								}
+							</Column>
+						</FieldsetToggle>
 						{ (!creation && currentSpaceId != null) && <SpaceInvites spaceId={ currentSpaceId } isPlayerAdmin={ isPlayerAdmin } /> }
 						<br />
 						{ canEdit && <Button className='fill-x' onClick={ () => UpdateSpace(directoryConnector, modifiedData, () => navigate('/room')) }>Update space</Button> }
@@ -407,6 +440,50 @@ export function SpaceConfiguration({ creation = false }: { creation?: boolean; }
 				<Tab name='◄ Back' tabClassName='slim' onClick={ () => navigate('/room') } />
 			</TabContainer>
 		</div>
+	);
+}
+
+function GhostManagement({ config, setConfig, canEdit }: {
+	config: SpaceGhostManagementConfig;
+	setConfig: (newConfig: SpaceGhostManagementConfig) => void;
+	canEdit: boolean;
+}): ReactElement {
+	return (
+		<>
+			<Column>
+				<label>Autokick offline characters after (minutes)</label>
+				<input
+					type='number'
+					min={ 0 }
+					value={ config.timer }
+					onChange={ (e) => {
+						setConfig({
+							...config,
+							timer: e.target.valueAsNumber,
+						});
+					} }
+					readOnly={ !canEdit }
+				/>
+			</Column>
+			<SelectSettingInput<SpaceGhostManagementConfig['ignore']>
+				currentValue={ config.ignore }
+				defaultValue='admin'
+				label='Ignore characters that are'
+				onChange={ (newValue) => {
+					setConfig({
+						...config,
+						ignore: newValue,
+					});
+				} }
+				schema={ SpaceGhostManagementConfigSchema.shape.ignore }
+				stringify={ {
+					none: '[None] (all characters are affected)',
+					owner: 'Owner',
+					admin: 'Owner or Admin',
+					allowed: 'Owner, Admin, or on the Allowlist',
+				} }
+			/>
+		</>
 	);
 }
 

--- a/pandora-client-web/test/tsconfig.json
+++ b/pandora-client-web/test/tsconfig.json
@@ -7,12 +7,17 @@
 		],
 		"types": [
 			"@types/jest",
+			"@testing-library/jest-dom",
 			"offscreencanvas"
 		],
 		"jsx": "react"
 	},
 	"include": [
 		"../src/**/*.d.ts",
-		"./**/*"
+		"../src/**/*.ts",
+		"./**/*.ts"
+	],
+	"exclude": [
+		"./setup.ts"
 	]
 }

--- a/pandora-client-web/test/tsconfig.setup.json
+++ b/pandora-client-web/test/tsconfig.setup.json
@@ -8,18 +8,12 @@
 		"types": [
 			"@types/jest",
 			"@testing-library/jest-dom",
+			"@types/node",
 			"offscreencanvas"
 		],
 		"jsx": "react"
 	},
 	"include": [
-		"../src/**/*.d.ts",
-		"../src/**/*.ts",
-		"../src/**/*.tsx",
-		"./**/*.ts",
-		"./**/*.tsx"
-	],
-	"exclude": [
 		"./setup.ts"
 	]
 }

--- a/pandora-common/src/chat/chatActions.ts
+++ b/pandora-common/src/chat/chatActions.ts
@@ -8,6 +8,7 @@ const CHAT_ACTIONS_DEF = {
 	characterDisconnected: 'SOURCE_CHARACTER disconnected.',
 	characterReconnected: 'SOURCE_CHARACTER reconnected.',
 	characterKicked: 'TARGET_CHARACTER has been kicked by SOURCE_CHARACTER.',
+	characterAutoKicked: `TARGET_CHARACTER left with the help of Pandora's Space Service.`,
 	characterBanned: 'TARGET_CHARACTER has been banned by SOURCE_CHARACTER.',
 
 	spaceUpdatedSingle: `SOURCE_CHARACTER changed the spaces's CHANGE.`,

--- a/pandora-common/src/networking/shard_directory.ts
+++ b/pandora-common/src/networking/shard_directory.ts
@@ -39,6 +39,14 @@ export const ShardDirectorySchema = {
 		}),
 		response: null,
 	},
+	characterAutomod: {
+		request: z.object({
+			id: CharacterIdSchema,
+			action: z.enum(['kick']),
+			reason: z.enum(['ghostManagement']),
+		}),
+		response: null,
+	},
 	characterError: {
 		request: z.object({
 			id: CharacterIdSchema,

--- a/pandora-common/src/space/room.ts
+++ b/pandora-common/src/space/room.ts
@@ -103,7 +103,7 @@ export function IsValidRoomPosition(roomBackground: Immutable<RoomBackgroundData
 
 export function GenerateInitialRoomPosition(roomBackground: Immutable<RoomBackgroundData>): CharacterRoomPosition {
 	// Random spread to use for the positioning
-	const spreadX = 200;
+	const spreadX = 1000;
 	const spreadY = 100;
 
 	// Absolute bounds of the background

--- a/pandora-common/src/space/space.ts
+++ b/pandora-common/src/space/space.ts
@@ -82,6 +82,24 @@ export const SpaceDevelopmentConfigSchema = z.object({
 });
 export type SpaceDevelopmentConfig = z.infer<typeof SpaceDevelopmentConfigSchema>;
 
+export const SpaceGhostManagementConfigSchema = z.object({
+	/**
+	 * Which characters to exclude from automatic ghost management.
+	 * - `none` = applies to all characters
+	 * - `owner` = Owners are excluded
+	 * - `admin` = Owners and admins are excluded
+	 * - `allowed` = Owners, admins, and people on allowlist are excluded
+	 */
+	ignore: z.enum(['none', 'owner', 'admin', 'allowed']),
+	/**
+	 * Time to kick ghost characters in minutes.
+	 * This timer might reset itself seemingly sporadically.
+	 */
+	timer: z.number().nonnegative(),
+});
+
+export type SpaceGhostManagementConfig = z.infer<typeof SpaceGhostManagementConfigSchema>;
+
 export const SpaceDirectoryConfigSchema = SpaceBaseInfoSchema.extend({
 	/** The requested features */
 	features: z.array(SpaceFeatureSchema).max(SpaceFeatureSchema.options.length),
@@ -97,6 +115,8 @@ export const SpaceDirectoryConfigSchema = SpaceBaseInfoSchema.extend({
 	allow: AccountIdSchema.array().default([]),
 	/** The ID of the background or custom data */
 	background: z.union([z.string(), RoomBackgroundDataSchema.extend({ image: HexColorStringSchema.catch('#1099bb') })]).catch(CloneDeepMutable(DEFAULT_BACKGROUND)),
+	/** Automatic space ghost management settings. `null` if disabled completely. */
+	ghostManagement: SpaceGhostManagementConfigSchema.nullable().default(null),
 });
 export type SpaceDirectoryConfig = z.infer<typeof SpaceDirectoryConfigSchema>;
 
@@ -164,4 +184,4 @@ export const SpaceDirectoryDataSchema = SpaceDataSchema.pick(ArrayToRecordKeys(S
 export type SpaceDirectoryData = z.infer<typeof SpaceDirectoryDataSchema>;
 
 /** Reason for why a character left (was removed from) a space */
-export type SpaceLeaveReason = 'leave' | 'disconnect' | 'destroy' | 'error' | 'kick' | 'ban';
+export type SpaceLeaveReason = 'leave' | 'disconnect' | 'destroy' | 'error' | 'kick' | 'ban' | 'automodKick';

--- a/pandora-common/src/space/space.ts
+++ b/pandora-common/src/space/space.ts
@@ -96,6 +96,10 @@ export const SpaceGhostManagementConfigSchema = z.object({
 	 * This timer might reset itself seemingly sporadically.
 	 */
 	timer: z.number().nonnegative(),
+	/**
+	 * Whether the mechanism should affect characters that are in room devices or not.
+	 */
+	affectCharactersInRoomDevice: z.boolean().default(false),
 });
 
 export type SpaceGhostManagementConfig = z.infer<typeof SpaceGhostManagementConfigSchema>;

--- a/pandora-server-directory/src/networking/manager_shard.ts
+++ b/pandora-server-directory/src/networking/manager_shard.ts
@@ -28,6 +28,7 @@ export const ConnectionManagerShard = new class ConnectionManagerShard implement
 			shardRegister: this.handleShardRegister.bind(this),
 			shardRequestStop: this.handleShardRequestStop.bind(this),
 			characterClientDisconnect: this.handleCharacterClientDisconnect.bind(this),
+			characterAutomod: this.handleCharacterAutomod.bind(this),
 			characterError: this.handleCharacterError.bind(this),
 			spaceError: this.handleSpaceError.bind(this),
 			createCharacter: this.createCharacter.bind(this),
@@ -75,6 +76,20 @@ export const ConnectionManagerShard = new class ConnectionManagerShard implement
 			throw new BadMessageError();
 
 		await character.disconnect();
+	}
+
+	private async handleCharacterAutomod({ id, action, reason }: IShardDirectoryArgument['characterAutomod'], connection: IConnectionShard): Promise<void> {
+		const shard = connection.shard;
+		if (!shard)
+			throw new BadMessageError();
+		const character = shard.getConnectedCharacter(id);
+		if (!character)
+			throw new BadMessageError();
+
+		const space = character.space;
+		if (space != null) {
+			await space.automodAction(id, action, reason);
+		}
 	}
 
 	private async handleCharacterError({ id }: IShardDirectoryArgument['characterError'], connection: IConnectionShard): Promise<void> {

--- a/pandora-server-directory/test/spaces/testData.ts
+++ b/pandora-server-directory/test/spaces/testData.ts
@@ -11,6 +11,7 @@ const TEST_SPACE_DEFAULTS: Readonly<SpaceDirectoryConfig> = {
 	public: true,
 	features: [],
 	background: CloneDeepMutable(DEFAULT_BACKGROUND),
+	ghostManagement: null,
 };
 
 export const TEST_SPACE: Readonly<SpaceDirectoryConfig> = {

--- a/pandora-server-shard/src/character/character.ts
+++ b/pandora-server-shard/src/character/character.ts
@@ -1,57 +1,57 @@
 import {
+	AccountRole,
 	AppearanceActionContext,
+	AppearanceBundle,
+	Assert,
 	AssertNever,
+	AssertNotNullable,
+	AssetFrameworkCharacterState,
+	AssetFrameworkGlobalStateContainer,
 	AssetManager,
+	AssetPreferencesPublic,
+	AsyncSynchronized,
+	CHARACTER_SHARD_UPDATEABLE_PROPERTIES,
+	CharacterDataSchema,
 	CharacterId,
+	CharacterRestrictionsManager,
+	CharacterRoomPosition,
+	CleanupAssetPreferences,
+	CloneDeepMutable,
+	GameLogicCharacterServer,
+	GenerateInitialRoomPosition,
+	GetDefaultAppearanceBundle,
 	GetLogger,
 	ICharacterData,
 	ICharacterDataShardUpdate,
+	ICharacterPrivateData,
 	ICharacterPublicData,
 	ICharacterPublicSettings,
-	IChatMessage,
-	IShardCharacterDefinition,
-	Logger,
-	SpaceId,
-	IsAuthorized,
-	AccountRole,
-	IShardAccountDefinition,
-	CharacterDataSchema,
-	AssetFrameworkGlobalStateContainer,
-	AssetFrameworkCharacterState,
-	AppearanceBundle,
-	Assert,
-	AssertNotNullable,
-	ICharacterPrivateData,
-	CharacterRestrictionsManager,
-	AsyncSynchronized,
-	GetDefaultAppearanceBundle,
-	CharacterRoomPosition,
-	GameLogicCharacterServer,
-	IShardClientChangeEvents,
-	NOT_NARROWING_FALSE,
-	AssetPreferencesPublic,
-	ResolveAssetPreference,
-	KnownObject,
-	CleanupAssetPreferences,
-	CHARACTER_SHARD_UPDATEABLE_PROPERTIES,
-	CloneDeepMutable,
-	ROOM_INVENTORY_BUNDLE_DEFAULT,
 	ICharacterRoomData,
-	RoomBackgroundData,
+	IChatMessage,
+	IShardAccountDefinition,
+	IShardCharacterDefinition,
+	IShardClientChangeEvents,
+	IsAuthorized,
 	IsValidRoomPosition,
-	GenerateInitialRoomPosition,
+	KnownObject,
+	Logger,
+	NOT_NARROWING_FALSE,
+	ROOM_INVENTORY_BUNDLE_DEFAULT,
+	ResolveAssetPreference,
+	RoomBackgroundData,
+	SpaceId,
 } from 'pandora-common';
-import { DirectoryConnector } from '../networking/socketio_directory_connector';
-import type { Space } from '../spaces/space';
-import { SpaceManager } from '../spaces/spaceManager';
+import { assetManager } from '../assets/assetManager';
 import { GetDatabase } from '../database/databaseProvider';
 import { ClientConnection } from '../networking/connection_client';
+import { DirectoryConnector } from '../networking/socketio_directory_connector';
 import { PersonalSpace } from '../spaces/personalSpace';
-import { assetManager } from '../assets/assetManager';
+import type { Space } from '../spaces/space';
+import { SpaceManager } from '../spaces/spaceManager';
 
-import _, { isEqual } from 'lodash';
-import { diffString } from 'json-diff';
 import { Immutable } from 'immer';
+import { diffString } from 'json-diff';
+import _, { isEqual } from 'lodash';
 
 /** Time (in ms) after which manager prunes character without any active connection */
 export const CHARACTER_TIMEOUT = 30_000;
@@ -73,6 +73,7 @@ export class Character {
 	private readonly data: Omit<ICharacterData, ManuallyGeneratedKeys>;
 	public accountData: IShardAccountDefinition;
 	public connectSecret: string | null;
+	public lastOnline: number;
 
 	private readonly _personalSpace: PersonalSpace;
 
@@ -192,6 +193,7 @@ export class Character {
 		this.data = data;
 		this.accountData = account;
 		this.connectSecret = connectSecret;
+		this.lastOnline = Date.now();
 
 		this._personalSpace = new PersonalSpace(this, data.personalRoom?.inventory ?? CloneDeepMutable(ROOM_INVENTORY_BUNDLE_DEFAULT));
 
@@ -271,6 +273,9 @@ export class Character {
 			if (data.connectSecret == null && this._clientTimeout != null) {
 				clearInterval(this._clientTimeout);
 				this._clientTimeout = null;
+			}
+			if (oldOnline || this.isOnline) {
+				this.lastOnline = Date.now();
 			}
 			if (this.isOnline !== oldOnline) {
 				// Clear waiting messages when going offline

--- a/pandora-server-shard/src/spaces/personalSpace.ts
+++ b/pandora-server-shard/src/spaces/personalSpace.ts
@@ -1,8 +1,8 @@
-import { Space } from './space';
-import { Character } from '../character/character';
-import { AccountId, DEFAULT_BACKGROUND, GetLogger, SpaceDirectoryConfig, RoomInventoryBundle } from 'pandora-common';
 import { cloneDeep } from 'lodash';
+import { AccountId, DEFAULT_BACKGROUND, GetLogger, RoomInventoryBundle, SpaceDirectoryConfig } from 'pandora-common';
 import { assetManager } from '../assets/assetManager';
+import { Character } from '../character/character';
+import { Space } from './space';
 
 export class PersonalSpace extends Space {
 	private readonly _character: Character;
@@ -29,6 +29,7 @@ export class PersonalSpace extends Space {
 			// Try to use the first background (if there is some)
 			// otherwise default to the default, solid-color background (important for tests that don't have any assets).
 			background: assetManager.getBackgrounds()[0].id ?? cloneDeep(DEFAULT_BACKGROUND),
+			ghostManagement: null,
 		};
 	}
 

--- a/pandora-server-shard/src/spaces/publicSpace.ts
+++ b/pandora-server-shard/src/spaces/publicSpace.ts
@@ -115,6 +115,14 @@ export class PublicSpace extends Space {
 				if (ignore)
 					continue;
 
+				// Check if the character is in a room device
+				if (!this.config.ghostManagement.affectCharactersInRoomDevice) {
+					const restrictionManager = character.getRestrictionManager();
+
+					if (restrictionManager.getRoomDeviceLink() != null)
+						continue;
+				}
+
 				// Check if the character has been offline for long enough
 				if (Date.now() > (character.lastOnline + (this.config.ghostManagement.timer * 60_000))) {
 					DirectoryConnector.sendMessage('characterAutomod', {

--- a/pandora-server-shard/src/spaces/publicSpace.ts
+++ b/pandora-server-shard/src/spaces/publicSpace.ts
@@ -1,24 +1,26 @@
+import { diffString } from 'json-diff';
+import _, { omit, pick } from 'lodash';
 import {
 	AccountId,
+	AssertNever,
 	AsyncSynchronized,
-	SPACE_SHARD_UPDATEABLE_PROPERTIES,
-	SpaceDataSchema,
+	GameStateUpdate,
+	GenerateInitialRoomPosition,
 	GetLogger,
+	IShardSpaceDefinition,
+	IsValidRoomPosition,
+	ResolveBackground,
+	SPACE_SHARD_UPDATEABLE_PROPERTIES,
 	SpaceData,
+	SpaceDataSchema,
 	SpaceDataShardUpdate,
 	SpaceDirectoryConfig,
-	GameStateUpdate,
-	IShardSpaceDefinition,
-	ResolveBackground,
 	SpaceId,
-	IsValidRoomPosition,
-	GenerateInitialRoomPosition,
 } from 'pandora-common';
-import { Space } from './space';
 import { assetManager } from '../assets/assetManager';
 import { GetDatabase } from '../database/databaseProvider';
-import _, { omit, pick } from 'lodash';
-import { diffString } from 'json-diff';
+import { DirectoryConnector } from '../networking/socketio_directory_connector';
+import { Space } from './space';
 
 export class PublicSpace extends Space {
 	private readonly data: IShardSpaceDefinition;
@@ -84,6 +86,45 @@ export class PublicSpace extends Space {
 		this.save().catch((err) => {
 			this.logger.error('Periodic save failed:', err);
 		});
+
+		// Automod characters
+		if (this.config.ghostManagement != null) {
+			for (const character of this.characters) {
+				if (character.isOnline)
+					continue;
+
+				let ignore: boolean;
+
+				switch (this.config.ghostManagement.ignore) {
+					case 'allowed':
+						ignore = this.isAllowed(character);
+						break;
+					case 'admin':
+						ignore = this.isAdmin(character);
+						break;
+					case 'owner':
+						ignore = this.isOwner(character);
+						break;
+					case 'none':
+						ignore = false;
+						break;
+					default:
+						AssertNever(this.config.ghostManagement.ignore);
+				}
+
+				if (ignore)
+					continue;
+
+				// Check if the character has been offline for long enough
+				if (Date.now() > (character.lastOnline + (this.config.ghostManagement.timer * 60_000))) {
+					DirectoryConnector.sendMessage('characterAutomod', {
+						id: character.id,
+						action: 'kick',
+						reason: 'ghostManagement',
+					});
+				}
+			}
+		}
 	}
 
 	protected override _onDataModified(data: 'inventory'): void {


### PR DESCRIPTION
Adds ability to configure automatic kick of offline characters.
The scan for offline characters happens regularly by Shard and checks if character has been offline for X minutes before requesting Directory to kick it. If the request fails for whatever reason, it will be re-attempted during the next cycle.
Also has an option to ignore Owners/Admins/VIPs of a space.

Additionally increased the randomness of initial position generation 5-fold.