### PR TITLE
[CHANGE] message toasts location and fixes not working word wrapping in the profiles

### DIFF
--- a/pandora-client-web/src/components/profileScreens/profileScreens.scss
+++ b/pandora-client-web/src/components/profileScreens/profileScreens.scss
@@ -4,7 +4,6 @@
 	display: flex;
 	padding: 0.5em !important;
 	overflow-y: hidden;
-
 }
 
 .profileView {
@@ -55,6 +54,17 @@
 		border: 1px solid black;
 		font-family: Arial, Helvetica, sans-serif;
 		white-space: pre-wrap;
+		word-wrap: break-word;
+		word-break: break-word;
+
+		a {
+			color: $theme-link-light;
+			text-decoration: underline;
+
+			&:hover {
+				color: $grey-light;
+			}
+		}
 	}
 
 	.profileEdit {

--- a/pandora-client-web/src/editor/index.tsx
+++ b/pandora-client-web/src/editor/index.tsx
@@ -38,7 +38,14 @@ async function Start(): Promise<void> {
 			<EulaGate>
 				<BrowserRouter basename='/editor'>
 					<EditorContextProvider>
-						<ToastContainer theme='dark' />
+						<ToastContainer
+							theme='dark'
+							style={ {
+								position: 'absolute',
+							} }
+							toastStyle={ { backgroundColor: '#333' } }
+							position='top-left'
+						/>
 						<AssetLoaderElement />
 					</EditorContextProvider>
 				</BrowserRouter>

--- a/pandora-client-web/src/index.tsx
+++ b/pandora-client-web/src/index.tsx
@@ -48,6 +48,7 @@ function Start(): void {
 								style={ {
 									position: 'absolute',
 								} }
+								toastStyle={ { backgroundColor: '#333' } }
 							/>
 							<div className='main'>
 								<PandoraRoutes />

--- a/pandora-client-web/src/index.tsx
+++ b/pandora-client-web/src/index.tsx
@@ -49,6 +49,7 @@ function Start(): void {
 									position: 'absolute',
 								} }
 								toastStyle={ { backgroundColor: '#333' } }
+								position='top-left'
 							/>
 							<div className='main'>
 								<PandoraRoutes />

--- a/pandora-client-web/src/persistentToast.ts
+++ b/pandora-client-web/src/persistentToast.ts
@@ -9,6 +9,7 @@ export const TOAST_OPTIONS_SUCCESS: ToastOptions = {
 	closeOnClick: true,
 	closeButton: true,
 	draggable: true,
+	position: 'top-left',
 };
 export const TOAST_OPTIONS_WARNING: ToastOptions = {
 	type: 'warning',
@@ -17,6 +18,7 @@ export const TOAST_OPTIONS_WARNING: ToastOptions = {
 	closeOnClick: true,
 	closeButton: true,
 	draggable: true,
+	position: 'top-left',
 };
 export const TOAST_OPTIONS_ERROR: ToastOptions = {
 	type: 'error',
@@ -25,6 +27,7 @@ export const TOAST_OPTIONS_ERROR: ToastOptions = {
 	closeOnClick: true,
 	closeButton: true,
 	draggable: true,
+	position: 'top-left',
 };
 export const TOAST_OPTIONS_PENDING: ToastOptions = {
 	type: 'default',
@@ -33,6 +36,7 @@ export const TOAST_OPTIONS_PENDING: ToastOptions = {
 	closeOnClick: false,
 	closeButton: false,
 	draggable: false,
+	position: 'top-left',
 };
 
 export class PersistentToast {

--- a/pandora-client-web/src/persistentToast.ts
+++ b/pandora-client-web/src/persistentToast.ts
@@ -9,7 +9,6 @@ export const TOAST_OPTIONS_SUCCESS: ToastOptions = {
 	closeOnClick: true,
 	closeButton: true,
 	draggable: true,
-	position: 'top-left',
 };
 export const TOAST_OPTIONS_WARNING: ToastOptions = {
 	type: 'warning',
@@ -18,7 +17,6 @@ export const TOAST_OPTIONS_WARNING: ToastOptions = {
 	closeOnClick: true,
 	closeButton: true,
 	draggable: true,
-	position: 'top-left',
 };
 export const TOAST_OPTIONS_ERROR: ToastOptions = {
 	type: 'error',
@@ -27,7 +25,6 @@ export const TOAST_OPTIONS_ERROR: ToastOptions = {
 	closeOnClick: true,
 	closeButton: true,
 	draggable: true,
-	position: 'top-left',
 };
 export const TOAST_OPTIONS_PENDING: ToastOptions = {
 	type: 'default',
@@ -36,7 +33,6 @@ export const TOAST_OPTIONS_PENDING: ToastOptions = {
 	closeOnClick: false,
 	closeButton: false,
 	draggable: false,
-	position: 'top-left',
 };
 
 export class PersistentToast {

--- a/pandora-client-web/src/styles/_constants.scss
+++ b/pandora-client-web/src/styles/_constants.scss
@@ -23,6 +23,7 @@ $red-dark: #5e0000;
 $theme-error: #b60000;
 $theme-warning: #fd0;
 $theme-link: #349;
+$theme-link-light: #58e;
 $theme-notification: #d00;
 
 $drop-shadow: rgb(5,5,5, 0.2);

--- a/pandora-client-web/src/ui/screens/room/room.scss
+++ b/pandora-client-web/src/ui/screens/room/room.scss
@@ -146,11 +146,11 @@
 		}
 
 		a {
-			color: $white;
+			color: $theme-link-light;
 			text-decoration: underline;
 
 			&:hover {
-				color: $grey-mid;
+				color: $grey-light;
 			}
 		}
 

--- a/pandora-tests/test/wiki.test.ts
+++ b/pandora-tests/test/wiki.test.ts
@@ -1,7 +1,12 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { SetupTestingEnv, TestOpenPandora } from './utils/helpers';
+import { TestStartDirectory } from './utils/server';
 
 SetupTestingEnv();
+
+test.beforeAll(async () => {
+	await TestStartDirectory({ keepActive: true });
+});
 
 test.describe('Wiki', () => {
 	test('Selects default tab', async ({ page }) => {

--- a/pandora-tests/test/wiki.test.ts
+++ b/pandora-tests/test/wiki.test.ts
@@ -26,20 +26,20 @@ test.describe('Wiki', () => {
 		// Initial tab is introcution
 		await expect(page.getByRole('button', { name: 'Introduction' })).toHaveClass('tab active');
 		await expect(page.getByRole('button', { name: 'Contact' })).toHaveClass('tab');
-		await expect(page.getByRole('heading', { name: 'Introduction to Pandora' })).toBeVisible();
+		await expect(page.getByRole('heading', { name: 'Introduction to Pandora' })).toBeVisible({ timeout: 10_000 });
 		await page.waitForURL('/wiki/introduction');
 
 		// Nothing changes when clicking already selected tab
 		await page.getByRole('button', { name: 'Introduction' }).click();
 		await expect(page.getByRole('button', { name: 'Introduction' })).toHaveClass('tab active');
 		await expect(page.getByRole('button', { name: 'Contact' })).toHaveClass('tab');
-		await expect(page.getByRole('heading', { name: 'Introduction to Pandora' })).toBeVisible();
+		await expect(page.getByRole('heading', { name: 'Introduction to Pandora' })).toBeVisible({ timeout: 10_000 });
 		await page.waitForURL('/wiki/introduction');
 
 		// Switch to tab "Contact"
 		await page.getByRole('button', { name: 'Contact' }).click();
 		await expect(page.getByRole('button', { name: 'Contact' })).toHaveClass('tab active');
-		await expect(page.getByRole('heading', { name: 'Contact Us', exact: true })).toBeVisible();
+		await expect(page.getByRole('heading', { name: 'Contact Us', exact: true })).toBeVisible({ timeout: 10_000 });
 		await page.waitForURL('/wiki/contact');
 
 		await expect(page.getByRole('button', { name: 'Introduction' })).toHaveClass('tab');

--- a/pandora-tests/test/wiki.test.ts
+++ b/pandora-tests/test/wiki.test.ts
@@ -26,20 +26,20 @@ test.describe('Wiki', () => {
 		// Initial tab is introcution
 		await expect(page.getByRole('button', { name: 'Introduction' })).toHaveClass('tab active');
 		await expect(page.getByRole('button', { name: 'Contact' })).toHaveClass('tab');
-		await expect(page.getByRole('heading', { name: 'Introduction to Pandora' })).toBeVisible({ timeout: 10_000 });
+		await expect(page.getByRole('heading', { name: 'Introduction to Pandora' })).toBeVisible();
 		await page.waitForURL('/wiki/introduction');
 
 		// Nothing changes when clicking already selected tab
 		await page.getByRole('button', { name: 'Introduction' }).click();
 		await expect(page.getByRole('button', { name: 'Introduction' })).toHaveClass('tab active');
 		await expect(page.getByRole('button', { name: 'Contact' })).toHaveClass('tab');
-		await expect(page.getByRole('heading', { name: 'Introduction to Pandora' })).toBeVisible({ timeout: 10_000 });
+		await expect(page.getByRole('heading', { name: 'Introduction to Pandora' })).toBeVisible();
 		await page.waitForURL('/wiki/introduction');
 
 		// Switch to tab "Contact"
 		await page.getByRole('button', { name: 'Contact' }).click();
 		await expect(page.getByRole('button', { name: 'Contact' })).toHaveClass('tab active');
-		await expect(page.getByRole('heading', { name: 'Contact Us', exact: true })).toBeVisible({ timeout: 10_000 });
+		await expect(page.getByRole('heading', { name: 'Contact Us', exact: true })).toBeVisible();
 		await page.waitForURL('/wiki/contact');
 
 		await expect(page.getByRole('button', { name: 'Introduction' })).toHaveClass('tab');


### PR DESCRIPTION
Fixes https://github.com/Project-Pandora-Game/pandora/issues/740

- Changed the info/warning/error toasts to be top-left instead of top-right to conflict less with UI elements
- Changed the link color in chats and profiles
- Fixed the incorrect wrapping of long links /words in character and account profiles