### PR TITLE
[FIX] Downgrade pnpm to 9.0.6 due to failing deployment, add Docker CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,27 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
 
+  build-docker:
+    name: Build (Docker)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build (pandora-server-directory)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: pandora-server-directory
+          tags: pandora/server-directory:latest
+      - name: Build (pandora-server-shard)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: pandora-server-shard
+          tags: pandora/server-shard:latest
+
   install-common:
     name: Check installability of pandora-common
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"private": true,
-	"packageManager": "pnpm@9.1.0",
+	"packageManager": "pnpm@9.0.6",
 	"pnpm": {
 		"overrides": {
 			"@types/css-font-loading-module": "0.0.13",


### PR DESCRIPTION
Downgrades pnpm as the latest version is failing with the following errors during docker build, shrinkwrap phase.
Also add a CI to try building docker image to catch this error.

```
 WARN  Failed to create bin at /app/deploy/directory/node_modules/.bin/acorn. ENOENT: no such file or directory, open '/app/deploy/directory/node_modules/.pnpm/acorn@8.11.3/node_modules/acorn/bin/acorn'
 WARN  Failed to create bin at /app/deploy/directory/node_modules/.bin/browserslist. ENOENT: no such file or directory, open '/app/deploy/directory/node_modules/.pnpm/browserslist@4.23.0/node_modules/browserslist/cli.js'
 WARN  Failed to create bin at /app/deploy/directory/node_modules/.bin/ts-node. ENOENT: no such file or directory, open '/app/deploy/directory/node_modules/.pnpm/ts-node@10.9.2_@types+node@20.12.8_typescript@5.4.5/node_modules/ts-node/dist/bin.js'
 WARN  Failed to create bin at /app/deploy/directory/node_modules/.bin/ts-node-cwd. ENOENT: no such file or directory, open '/app/deploy/directory/node_modules/.pnpm/ts-node@10.9.2_@types+node@20.12.8_typescript@5.4.5/node_modules/ts-node/dist/bin-cwd.js'
 WARN  Failed to create bin at /app/deploy/directory/node_modules/.bin/ts-node-esm. ENOENT: no such file or directory, open '/app/deploy/directory/node_modules/.pnpm/ts-node@10.9.2_@types+node@20.12.8_typescript@5.4.5/node_modules/ts-node/dist/bin-esm.js'
 WARN  Failed to create bin at /app/deploy/directory/node_modules/.bin/ts-node-script. ENOENT: no such file or directory, open '/app/deploy/directory/node_modules/.pnpm/ts-node@10.9.2_@types+node@20.12.8_typescript@5.4.5/node_modules/ts-node/dist/bin-script.js'
 WARN  Failed to create bin at /app/deploy/directory/node_modules/.bin/ts-node-transpile-only. ENOENT: no such file or directory, open '/app/deploy/directory/node_modules/.pnpm/ts-node@10.9.2_@types+node@20.12.8_typescript@5.4.5/node_modules/ts-node/dist/bin-transpile.js'
 WARN  Failed to create bin at /app/deploy/directory/node_modules/.bin/ts-script. ENOENT: no such file or directory, open '/app/deploy/directory/node_modules/.pnpm/ts-node@10.9.2_@types+node@20.12.8_typescript@5.4.5/node_modules/ts-node/dist/bin-script-deprecated.js'
. postinstall$ node .hooks/postinstall.cjs
. postinstall: Done
 ERR_PNPM_PEER_DEP_ISSUES  Unmet peer dependencies

.
└─┬ ts-node 10.9.2
  └── ✕ missing peer typescript@>=2.7
Peer dependencies that should be installed:
  typescript@>=2.7
```