### PR TITLE
[FEATURE] Clickable links in account/character profiles

### DIFF
--- a/pandora-client-web/src/components/profileScreens/accountProfile.tsx
+++ b/pandora-client-web/src/components/profileScreens/accountProfile.tsx
@@ -8,6 +8,7 @@ import { toast } from 'react-toastify';
 import { TOAST_OPTIONS_ERROR, TOAST_OPTIONS_WARNING } from '../../persistentToast';
 import { Scrollable } from '../common/scrollbar/scrollbar';
 import { Link } from 'react-router-dom';
+import { ProfileDescriptionLine } from './profileDescription';
 
 export function AccountProfile({ accountId }: { accountId: AccountId; }): ReactElement {
 	const accountData = useAccountProfileData(accountId);
@@ -146,7 +147,7 @@ function AccountProfileDescription({ profileDescription, allowEdit }: { profileD
 				}
 			</Row>
 			<div className='flex-1 profileDescriptionContent'>
-				{ editedDescription.trim() }
+				{ editedDescription.trim().split('\n').map((line, i) => (<ProfileDescriptionLine key={ i } line={ line } index={ i } />)) }
 			</div>
 		</Column>
 	);

--- a/pandora-client-web/src/components/profileScreens/characterProfile.tsx
+++ b/pandora-client-web/src/components/profileScreens/characterProfile.tsx
@@ -12,6 +12,7 @@ import { Button } from '../common/button/button';
 import { toast } from 'react-toastify';
 import { TOAST_OPTIONS_ERROR, TOAST_OPTIONS_WARNING } from '../../persistentToast';
 import { Link } from 'react-router-dom';
+import { ProfileDescriptionLine } from './profileDescription';
 
 export function CharacterProfile({ characterId }: { characterId: CharacterId; }): ReactElement {
 	const characters = useSpaceCharacters();
@@ -146,7 +147,7 @@ function CharacterProfileDescription({ profileDescription, allowEdit }: { profil
 				}
 			</Row>
 			<div className='flex-1 profileDescriptionContent'>
-				{ profileDescription }
+				{ ...profileDescription.split('\n').map((line, i) => (<ProfileDescriptionLine key={ i } line={ line } index={ i } />)) }
 			</div>
 		</Column>
 	);

--- a/pandora-client-web/src/components/profileScreens/profileDescription.tsx
+++ b/pandora-client-web/src/components/profileScreens/profileDescription.tsx
@@ -1,0 +1,37 @@
+import type { ReactElement } from 'react';
+import { SpaceInviteEmbed } from '../../ui/screens/spaceJoin/spaceJoin';
+import { UntrustedLink } from '../common/link/externalLink';
+import React from 'react';
+
+export function ProfileDescriptionLine({ line, index }: { line: string; index: number; }): ReactElement {
+	if (line.match(/^https?:\/\//)) {
+		const url = new URL(line);
+		switch (url.hostname) {
+			case 'project-pandora.com':
+			case 'www.project-pandora.com':
+				if (url.pathname.startsWith('/space/join/')) {
+					const invite = url.searchParams.get('invite') ?? undefined;
+					const spaceId = url.pathname.split('/').pop();
+					if (!spaceId)
+						break;
+
+					return <SpaceInviteEmbed key={ index } spaceId={ spaceId } invite={ invite } />;
+				}
+				break;
+		}
+		return (
+			<UntrustedLink key={ index } href={ line }>
+				{ line }
+			</UntrustedLink>
+		);
+	}
+	if (line.length === 0) {
+		// Keep single space for empty lines to preserve line-breaks.
+		return (
+			<span key={ index }> </span>
+		);
+	}
+	return (
+		<span key={ index }>{ line }</span>
+	);
+}

--- a/pandora-client-web/src/components/profileScreens/profileScreens.scss
+++ b/pandora-client-web/src/components/profileScreens/profileScreens.scss
@@ -55,6 +55,8 @@
 		border: 1px solid black;
 		font-family: Arial, Helvetica, sans-serif;
 		white-space: pre-wrap;
+		display: flex;
+		flex-direction: column;
 	}
 
 	.profileEdit {


### PR DESCRIPTION
Closes #711.

Splits profile descriptions by line to replace links with `<UntrustedLink>` elements. Consequently, currently only detects links when they're at the start of a line.