### PR TITLE
[FEATURE] item custom name and description

### DIFF
--- a/pandora-client-web/src/components/settings/interfaceSettings.tsx
+++ b/pandora-client-web/src/components/settings/interfaceSettings.tsx
@@ -133,6 +133,7 @@ function WardrobeSettings(): ReactElement {
 			<SelectAccountSettings setting='wardrobeOutfitsPreview' label='Saved item collection previews' stringify={ WARDROBE_PREVIEWS_DESCRIPTION } />
 			<SelectAccountSettings setting='wardrobeSmallPreview' label='Item previews: List mode with small previews' stringify={ WARDROBE_PREVIEW_TYPE_DESCRIPTION } />
 			<SelectAccountSettings setting='wardrobeBigPreview' label='Item previews: Grid mode with big previews' stringify={ WARDROBE_PREVIEW_TYPE_DESCRIPTION } />
+			<SelectAccountSettings setting='wardrobeItemDisplayNameType' label='Item name display' stringify={ WARDROBE_ITEM_DISPLAY_NAME_TYPE_DESCRIPTION } />
 		</fieldset>
 	);
 }
@@ -154,4 +155,10 @@ const WARDROBE_PREVIEWS_DESCRIPTION: Record<AccountSettings['wardrobeOutfitsPrev
 const WARDROBE_PREVIEW_TYPE_DESCRIPTION: Record<AccountSettings['wardrobeSmallPreview'], string> = {
 	icon: 'Show attribute icon',
 	image: 'Show preview image',
+};
+
+const WARDROBE_ITEM_DISPLAY_NAME_TYPE_DESCRIPTION: Record<AccountSettings['wardrobeItemDisplayNameType'], string> = {
+	custom: 'Custom name',
+	original: 'Original name',
+	custom_with_original_in_brackets: 'Custom name [Original name]',
 };

--- a/pandora-client-web/src/components/settings/interfaceSettings.tsx
+++ b/pandora-client-web/src/components/settings/interfaceSettings.tsx
@@ -28,6 +28,7 @@ function ChatroomSettings(): ReactElement {
 			<ChatroomChatFontSize />
 			<ChatroomCharacterNameFontSize />
 			<ChatroomOfflineCharacters />
+			<SelectAccountSettings setting='interfaceChatroomItemDisplayNameType' label='Item name display' stringify={ ITEM_DISPLAY_NAME_TYPE_DESCRIPTION } />
 		</fieldset>
 	);
 }
@@ -133,7 +134,7 @@ function WardrobeSettings(): ReactElement {
 			<SelectAccountSettings setting='wardrobeOutfitsPreview' label='Saved item collection previews' stringify={ WARDROBE_PREVIEWS_DESCRIPTION } />
 			<SelectAccountSettings setting='wardrobeSmallPreview' label='Item previews: List mode with small previews' stringify={ WARDROBE_PREVIEW_TYPE_DESCRIPTION } />
 			<SelectAccountSettings setting='wardrobeBigPreview' label='Item previews: Grid mode with big previews' stringify={ WARDROBE_PREVIEW_TYPE_DESCRIPTION } />
-			<SelectAccountSettings setting='wardrobeItemDisplayNameType' label='Item name display' stringify={ WARDROBE_ITEM_DISPLAY_NAME_TYPE_DESCRIPTION } />
+			<SelectAccountSettings setting='wardrobeItemDisplayNameType' label='Item name display' stringify={ ITEM_DISPLAY_NAME_TYPE_DESCRIPTION } />
 		</fieldset>
 	);
 }
@@ -157,7 +158,7 @@ const WARDROBE_PREVIEW_TYPE_DESCRIPTION: Record<AccountSettings['wardrobeSmallPr
 	image: 'Show preview image',
 };
 
