### PR TITLE
[FIX] Revert "[CHORE] Update pnpm to v9.1.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"private": true,
-	"packageManager": "pnpm@9.1.0",
+	"packageManager": "pnpm@9.0.6",
 	"pnpm": {
 		"overrides": {
 			"@types/css-font-loading-module": "0.0.13",


### PR DESCRIPTION
Reverts Project-Pandora-Game/pandora#761

The PR was auto-merged because the failing check wasn't set as required. That is now fixed.