### PR TITLE
[CHANGE] Improve robustness of DM encryption checks

### DIFF
--- a/pandora-client-web/src/components/directMessage/directMessage.tsx
+++ b/pandora-client-web/src/components/directMessage/directMessage.tsx
@@ -1,26 +1,26 @@
-import { IDirectoryAccountInfo, IDirectoryDirectMessageAccount, LIMIT_DIRECT_MESSAGE_LENGTH } from 'pandora-common';
+import classNames from 'classnames';
+import { GetLogger, IDirectoryAccountInfo, IDirectoryDirectMessageAccount, LIMIT_DIRECT_MESSAGE_LENGTH } from 'pandora-common';
 import React, { ReactElement, useMemo } from 'react';
+import { useNavigate } from 'react-router';
 import { toast } from 'react-toastify';
 import { useAutoScroll } from '../../common/useAutoScroll';
 import { useEvent } from '../../common/useEvent';
+import { useTextFormattingOnKeyboardEvent } from '../../common/useTextFormattingOnKeyboardEvent';
+import { useInputAutofocus } from '../../common/userInteraction/inputAutofocus';
 import { DirectMessage } from '../../networking/directMessageManager';
 import { useObservable } from '../../observable';
 import { TOAST_OPTIONS_ERROR } from '../../persistentToast';
+import { AutoCompleteHint, IChatInputHandler, chatInputContext, useChatInput } from '../../ui/components/chat/chatInput';
 import { RenderChatPart } from '../../ui/components/chat/chatMessages';
+import { AutocompleteDisplayData, COMMAND_KEY, CommandAutocomplete, CommandAutocompleteCycle, ICommandInvokeContext, RunCommand } from '../../ui/components/chat/commandsProcessor';
+import { Column } from '../common/container/container';
 import { Scrollable } from '../common/scrollbar/scrollbar';
 import { DirectMessageChannelProvider, useDirectMessageChannel } from '../gameContext/directMessageChannelProvieder';
-import { useCurrentAccount, useDirectoryConnector, useAccountSettings } from '../gameContext/directoryConnectorContextProvider';
-import './directMessage.scss';
-import { useTextFormattingOnKeyboardEvent } from '../../common/useTextFormattingOnKeyboardEvent';
-import classNames from 'classnames';
-import { AutoCompleteHint, IChatInputHandler, chatInputContext, useChatInput } from '../../ui/components/chat/chatInput';
-import { DIRECT_MESSAGE_COMMANDS, DirectMessageCommandExecutionContext } from './directMessageCommandContext';
-import { useShardConnector } from '../gameContext/shardConnectorContextProvider';
+import { useAccountSettings, useCurrentAccount, useDirectoryConnector } from '../gameContext/directoryConnectorContextProvider';
 import { useGameStateOptional } from '../gameContext/gameStateContextProvider';
-import { useNavigate } from 'react-router';
-import { AutocompleteDisplayData, COMMAND_KEY, CommandAutocomplete, CommandAutocompleteCycle, ICommandInvokeContext, RunCommand } from '../../ui/components/chat/commandsProcessor';
-import { useInputAutofocus } from '../../common/userInteraction/inputAutofocus';
-import { Column } from '../common/container/container';
+import { useShardConnector } from '../gameContext/shardConnectorContextProvider';
+import './directMessage.scss';
+import { DIRECT_MESSAGE_COMMANDS, DirectMessageCommandExecutionContext } from './directMessageCommandContext';
 
 export function DirectMessage({ accountId }: { accountId: number; }): ReactElement {
 	const ref = React.useRef<HTMLTextAreaElement>(null);
@@ -176,7 +176,10 @@ function DirectChannelInputImpl(_: unknown, ref: React.ForwardedRef<HTMLTextArea
 				return false;
 			}
 			channel.sendMessage(input, editing?.target)
-				.catch((e) => toast(`Failed to send message: ${e as string}`, TOAST_OPTIONS_ERROR));
+				.catch((e) => {
+					toast(`Failed to send message: ${String(e)}`, TOAST_OPTIONS_ERROR);
+					GetLogger('DirectMessage').error('Failed to send message:', e);
+				});
 
 			return true;
 		}

