### PR TITLE
[FIX] Do not freeze asset preferences data before cleanup

### DIFF
--- a/pandora-common/src/gameLogic/assetPreferences/assetPreferencesSubsystemServer.ts
+++ b/pandora-common/src/gameLogic/assetPreferences/assetPreferencesSubsystemServer.ts
@@ -1,7 +1,7 @@
 import { Immutable, freeze } from 'immer';
 import type { AssetManager } from '../../assets/assetManager';
 import { AssetPreferenceType, AssetPreferencesPublic, AssetPreferencesServer, CleanupAssetPreferences, IsAssetPreferenceType } from '../../character/assetPreferences';
-import { KnownObject } from '../../utility';
+import { CloneDeepMutable, KnownObject } from '../../utility';
 import type { GameLogicCharacterServer } from '../character/characterServer';
 import { GameLogicPermissionServer, IPermissionProvider } from '../permissions';
 import { ASSET_PREFERENCES_PERMISSIONS, AssetPreferencesSubsystem } from './assetPreferencesSubsystem';
@@ -18,11 +18,12 @@ export class AssetPreferencesSubsystemServer extends AssetPreferencesSubsystem i
 	constructor(character: GameLogicCharacterServer, data: AssetPreferencesServer, assetManager: AssetManager) {
 		super();
 		// Load and cleanup preferences data
-		this._publicPreferences = freeze({
+		this._publicPreferences = CloneDeepMutable({
 			assets: data.assets,
 			attributes: data.attributes,
-		}, true);
+		});
 		CleanupAssetPreferences(assetManager, this._publicPreferences);
+		freeze(this._publicPreferences, true);
 
 		// Load permissions
 		const permissions = new Map<AssetPreferenceType, GameLogicPermissionServer>();


### PR DESCRIPTION
Freezing the data before cleanup obviously causes error when the cleanup would actually try to change something.
This in turn prevented old characters that did have limits set for unknown attributes from loading successfully.

Fixes the following crash:
```
Failed to load character c*** for access ***:
 [TypeError: Cannot delete property 'Vagina_protruding' of #<Object>
    at CleanupAssetPreferences (/app/node_modules/.pnpm/pandora-common@file+pandora-common/node_modules/pandora-common/src/character/assetPreferences.ts:111:22)
    at AssetPreferencesSubsystemServer (/app/node_modules/.pnpm/pandora-common@file+pandora-common/node_modules/pandora-common/src/gameLogic/assetPreferences/assetPreferencesSubsystemServer.ts:25:26)
    at GameLogicCharacterServer (/app/node_modules/.pnpm/pandora-common@file+pandora-common/node_modules/pandora-common/src/gameLogic/character/characterServer.ts:25:27)
    at Character (/app/src/character/character.ts:202:29)
    at CharacterManager.loadCharacter (/app/src/character/characterManager.ts:62:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Promise.all (index 11)
    at SocketIODirectoryConnector.updateFromDirectory (/app/src/networking/socketio_directory_connector.ts:238:4)
    at MessageHandler.onMessage (/app/node_modules/.pnpm/pandora-common@file+pandora-common/node_modules/pandora-common/src/networking/message_handler.ts:68:11)
]
```