-const WARDROBE_ITEM_DISPLAY_NAME_TYPE_DESCRIPTION: Record<AccountSettings['wardrobeItemDisplayNameType'], string> = {
+const ITEM_DISPLAY_NAME_TYPE_DESCRIPTION: Record<AccountSettings['wardrobeItemDisplayNameType'], string> = {
 	custom: 'Custom name',
 	original: 'Original name',
 	custom_with_original_in_brackets: 'Custom name [Original name]',

--- a/pandora-client-web/src/components/wardrobe/itemDetail/_wardrobeItemDetail.tsx
+++ b/pandora-client-web/src/components/wardrobe/itemDetail/_wardrobeItemDetail.tsx
@@ -190,11 +190,11 @@ function WardrobeItemNameAndDescriptionInfo({ item, itemPath, onStartEdit }: { i
 		<FieldsetToggle legend='Item'>
 			<Column>
 				<Row>
-					<label htmlFor='original-name'>Original name:</label>
+					<label className='margin-auto-vertical' htmlFor='original-name'>Original name:</label>
 					<input id='original-name' type='text' value={ item.asset.definition.name } readOnly />
 				</Row>
 				<Row>
-					<label htmlFor='custom-name'>Custom name:</label>
+					<label className='margin-auto-vertical' htmlFor='custom-name'>Custom name:</label>
 					<input id='custom-name' type='text' value={ item.name ?? '' } readOnly />
 				</Row>
 				<label>Description:</label>
@@ -231,11 +231,11 @@ function WardrobeItemNameAndDescriptionEdit({ item, itemPath, onEndEdit }: { ite
 		<FieldsetToggle legend='Item'>
 			<Column>
 				<Row>
-					<label htmlFor='original-name'>Original name:</label>
+					<label className='margin-auto-vertical' htmlFor='original-name'>Original name:</label>
 					<input id='original-name' type='text' value={ item.asset.definition.name } readOnly />
 				</Row>
 				<Row>
-					<label htmlFor='custom-name'>Custom name:</label>
+					<label className='margin-auto-vertical' htmlFor='custom-name'>Custom name:</label>
 					<input id='custom-name' type='text' value={ name } onChange={ (e) => setName(e.target.value) } maxLength={ LIMIT_ITEM_NAME_LENGTH } />
 				</Row>
 				<label htmlFor='custom-description'>Description:</label>

--- a/pandora-client-web/src/components/wardrobe/itemDetail/_wardrobeItemDetail.tsx
+++ b/pandora-client-web/src/components/wardrobe/itemDetail/_wardrobeItemDetail.tsx
@@ -13,6 +13,7 @@ import { WardrobeActionButton } from '../wardrobeComponents';
 import { WardrobeItemColorization } from './wardrobeItemColor';
 import { WardrobeModuleConfig } from '../modules/_wardrobeModules';
 import { WardrobeRoomDeviceDeployment, WardrobeRoomDeviceSlots, WardrobeRoomDeviceWearable } from './wardrobeItemRoomDevice';
+import { WardrobeItemName } from './wardrobeItemName';
 
 export function WardrobeItemConfigMenu({
 	item,
@@ -58,7 +59,7 @@ export function WardrobeItemConfigMenu({
 	return (
 		<div className='inventoryView'>
 			<div className='toolbar'>
-				<span>Editing item: { wornItem.asset.definition.name }</span>
+				<span>Editing item:&nbsp;<WardrobeItemName item={ wornItem } /></span>
 				{ !singleItemContainer && <button className='modeButton' onClick={ close }>✖️</button> }
 			</div>
 			<Column padding='medium' overflowX='hidden' overflowY='auto'>

--- a/pandora-client-web/src/components/wardrobe/itemDetail/_wardrobeItemDetail.tsx
+++ b/pandora-client-web/src/components/wardrobe/itemDetail/_wardrobeItemDetail.tsx
@@ -1,5 +1,9 @@
 import {
 	ItemPath,
+	LIMIT_ITEM_DESCRIPTION_LENGTH,
+	LIMIT_ITEM_NAME_LENGTH,
+	type AppearanceAction,
+	type Item,
 } from 'pandora-common';
 import React, { ReactElement, useCallback, useEffect, useRef } from 'react';
 import { FieldsetToggle } from '../../common/fieldsetToggle';
@@ -7,13 +11,16 @@ import { Column, Row } from '../../common/container/container';
 import { ItemModuleLockSlot } from 'pandora-common/dist/assets/modules/lockSlot';
 import { SplitContainerPath } from 'pandora-common/dist/assets/appearanceHelpers';
 import deleteIcon from '../../../assets/icons/delete.svg';
-import { useWardrobeContext } from '../wardrobeContext';
+import { useWardrobeContext, useWardrobeExecuteCallback } from '../wardrobeContext';
 import { useWardrobeTargetItem } from '../wardrobeUtils';
 import { WardrobeActionButton } from '../wardrobeComponents';
 import { WardrobeItemColorization } from './wardrobeItemColor';
 import { WardrobeModuleConfig } from '../modules/_wardrobeModules';
 import { WardrobeRoomDeviceDeployment, WardrobeRoomDeviceSlots, WardrobeRoomDeviceWearable } from './wardrobeItemRoomDevice';
 import { WardrobeItemName } from './wardrobeItemName';
+import { Button } from '../../common/button/button';
+import { useEvent } from '../../../common/useEvent';
+import { useStaggeredAppearanceActionResult } from '../wardrobeCheckQueue';
 
 export function WardrobeItemConfigMenu({
 	item,
@@ -116,6 +123,11 @@ export function WardrobeItemConfigMenu({
 					}
 				</Row>
 				{
+					(!wornItem.isType('roomDeviceWearablePart')) ? (
+						<WardrobeItemNameAndDescription item={ wornItem } itemPath={ item } />
+					) : null
+				}
+				{
 					(wornItem.isType('personal') || wornItem.isType('roomDevice')) ? (
 						<WardrobeItemColorization wornItem={ wornItem } item={ item } />
 					) : null
@@ -145,5 +157,94 @@ export function WardrobeItemConfigMenu({
 				}
 			</Column>
 		</div>
+	);
+}
+
+function WardrobeItemNameAndDescription({ item, itemPath }: { item: Item; itemPath: ItemPath; }): ReactElement {
+	const [edit, setEdit] = React.useState(false);
+	const onStartEdit = React.useCallback(() => setEdit(true), []);
+	const onEndEdit = React.useCallback(() => setEdit(false), []);
+
+	if (edit) {
+		return <WardrobeItemNameAndDescriptionEdit item={ item } itemPath={ itemPath } onEndEdit={ onEndEdit } />;
+	}
+
+	return (
+		<WardrobeItemNameAndDescriptionInfo item={ item } itemPath={ itemPath } onStartEdit={ onStartEdit } />
+	);
+}
+
+function WardrobeItemNameAndDescriptionInfo({ item, itemPath, onStartEdit }: { item: Item; itemPath: ItemPath; onStartEdit: () => void; }): ReactElement {
+	const { targetSelector } = useWardrobeContext();
+	const action = React.useMemo<AppearanceAction>(() => ({
+		type: 'customize',
+		target: targetSelector,
+		item: itemPath,
+		name: item.name ?? '',
+		description: item.description ?? '',
+	}), [targetSelector, itemPath, item.name, item.description]);
+	const checkResult = useStaggeredAppearanceActionResult(action, { immediate: true });
+	const available = checkResult != null && checkResult.problems.length === 0;
+
+	return (
+		<FieldsetToggle legend='Item'>
+			<Column>
+				<Row>
+					<label htmlFor='original-name'>Original name:</label>
+					<input id='original-name' type='text' value={ item.asset.definition.name } readOnly />
+				</Row>
+				<Row>
+					<label htmlFor='custom-name'>Custom name:</label>
+					<input id='custom-name' type='text' value={ item.name ?? '' } readOnly />
+				</Row>
+				<label>Description:</label>
+				<textarea id='custom-description' value={ item.description ?? '' } readOnly />
+				{
+					available ? (
+						<Row>
+							<Button onClick={ onStartEdit }>Edit</Button>
+						</Row>
+					) : null
+				}
+			</Column>
+		</FieldsetToggle>
+	);
+}
+
+function WardrobeItemNameAndDescriptionEdit({ item, itemPath, onEndEdit }: { item: Item; itemPath: ItemPath; onEndEdit: () => void; }): ReactElement {
+	const { targetSelector } = useWardrobeContext();
+	const [execute, processing] = useWardrobeExecuteCallback({ onSuccess: onEndEdit });
+	const [name, setName] = React.useState(item.name ?? '');
+	const [description, setDescription] = React.useState(item.description ?? '');
+
+	const onSave = useEvent(() => {
+		execute({
+			type: 'customize',
+			target: targetSelector,
+			item: itemPath,
+			name: name.trim(),
+			description: description.trim(),
+		});
+	});
+
+	return (
+		<FieldsetToggle legend='Item'>
+			<Column>
+				<Row>
+					<label htmlFor='original-name'>Original name:</label>
+					<input id='original-name' type='text' value={ item.asset.definition.name } readOnly />
+				</Row>
+				<Row>
+					<label htmlFor='custom-name'>Custom name:</label>
+					<input id='custom-name' type='text' value={ name } onChange={ (e) => setName(e.target.value) } maxLength={ LIMIT_ITEM_NAME_LENGTH } />
+				</Row>
+				<label htmlFor='custom-description'>Description:</label>
+				<textarea id='custom-description' value={ description } onChange={ (e) => setDescription(e.target.value) } maxLength={ LIMIT_ITEM_DESCRIPTION_LENGTH } />
+				<Row>
+					<Button onClick={ onEndEdit } disabled={ processing }>Cancel</Button>
+					<Button onClick={ onSave } disabled={ processing }>Save</Button>
+				</Row>
+			</Column>
+		</FieldsetToggle>
 	);
 }

--- a/pandora-client-web/src/components/wardrobe/itemDetail/wardrobeItemName.tsx
+++ b/pandora-client-web/src/components/wardrobe/itemDetail/wardrobeItemName.tsx
@@ -21,16 +21,20 @@ export function WardrobeItemName({
 }
 
 export function ResolveItemDisplayName(item: Item, itemDisplayNameType: ItemDisplayNameType): string {
-	if (item.name == null || item.name === item.asset.definition.name)
-		return item.asset.definition.name;
+	return ResolveItemDisplayNameType(item.asset.definition.name, item.name, itemDisplayNameType);
+}
+
+export function ResolveItemDisplayNameType(original: string, custom: string | null | undefined, itemDisplayNameType: ItemDisplayNameType): string {
+	if (custom == null || custom === '' || custom === original)
+		return original;
 
 	switch (itemDisplayNameType) {
 		case 'original':
-			return item.asset.definition.name;
+			return original;
 		case 'custom':
-			return item.name;
+			return custom;
 		case 'custom_with_original_in_brackets':
-			return `${item.name} [${item.asset.definition.name}]`;
+			return `${custom} [${original}]`;
 		default:
 			AssertNever(itemDisplayNameType);
 	}

--- a/pandora-client-web/src/components/wardrobe/itemDetail/wardrobeItemName.tsx
+++ b/pandora-client-web/src/components/wardrobe/itemDetail/wardrobeItemName.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import {
+	AssertNever,
+	type Item,
+	type ItemDisplayNameType,
+} from 'pandora-common';
+import { useWardrobeContext } from '../wardrobeContext';
+
+export function WardrobeItemName({
+	item,
+}: {
+	item: Item;
+}): React.ReactElement {
+	const { itemDisplayNameType } = useWardrobeContext();
+
+	return (
+		<>
+			{ ResolveItemDisplayName(item, itemDisplayNameType) }
+		</>
+	);
+}
+
+export function ResolveItemDisplayName(item: Item, itemDisplayNameType: ItemDisplayNameType): string {
+	if (item.name == null || item.name === item.asset.definition.name)
+		return item.asset.definition.name;
+
+	switch (itemDisplayNameType) {
+		case 'original':
+			return item.asset.definition.name;
+		case 'custom':
+			return item.name;
+		case 'custom_with_original_in_brackets':
+			return `${item.name} [${item.asset.definition.name}]`;
+		default:
+			AssertNever(itemDisplayNameType);
+	}
+}

--- a/pandora-client-web/src/components/wardrobe/modules/wardrobeModuleLockSlot.tsx
+++ b/pandora-client-web/src/components/wardrobe/modules/wardrobeModuleLockSlot.tsx
@@ -20,6 +20,7 @@ import { useWardrobeContext } from '../wardrobeContext';
 import { WardrobeActionButton } from '../wardrobeComponents';
 import type { Immutable } from 'immer';
 import { useAssetManager } from '../../../assets/assetManager';
+import { WardrobeItemName } from '../itemDetail/wardrobeItemName';
 
 export function WardrobeModuleConfigLockSlot({ item, moduleName, m }: WardrobeModuleProps<ItemModuleLockSlot>): ReactElement {
 	const { targetSelector, target, focuser } = useWardrobeContext();
@@ -49,7 +50,7 @@ export function WardrobeModuleConfigLockSlot({ item, moduleName, m }: WardrobeMo
 				<Row padding='medium' wrap>
 					<img width='21' height='33' src={ openLock } />
 					<Row padding='medium' alignY='center'>
-						Lock: { m.lock.asset.definition.name } (unlocked)
+						Lock:&nbsp;<WardrobeItemName item={ m.lock } /> (unlocked)
 					</Row>
 				</Row>
 				<Row wrap>
@@ -104,7 +105,7 @@ export function WardrobeModuleConfigLockSlot({ item, moduleName, m }: WardrobeMo
 			<Row padding='medium' wrap>
 				<img width='21' height='33' src={ closedLock } />
 				<Row padding='medium' alignY='center'>
-					Locked with: { m.lock.asset.definition.name }
+					Locked with:&nbsp;<WardrobeItemName item={ m.lock } />
 				</Row>
 			</Row>
 			<WardrobeLockSlotLocked item={ item } moduleName={ moduleName } m={ m } lock={ m.lock } />

--- a/pandora-client-web/src/components/wardrobe/views/wardrobeItemView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobeItemView.tsx
@@ -29,6 +29,7 @@ import { useWardrobeTargetItem, useWardrobeTargetItems } from '../wardrobeUtils'
 import { InventoryAssetPreview, StorageUsageMeter, WardrobeActionButton } from '../wardrobeComponents';
 import { useNavigate } from 'react-router';
 import { Button } from '../../common/button/button';
+import { ResolveItemDisplayName, WardrobeItemName } from '../itemDetail/wardrobeItemName';
 
 export function InventoryItemView({
 	className,
@@ -39,7 +40,7 @@ export function InventoryItemView({
 	title: string;
 	filter?: (item: Item) => boolean;
 }): ReactElement | null {
-	const { target, targetSelector, heldItem, focuser } = useWardrobeContext();
+	const { target, targetSelector, heldItem, focuser, itemDisplayNameType } = useWardrobeContext();
 	const focus = useObservable(focuser.current);
 	const appearance = useWardrobeTargetItems(target);
 	const itemCount = useMemo(() => AppearanceItemsCalculateTotalCount(appearance), [appearance]);
@@ -54,12 +55,12 @@ export function InventoryItemView({
 			const module = item?.getModules().get(step.module);
 			if (!item || !module)
 				return [[], undefined, []];
-			steps.push(`${item.asset.definition.name} (${module.config.name})`);
+			steps.push(`${ResolveItemDisplayName(item, itemDisplayNameType)} (${module.config.name})`);
 			container = module;
 			items = item.getModuleItems(step.module);
 		}
 		return [items, container, steps];
-	}, [appearance, filter, focus]);
+	}, [appearance, filter, focus, itemDisplayNameType]);
 
 	const singleItemContainer = containerModule != null && containerModule instanceof ItemModuleLockSlot;
 	useEffect(() => {
@@ -292,7 +293,7 @@ function InventoryItemViewList({ item, selected = false, singleItemContainer = f
 					/> : null
 			}
 			<InventoryAssetPreview asset={ asset } small={ true } />
-			<span className='itemName'>{ asset.definition.name }</span>
+			<span className='itemName'><WardrobeItemName item={ wornItem } /></span>
 			<div className='quickActions'>
 				{
 					singleItemContainer ? null : (

--- a/pandora-client-web/src/components/wardrobe/views/wardrobeSecondaryInventoryView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobeSecondaryInventoryView.tsx
@@ -18,6 +18,7 @@ import { InventoryAssetPreview, WardrobeActionButton } from '../wardrobeComponen
 import { useWardrobeContext } from '../wardrobeContext';
 import { WardrobeContextExtraItemActionComponent, WardrobeHeldItem } from '../wardrobeTypes';
 import { InventoryItemViewDropArea } from './wardrobeItemView';
+import { WardrobeItemName } from '../itemDetail/wardrobeItemName';
 
 export function SecondaryInventoryView({ title, secondaryTarget, secondaryTargetContainer = EMPTY_ARRAY, quickActionTarget, quickActionTargetContainer }: {
 	title: string;
@@ -161,7 +162,7 @@ function RoomInventoryViewListItem({ target, itemPath, quickActionTarget, quickA
 					/> : null
 			}
 			<InventoryAssetPreview asset={ asset } small={ true } />
-			<span className='itemName'>{ asset.definition.name }</span>
+			<span className='itemName'><WardrobeItemName item={ item } /></span>
 			<div className='quickActions'>
 				{ showExtraActionButtons ? (
 					<>

--- a/pandora-client-web/src/components/wardrobe/wardrobe.scss
+++ b/pandora-client-web/src/components/wardrobe/wardrobe.scss
@@ -692,3 +692,8 @@ $drop-overlay-gap: 0.3em;
 		}
 	}
 }
+
+.margin-auto-vertical {
+	margin-top: auto;
+	margin-bottom: auto;
+}

--- a/pandora-client-web/src/components/wardrobe/wardrobeComponents.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobeComponents.tsx
@@ -28,14 +28,15 @@ import { useObservable } from '../../observable';
 import { Column } from '../common/container/container';
 
 export function ActionWarningContent({ problems, prompt }: { problems: readonly AppearanceActionProblem[]; prompt: boolean; }): ReactElement {
+	const { wardrobeItemDisplayNameType } = useAccountSettings();
 	const assetManager = useAssetManager();
 	const reasons = useMemo(() => (
 		_.uniq(
 			problems
-				.map((problem) => RenderAppearanceActionProblem(assetManager, problem))
+				.map((problem) => RenderAppearanceActionProblem(assetManager, problem, wardrobeItemDisplayNameType))
 				.filter(Boolean),
 		)
-	), [assetManager, problems]);
+	), [assetManager, problems, wardrobeItemDisplayNameType]);
 
 	if (reasons.length === 0) {
 		return (

--- a/pandora-client-web/src/components/wardrobe/wardrobeContext.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobeContext.tsx
@@ -132,7 +132,7 @@ type ExecuteCallbackOptions = {
 
 export function useWardrobeExecuteCallback({ onSuccess, onFailure }: ExecuteCallbackOptions = {}) {
 	const assetManager = useAssetManager();
-	const { execute } = useWardrobeContext();
+	const { execute, itemDisplayNameType } = useWardrobeContext();
 	return useAsyncEvent(
 		async (action: AppearanceAction) => await execute(action),
 		(result) => {
@@ -156,7 +156,7 @@ export function useWardrobeExecuteCallback({ onSuccess, onFailure }: ExecuteCall
 							<ul>
 								{
 									result.problems.map((problem, i) => (
-										<li key={ i } className='display-linebreak'>{ RenderAppearanceActionProblem(assetManager, problem) }</li>
+										<li key={ i } className='display-linebreak'>{ RenderAppearanceActionProblem(assetManager, problem, itemDisplayNameType) }</li>
 									))
 								}
 							</ul>

--- a/pandora-client-web/src/components/wardrobe/wardrobeContext.tsx
+++ b/pandora-client-web/src/components/wardrobe/wardrobeContext.tsx
@@ -109,7 +109,8 @@ export function WardrobeContextProvider({ target, player, children }: { target: 
 		actionPreviewState,
 		showExtraActionButtons: settings.wardrobeExtraActionButtons,
 		showHoverPreview: settings.wardrobeHoverPreview,
-	}), [actualTarget, targetSelector, player, globalState, assetList, heldItem, scrollToItem, focuser, extraItemActions, actions, actionPreviewState, settings.wardrobeExtraActionButtons, settings.wardrobeHoverPreview, shardConnector]);
+		itemDisplayNameType: settings.wardrobeItemDisplayNameType,
+	}), [actualTarget, targetSelector, player, globalState, assetList, heldItem, scrollToItem, focuser, extraItemActions, actions, actionPreviewState, settings.wardrobeExtraActionButtons, settings.wardrobeHoverPreview, settings.wardrobeItemDisplayNameType, shardConnector]);
 
 	return (
 		<wardrobeContext.Provider value={ context }>

--- a/pandora-client-web/src/components/wardrobe/wardrobeTypes.ts
+++ b/pandora-client-web/src/components/wardrobe/wardrobeTypes.ts
@@ -14,6 +14,7 @@ import {
 	ItemTemplate,
 	ModuleType,
 	ActionTargetSelector,
+	type ItemDisplayNameType,
 } from 'pandora-common';
 import { ICharacter, IChatroomCharacter } from '../../character/character';
 import { Observable, type ReadonlyObservable } from '../../observable';
@@ -54,6 +55,7 @@ export interface WardrobeContext {
 	// Settings
 	showExtraActionButtons: boolean;
 	showHoverPreview: boolean;
+	itemDisplayNameType: ItemDisplayNameType;
 }
 
 export interface WardrobeFocus {

--- a/pandora-client-web/src/editor/components/wardrobe/wardrobe.tsx
+++ b/pandora-client-web/src/editor/components/wardrobe/wardrobe.tsx
@@ -114,6 +114,7 @@ export function EditorWardrobeContextProvider({ children }: { children: ReactNod
 		},
 		showExtraActionButtons: true,
 		showHoverPreview: true,
+		itemDisplayNameType: 'custom_with_original_in_brackets',
 	}), [character, globalState, assetList, heldItem, scrollToItem, focuser, extraItemActions, actions, actionPreviewState, assetManager, editor]);
 
 	return (

--- a/pandora-client-web/src/ui/components/chat/chat.tsx
+++ b/pandora-client-web/src/ui/components/chat/chat.tsx
@@ -269,9 +269,10 @@ function DisplayName({ message, color }: { message: IChatMessageChat; color: str
 
 export function ActionMessage({ message, ignoreColor = false }: { message: IChatMessageProcessed<IChatMessageAction>; ignoreColor?: boolean; }): ReactElement | null {
 	const assetManager = useAssetManager();
+	const { interfaceChatroomItemDisplayNameType } = useAccountSettings();
 	const [folded, setFolded] = useState(true);
 
-	const [content, extraContent] = useMemo(() => RenderActionContent(message, assetManager), [message, assetManager]);
+	const [content, extraContent] = useMemo(() => RenderActionContent(message, assetManager, interfaceChatroomItemDisplayNameType), [message, assetManager, interfaceChatroomItemDisplayNameType]);
 
 	// If there is nothing to display, hide this message
 	if (content.length === 0 && extraContent == null)

--- a/pandora-common/src/account/settings.ts
+++ b/pandora-common/src/account/settings.ts
@@ -5,6 +5,9 @@ import { DisplayNameSchema, HexColorStringSchema } from '../validation';
 
 //#region Settings declarations
 
+const ItemDisplayNameTypeSchema = z.enum(['original', 'custom', 'custom_with_original_in_brackets']);
+export type ItemDisplayNameType = z.infer<typeof ItemDisplayNameTypeSchema>;
+
 export const AccountSettingsSchema = z.object({
 	visibleRoles: z.array(AccountRoleSchema).max(AccountRoleSchema.options.length),
 	labelColor: HexColorStringSchema,
@@ -39,6 +42,10 @@ export const AccountSettingsSchema = z.object({
 	 * Controls whether to show the attribute icons or preview images in big preview.
 	 */
 	wardrobeBigPreview: z.enum(['icon', 'image']),
+	/**
+	 * Controls how item names appear in wardrobe
+	 */
+	wardrobeItemDisplayNameType: ItemDisplayNameTypeSchema,
 	/**
 	 * Controls how many parts (of 10 total) the room graphics takes, while in horizontal mode
 	 */
@@ -77,6 +84,7 @@ export const ACCOUNT_SETTINGS_DEFAULT = Object.freeze<AccountSettings>({
 	wardrobeOutfitsPreview: 'small',
 	wardrobeSmallPreview: 'image',
 	wardrobeBigPreview: 'image',
+	wardrobeItemDisplayNameType: 'custom_with_original_in_brackets',
 	interfaceChatroomGraphicsRatioHorizontal: 7,
 	interfaceChatroomGraphicsRatioVertical: 4,
 	interfaceChatroomOfflineCharacterFilter: 'ghost',

--- a/pandora-common/src/account/settings.ts
+++ b/pandora-common/src/account/settings.ts
@@ -70,6 +70,8 @@ export const AccountSettingsSchema = z.object({
 	 * Controls how big the font size used for the name of the character is
 	 */
 	interfaceChatroomCharacterNameFontSize: z.enum(['xs', 's', 'm', 'l', 'xl']),
+	/** Controls how item names appear in chat action messages */
+	interfaceChatroomItemDisplayNameType: ItemDisplayNameTypeSchema,
 });
 export type AccountSettings = z.infer<typeof AccountSettingsSchema>;
 
@@ -90,6 +92,7 @@ export const ACCOUNT_SETTINGS_DEFAULT = Object.freeze<AccountSettings>({
 	interfaceChatroomOfflineCharacterFilter: 'ghost',
 	interfaceChatroomChatFontSize: 'm',
 	interfaceChatroomCharacterNameFontSize: 'm',
+	interfaceChatroomItemDisplayNameType: 'custom_with_original_in_brackets',
 });
 
 export const ACCOUNT_SETTINGS_LIMITED_LIMITS = Object.freeze({

--- a/pandora-common/src/assets/appearanceActions.ts
+++ b/pandora-common/src/assets/appearanceActions.ts
@@ -534,9 +534,11 @@ export function ActionAddItem(processingContext: AppearanceActionProcessingConte
 				id: 'itemReplace',
 				item: {
 					assetId: item.asset.id,
+					itemName: item.name ?? '',
 				},
 				itemPrevious: {
 					assetId: removed[0].asset.id,
+					itemName: removed[0].name ?? '',
 				},
 			}),
 		);
@@ -547,6 +549,7 @@ export function ActionAddItem(processingContext: AppearanceActionProcessingConte
 				id: (!manipulatorContainer && rootManipulator.isCharacter()) ? 'itemAddCreate' : manipulatorContainer?.contentsPhysicallyEquipped ? 'itemAttach' : 'itemStore',
 				item: {
 					assetId: item.asset.id,
+					itemName: item.name ?? '',
 				},
 			}),
 		);
@@ -573,6 +576,7 @@ export function ActionRemoveItem(processingContext: AppearanceActionProcessingCo
 			id: (!manipulatorContainer && rootManipulator.isCharacter()) ? 'itemRemoveDelete' : manipulatorContainer?.contentsPhysicallyEquipped ? 'itemDetach' : 'itemUnload',
 			item: {
 				assetId: removedItems[0].asset.id,
+				itemName: removedItems[0].name ?? '',
 			},
 		}),
 	);
@@ -621,6 +625,7 @@ export function ActionTransferItem(processingContext: AppearanceActionProcessing
 				id: !manipulatorContainer ? 'itemRemove' : manipulatorContainer?.contentsPhysicallyEquipped ? 'itemDetach' : 'itemUnload',
 				item: {
 					assetId: item.asset.id,
+					itemName: item.name ?? '',
 				},
 			}),
 		);
@@ -632,6 +637,7 @@ export function ActionTransferItem(processingContext: AppearanceActionProcessing
 				id: !manipulatorContainer ? 'itemAdd' : manipulatorContainer?.contentsPhysicallyEquipped ? 'itemAttach' : 'itemStore',
 				item: {
 					assetId: removedItems[0].asset.id,
+					itemName: removedItems[0].name ?? '',
 				},
 			}),
 		);
@@ -732,6 +738,7 @@ export function ActionModuleAction({
 					containerManipulator.makeMessage({
 						item: {
 							assetId: it.asset.id,
+							itemName: it.name ?? '',
 						},
 						...m,
 					}),
@@ -963,6 +970,7 @@ export function ActionRoomDeviceDeploy(processingContext: AppearanceActionProces
 				id: (deployment != null) ? 'roomDeviceDeploy' : 'roomDeviceStore',
 				item: {
 					assetId: previousDeviceState.asset.id,
+					itemName: previousDeviceState.name ?? '',
 				},
 			}),
 		);
@@ -1044,6 +1052,7 @@ export function ActionRoomDeviceEnter({
 			id: 'roomDeviceSlotEnter',
 			item: {
 				assetId: item.asset.id,
+				itemName: item.name ?? '',
 			},
 			dictionary: {
 				ROOM_DEVICE_SLOT: item.asset.definition.slots[action.slot]?.name ?? '[UNKNOWN]',
@@ -1125,6 +1134,7 @@ export function ActionRoomDeviceLeave({
 					id: 'roomDeviceSlotLeave',
 					item: {
 						assetId: item.asset.id,
+						itemName: item.name ?? '',
 					},
 					dictionary: {
 						ROOM_DEVICE_SLOT: item.asset.definition.slots[action.slot]?.name ?? '[UNKNOWN]',
@@ -1150,6 +1160,7 @@ export function ActionRoomDeviceLeave({
 				id: 'roomDeviceSlotClear',
 				item: {
 					assetId: item.asset.id,
+					itemName: item.name ?? '',
 				},
 				dictionary: {
 					ROOM_DEVICE_SLOT: item.asset.definition.slots[action.slot]?.name ?? '[UNKNOWN]',

--- a/pandora-common/src/assets/appearanceHelpers.ts
+++ b/pandora-common/src/assets/appearanceHelpers.ts
@@ -167,7 +167,7 @@ class AppearanceContainerManipulator extends AppearanceManipulator {
 	}
 
 	public makeMessage(message: ActionHandlerMessageTemplate): ActionHandlerMessageWithTarget {
-		message.itemContainerPath ??= this.containerPath?.map((i) => ({ assetId: i.item.asset.id, module: i.moduleName }));
+		message.itemContainerPath ??= this.containerPath?.map((i) => ({ assetId: i.item.asset.id, module: i.moduleName, itemName: i.item.name ?? '' }));
 		return this._base.makeMessage(message);
 	}
 }
@@ -213,7 +213,7 @@ export class AppearanceRootManipulator extends AppearanceManipulator {
 	}
 
 	public override makeMessage(message: ActionHandlerMessageTemplate): ActionHandlerMessageWithTarget {
-		message.itemContainerPath ??= this.containerPath?.map((i) => ({ assetId: i.item.asset.id, module: i.moduleName }));
+		message.itemContainerPath ??= this.containerPath?.map((i) => ({ assetId: i.item.asset.id, module: i.moduleName, itemName: i.item.name ?? '' }));
 
 		let target: ActionHandlerMessageTarget;
 		if (this._target.type === 'character') {

--- a/pandora-common/src/assets/item/_internal.ts
+++ b/pandora-common/src/assets/item/_internal.ts
@@ -22,6 +22,8 @@ export interface ItemBaseProps<Type extends AssetType = AssetType> {
 	readonly id: ItemId;
 	readonly asset: Asset<Type>;
 	readonly color: Immutable<ItemColorBundle>;
+	readonly name?: string;
+	readonly description?: string;
 }
 
 /**
@@ -34,6 +36,8 @@ export abstract class ItemBase<Type extends AssetType = AssetType> implements It
 	public readonly id: ItemId;
 	public readonly asset: Asset<Type>;
 	public readonly color: Immutable<ItemColorBundle>;
+	public readonly name?: string;
+	public readonly description?: string;
 
 	public get type(): Type {
 		return this.asset.type;
@@ -61,6 +65,8 @@ export abstract class ItemBase<Type extends AssetType = AssetType> implements It
 			id: bundle.id,
 			asset,
 			color: ItemBase._loadColorBundle(asset, bundle.color),
+			name: bundle.name,
+			description: bundle.description,
 		};
 	}
 
@@ -95,6 +101,8 @@ export abstract class ItemBase<Type extends AssetType = AssetType> implements It
 			id: this.id,
 			asset: this.asset.id,
 			color: this.exportColorToBundle(),
+			name: this.name,
+			description: this.description,
 			moduleData,
 		};
 	}
@@ -205,7 +213,7 @@ export abstract class ItemBase<Type extends AssetType = AssetType> implements It
 
 	/** Returns if this item can be transferred between inventories */
 	public canBeTransferred(): boolean {
-		// No transfering bodyparts, thank you
+		// No transferring bodyparts, thank you
 		if (this.isType('personal') && this.asset.definition.bodypart)
 			return false;
 

--- a/pandora-common/src/assets/item/_internal.ts
+++ b/pandora-common/src/assets/item/_internal.ts
@@ -178,6 +178,7 @@ export abstract class ItemBase<Type extends AssetType = AssetType> implements It
 					error: {
 						problem: 'invalidState',
 						asset: this.asset.id,
+						itemName: this.name ?? '',
 						reason,
 					},
 				};
@@ -191,6 +192,7 @@ export abstract class ItemBase<Type extends AssetType = AssetType> implements It
 				error: {
 					problem: 'contentNotAllowed',
 					asset: this.asset.id,
+					itemName: this.name ?? '',
 				},
 			};
 
@@ -201,6 +203,7 @@ export abstract class ItemBase<Type extends AssetType = AssetType> implements It
 				error: {
 					problem: 'contentNotAllowed',
 					asset: this.asset.id,
+					itemName: this.name ?? '',
 				},
 			};
 

--- a/pandora-common/src/assets/item/_internal.ts
+++ b/pandora-common/src/assets/item/_internal.ts
@@ -56,6 +56,8 @@ export abstract class ItemBase<Type extends AssetType = AssetType> implements It
 		this.id = overrideProps?.id ?? props.id;
 		this.asset = overrideProps?.asset ?? props.asset;
 		this.color = overrideProps?.color ?? props.color;
+		this.name = overrideProps?.name ?? props.name;
+		this.description = overrideProps?.description ?? props.description;
 	}
 
 	protected static _parseBundle<Type extends AssetType = AssetType>(asset: Asset<Type>, bundle: ItemBundle, context: IItemLoadContext): ItemBaseProps<Type> {
@@ -225,6 +227,19 @@ export abstract class ItemBase<Type extends AssetType = AssetType> implements It
 		return this.withProps({
 			color: ItemBase._loadColorBundle(this.asset, color),
 		});
+	}
+
+	/** Returns a new item with the passed name and description */
+	public customize(newName: string, newDescription: string): Item<Type> {
+		let name: string | undefined = newName.trim();
+		if (name === '' || name === this.asset.definition.name)
+			name = undefined;
+
+		let description: string | undefined = newDescription.trim();
+		if (description === '')
+			description = undefined;
+
+		return this.withProps({ name, description });
 	}
 
 	@MemoizeNoArg

--- a/pandora-common/src/assets/item/base.ts
+++ b/pandora-common/src/assets/item/base.ts
@@ -46,6 +46,8 @@ export type ItemBundle = {
 	id: ItemId;
 	asset: AssetId;
 	color?: ItemColorBundle | HexRGBAColorString[];
+	name?: string;
+	description?: string;
 	moduleData?: Record<string, ItemModuleData>;
 	/** Room device specific data */
 	roomDeviceData?: RoomDeviceBundle;

--- a/pandora-common/src/assets/item/lock.ts
+++ b/pandora-common/src/assets/item/lock.ts
@@ -150,6 +150,7 @@ export class ItemLock extends ItemBase<'lock'> {
 				error: {
 					problem: 'contentNotAllowed',
 					asset: this.asset.id,
+					itemName: this.name ?? '',
 				},
 			};
 		}
@@ -194,6 +195,7 @@ export class ItemLock extends ItemBase<'lock'> {
 				moduleAction: action.action,
 				reason: 'blockSelf',
 				asset: this.asset.id,
+				itemName: this.name ?? '',
 			});
 			return null;
 		}
@@ -217,6 +219,7 @@ export class ItemLock extends ItemBase<'lock'> {
 				moduleAction: 'lock',
 				reason: 'noStoredPassword',
 				asset: this.asset.id,
+				itemName: this.name ?? '',
 			});
 			return null;
 		};
@@ -278,6 +281,7 @@ export class ItemLock extends ItemBase<'lock'> {
 					moduleAction: 'unlock',
 					reason: 'wrongPassword',
 					asset: this.asset.id,
+					itemName: this.name ?? '',
 				});
 			}
 		}

--- a/pandora-common/src/assets/item/roomDevice.ts
+++ b/pandora-common/src/assets/item/roomDevice.ts
@@ -140,6 +140,7 @@ export class ItemRoomDevice extends ItemBase<'roomDevice'> implements ItemRoomDe
 					error: {
 						problem: 'invalidState',
 						asset: this.asset.id,
+						itemName: this.name ?? '',
 						reason,
 					},
 				};
@@ -153,6 +154,7 @@ export class ItemRoomDevice extends ItemBase<'roomDevice'> implements ItemRoomDe
 				error: {
 					problem: 'contentNotAllowed',
 					asset: this.asset.id,
+					itemName: this.name ?? '',
 				},
 			};
 

--- a/pandora-common/src/assets/item/roomDeviceWearablePart.ts
+++ b/pandora-common/src/assets/item/roomDeviceWearablePart.ts
@@ -67,6 +67,7 @@ export class ItemRoomDeviceWearablePart extends ItemBase<'roomDeviceWearablePart
 				error: {
 					problem: 'contentNotAllowed',
 					asset: this.asset.id,
+					itemName: this.name ?? '',
 				},
 			};
 

--- a/pandora-common/src/assets/item/unified.ts
+++ b/pandora-common/src/assets/item/unified.ts
@@ -3,9 +3,9 @@ import { z, ZodTypeDef } from 'zod';
 import type { Asset } from '../asset';
 import type { AssetType } from '../definitions';
 
-import { LIMIT_OUTFIT_NAME_LENGTH, LIMIT_POSE_PRESET_NAME_LENGTH } from '../../inputLimits';
+import { LIMIT_ITEM_DESCRIPTION_LENGTH, LIMIT_ITEM_NAME_LENGTH, LIMIT_OUTFIT_NAME_LENGTH, LIMIT_POSE_PRESET_NAME_LENGTH } from '../../inputLimits';
 import { Assert, AssertNever } from '../../utility';
-import { HexRGBAColorStringSchema, ZodArrayWithInvalidDrop } from '../../validation';
+import { HexRGBAColorStringSchema, ZodArrayWithInvalidDrop, ZodTruncate } from '../../validation';
 import { AssetIdSchema } from '../base';
 import { CreateModuleDataFromTemplate, ItemModuleDataSchema, ItemModuleTemplateSchema } from '../modules';
 import { GenerateRandomItemId, IItemCreationContext, IItemLoadContext, Item, ItemBundle, ItemColorBundleSchema, ItemIdSchema, ItemTemplate } from './base';
@@ -26,6 +26,8 @@ export const ItemBundleSchema: z.ZodType<ItemBundle, ZodTypeDef, unknown> = z.ob
 	id: ItemIdSchema,
 	asset: AssetIdSchema,
 	color: ItemColorBundleSchema.or(z.array(HexRGBAColorStringSchema)).optional(),
+	name: z.string().transform(ZodTruncate(LIMIT_ITEM_NAME_LENGTH)).optional(),
+	description: z.string().transform(ZodTruncate(LIMIT_ITEM_DESCRIPTION_LENGTH)).optional(),
 	moduleData: z.record(z.lazy(() => ItemModuleDataSchema)).optional(),
 	/** Room device specific data */
 	roomDeviceData: RoomDeviceBundleSchema.optional(),

--- a/pandora-common/src/assets/modules.ts
+++ b/pandora-common/src/assets/modules.ts
@@ -50,12 +50,14 @@ export type ModuleActionError =
 		moduleAction: 'lock' | 'unlock';
 		reason: 'blockSelf';
 		asset: AssetId;
+		itemName: string;
 	}
 	| {
 		type: 'lockInteractionPrevented';
 		moduleAction: 'lock';
 		reason: 'noStoredPassword';
 		asset: AssetId;
+		itemName: string;
 	}
 	// Generic catch-all problem, supposed to be used when something simply went wrong (like bad data, target not found, and so on...)
 	| {
@@ -68,6 +70,7 @@ export type ModuleActionFailure =
 		moduleAction: 'unlock';
 		reason: 'wrongPassword';
 		asset: AssetId;
+		itemName: string;
 	};
 
 //#endregion

--- a/pandora-common/src/assets/modules/storage.ts
+++ b/pandora-common/src/assets/modules/storage.ts
@@ -170,6 +170,7 @@ export class ItemModuleStorage<TProperties = unknown, TStaticData = unknown> imp
 				error: {
 					problem: 'tooManyItems',
 					asset: null,
+					itemName: null,
 					limit: this.config.maxCount,
 				},
 			};
@@ -183,6 +184,7 @@ export class ItemModuleStorage<TProperties = unknown, TStaticData = unknown> imp
 				error: {
 					problem: 'contentNotAllowed',
 					asset: problematic.asset.id,
+					itemName: problematic.name ?? '',
 				},
 			};
 

--- a/pandora-common/src/assets/validation.ts
+++ b/pandora-common/src/assets/validation.ts
@@ -52,6 +52,7 @@ export function ValidateItemsPrefix(
 			error: {
 				problem: 'tooManyItems',
 				asset: null,
+				itemName: null,
 				limit,
 			},
 		};

--- a/pandora-common/src/character/restrictionTypes.ts
+++ b/pandora-common/src/character/restrictionTypes.ts
@@ -92,17 +92,20 @@ export type Restriction =
 	| {
 		type: 'blockedAddRemove';
 		asset: AssetId;
+		itemName: string;
 		self: boolean;
 	}
 	| {
 		type: 'blockedModule';
 		asset: AssetId;
+		itemName: string;
 		module: string;
 		self: boolean;
 	}
 	| {
 		type: 'covered';
 		asset: AssetId;
+		itemName: string;
 		attribute: string;
 	}
 	| {
@@ -129,4 +132,3 @@ export type RestrictionResult = {
 	allowed: false;
 	restriction: Restriction;
 };
-

--- a/pandora-common/src/character/restrictionsManager.ts
+++ b/pandora-common/src/character/restrictionsManager.ts
@@ -391,6 +391,7 @@ export class CharacterRestrictionsManager {
 					restriction: {
 						type: 'blockedAddRemove',
 						asset: item.asset.id,
+						itemName: item.name ?? '',
 						self: false,
 					},
 				};
@@ -402,6 +403,7 @@ export class CharacterRestrictionsManager {
 					restriction: {
 						type: 'blockedAddRemove',
 						asset: item.asset.id,
+						itemName: item.name ?? '',
 						self: true,
 					},
 				};
@@ -419,6 +421,7 @@ export class CharacterRestrictionsManager {
 					restriction: {
 						type: 'covered',
 						asset: item.asset.id,
+						itemName: item.name ?? '',
 						attribute: coveredAttribute,
 					},
 				};
@@ -521,6 +524,7 @@ export class CharacterRestrictionsManager {
 				restriction: {
 					type: 'blockedModule',
 					asset: item.asset.id,
+					itemName: item.name ?? '',
 					module: moduleName,
 					self: false,
 				},
@@ -533,6 +537,7 @@ export class CharacterRestrictionsManager {
 				restriction: {
 					type: 'blockedModule',
 					asset: item.asset.id,
+					itemName: item.name ?? '',
 					module: moduleName,
 					self: true,
 				},

--- a/pandora-common/src/chat/chat.ts
+++ b/pandora-common/src/chat/chat.ts
@@ -74,9 +74,11 @@ export type IChatMessageActionTargetCharacter = {
 };
 export type IChatMessageActionItem = {
 	assetId: AssetId;
+	itemName: string;
 };
 export type IChatMessageActionContainerPath = {
 	assetId: AssetId;
+	itemName: string;
 	module: string;
 }[];
 

--- a/pandora-common/src/inputLimits.ts
+++ b/pandora-common/src/inputLimits.ts
@@ -49,10 +49,10 @@ export const LIMIT_DIRECT_MESSAGE_LENGTH_BASE64 = LIMIT_DIRECT_MESSAGE_LENGTH * 
 
 export const LIMIT_DIRECT_MESSAGE_STORE_COUNT = 50;
 
-/** The maximum length of a custom item name (not yet implemented)*/
+/** The maximum length of a custom item name */
 export const LIMIT_ITEM_NAME_LENGTH = 40;
 
-/** The maximum length of a custom item description (not yet implemented) */
+/** The maximum length of a custom item description */
 export const LIMIT_ITEM_DESCRIPTION_LENGTH = 1_000;
 
 /** The maximum length of an account profile description */


### PR DESCRIPTION
Add support for user configurable custom item name and description

item name can be configured how to appear in wardrobe and action text separately, options
- `original name`
- `custom name`
- `custom name [original name]` - default for both

current implementation skips:
- item template support
- change items on other characters

character restrictions that could be changed later
- `name`: unfiltered for now
- `description` unfiltered