--- a/pandora-client-web/src/crypto/symmetric.ts
+++ b/pandora-client-web/src/crypto/symmetric.ts
@@ -1,10 +1,15 @@
-import { Encode, ArrayToBase64, Base64ToArray, Decode, GenerateIV } from './helpers';
-
-const subtle = globalThis.crypto.subtle;
+import { Assert } from 'pandora-common';
+import { ArrayToBase64, Base64ToArray, Decode, Encode, GenerateIV } from './helpers';
 
 const AES_GCM_PARAMS = { name: 'AES-GCM', length: 256 } as const;
 const AES_GCM_KEY_USAGES: readonly KeyUsage[] = ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'];
 const PBKDF2_PARAMS = { name: 'PBKDF2', iterations: 100_000, hash: 'SHA-512' } as const;
+
+function GetSubtle(): SubtleCrypto {
+	const subtle = globalThis.crypto.subtle;
+	Assert(subtle != null, 'Missing crypto.subtle support');
+	return subtle;
+}
 
 export class SymmetricEncryption {
 	#key: CryptoKey;
@@ -15,34 +20,34 @@ export class SymmetricEncryption {
 
 	public async encrypt(text: string): Promise<string> {
 		const { iv, alg } = GenerateIV();
-		const encrypted = await subtle.encrypt(alg, this.#key, Encode(text));
+		const encrypted = await GetSubtle().encrypt(alg, this.#key, Encode(text));
 		return iv + ':' + ArrayToBase64(new Uint8Array(encrypted));
 	}
 
 	public async decrypt(text: string): Promise<string> {
 		const [iv, encrypted] = text.split(':');
-		const decrypted = await subtle.decrypt(GenerateIV(iv).alg, this.#key, Base64ToArray(encrypted));
+		const decrypted = await GetSubtle().decrypt(GenerateIV(iv).alg, this.#key, Base64ToArray(encrypted));
 		return Decode(new Uint8Array(decrypted));
 	}
 
 	public async wrapKey(key: CryptoKey): Promise<{ iv: string; encrypted: string; }> {
 		const { iv, alg } = GenerateIV();
-		const encryptedKey = await subtle.wrapKey('pkcs8', key, this.#key, alg);
+		const encryptedKey = await GetSubtle().wrapKey('pkcs8', key, this.#key, alg);
 		return { iv, encrypted: ArrayToBase64(new Uint8Array(encryptedKey)) };
 	}
 
 	public async unwrapKey(iv: string, key: string, params: RsaHashedImportParams | EcKeyImportParams, usage: KeyUsage[]): Promise<CryptoKey> {
-		return await subtle.unwrapKey('pkcs8', Base64ToArray(key), this.#key, GenerateIV(iv).alg, params, true, usage);
+		return await GetSubtle().unwrapKey('pkcs8', Base64ToArray(key), this.#key, GenerateIV(iv).alg, params, true, usage);
 	}
 
 	public static async generate(gen?: { password: string; salt: Uint8Array; }): Promise<SymmetricEncryption> {
 		let key: CryptoKey | undefined;
 		if (gen === undefined) {
-			key = await subtle.generateKey(AES_GCM_PARAMS, true, AES_GCM_KEY_USAGES);
+			key = await GetSubtle().generateKey(AES_GCM_PARAMS, true, AES_GCM_KEY_USAGES);
 		} else {
 			const { password, salt } = gen;
-			const pbkdf2 = await subtle.importKey('raw', Encode(password), { name: 'PBKDF2' }, false, ['deriveKey']);
-			key = await subtle.deriveKey({
+			const pbkdf2 = await GetSubtle().importKey('raw', Encode(password), { name: 'PBKDF2' }, false, ['deriveKey']);
+			key = await GetSubtle().deriveKey({
 				...PBKDF2_PARAMS,
 				salt,
 			}, pbkdf2, AES_GCM_PARAMS, true, [...AES_GCM_KEY_USAGES]);
@@ -51,7 +56,7 @@ export class SymmetricEncryption {
 	}
 
 	public static async derive(publicKey: CryptoKey, privateKey: CryptoKey): Promise<SymmetricEncryption> {
-		const sharedKey = await subtle.deriveKey(
+		const sharedKey = await GetSubtle().deriveKey(
 			{ name: 'ECDH', public: publicKey },
 			privateKey,
 			AES_GCM_PARAMS,


### PR DESCRIPTION
Adds a few assets with more helpful error messages, removes saving `crypto.subtle` in a local variable, and adds a log of the full error when send crashes.
This (most likely) won't fix the crashes, but will at least allow us to debug them more.

Ref: #703 