### PR TITLE
[FEATURE] Multiple texture resolutions support

### DIFF
--- a/pandora-client-web/src/assets/assetGraphics.ts
+++ b/pandora-client-web/src/assets/assetGraphics.ts
@@ -10,6 +10,7 @@ import { EvaluateCondition } from '../graphics/utility';
 import { Observable, ReadonlyObservable, useObservable } from '../observable';
 import { useAssetManager } from './assetManager';
 import { GraphicsManagerInstance } from './graphicsManager';
+import { useAutomaticResolution } from '../services/screenResolution/screenResolution';
 
 export interface PointDefinitionCalculated extends PointDefinition {
 	index: number;
@@ -417,16 +418,19 @@ export function useImageResolutionAlternative(image: string): {
 	scale: number;
 } {
 	const { textureResolution } = useGraphicsSettings();
+	const automaticResolution = useAutomaticResolution();
+
+	const finalTextureResolution = textureResolution === 'auto' ? automaticResolution : textureResolution;
 
 	const EXTENSIONS = ['.png', '.jpg'];
 
 	for (const ext of EXTENSIONS) {
 		if (image.endsWith(ext)) {
-			if (textureResolution !== '1') {
+			if (finalTextureResolution !== '1') {
 				return {
-					image: image.substring(0, image.length - ext.length) + `_r${textureResolution}${ext}`,
-					resolution: 1 / GRAPHICS_TEXTURE_RESOLUTION_SCALE[textureResolution],
-					scale: GRAPHICS_TEXTURE_RESOLUTION_SCALE[textureResolution],
+					image: image.substring(0, image.length - ext.length) + `_r${finalTextureResolution}${ext}`,
+					resolution: 1 / GRAPHICS_TEXTURE_RESOLUTION_SCALE[finalTextureResolution],
+					scale: GRAPHICS_TEXTURE_RESOLUTION_SCALE[finalTextureResolution],
 				};
 			}
 		}

--- a/pandora-client-web/src/components/settings/helpers/settingsInputs.tsx
+++ b/pandora-client-web/src/components/settings/helpers/settingsInputs.tsx
@@ -60,11 +60,12 @@ export function ToggleSettingInput({ currentValue, defaultValue, label, onChange
 	);
 }
 
-export function SelectSettingInput<TValue extends string>({ currentValue, defaultValue, label, stringify, schema, onChange, onReset, deps }: {
+export function SelectSettingInput<TValue extends string>({ currentValue, defaultValue, label, stringify, optionOrder, schema, onChange, onReset, deps }: {
 	currentValue: TValue | undefined;
 	defaultValue: TValue;
 	label: ReactNode;
-	stringify: Readonly<Record<TValue, string>>;
+	stringify: Readonly<Record<TValue, string | (() => string)>>;
+	optionOrder?: readonly TValue[];
 	schema: ZodSchema<TValue, ZodTypeDef, unknown>;
 	onChange: (newValue: TValue) => void;
 	onReset?: () => void;
@@ -91,15 +92,19 @@ export function SelectSettingInput<TValue extends string>({ currentValue, defaul
 		setValue(newValue);
 	}, [schema, setValue]);
 
-	const options = useMemo(() => (
-		KnownObject
-			.entries(stringify)
-			.map(([k, v]) => (
-				<option key={ k } value={ k }>
-					{ v }
-				</option>
-			))
-	), [stringify]);
+	const options = useMemo(() => {
+		const entries = KnownObject.entries(stringify);
+
+		if (optionOrder != null) {
+			entries.sort((a, b) => optionOrder.indexOf(a[0]) - optionOrder.indexOf(b[0]));
+		}
+
+		return entries.map(([k, v]) => (
+			<option key={ k } value={ k }>
+				{ typeof v === 'function' ? v() : v }
+			</option>
+		));
+	}, [stringify, optionOrder]);
 
 	return (
 		<div className='input-section'>

--- a/pandora-client-web/src/editor/index.tsx
+++ b/pandora-client-web/src/editor/index.tsx
@@ -12,6 +12,7 @@ import { LoadSearchArgs } from '../config/searchArgs';
 import { ConfigurePixiSettings } from '../graphics/pixiSettings';
 import '../index.scss';
 import { TOAST_OPTIONS_ERROR } from '../persistentToast';
+import { ScreenResolutionSerice } from '../services/screenResolution/screenResolution';
 import '../styles/globalUtils.scss';
 import { LoadAssetsFromAssetDevServer, LoadAssetsFromFileSystem, LoadAssetsFromOfficialLink } from './assetLoader';
 import { AssetManagerEditor } from './assets/assetManager';
@@ -32,7 +33,9 @@ async function Start(): Promise<void> {
 	LoadSearchArgs();
 	SetupLogging();
 	ConfigurePixiSettings();
-	logger.info('Starting...');
+	// Force full resolution for all textures
+	ScreenResolutionSerice.forceFullResolution = true;
+	logger.info('Starting editor...');
 	createRoot(document.querySelector('#editor-root') as HTMLElement).render(
 		<React.StrictMode>
 			<EulaGate>

--- a/pandora-client-web/src/graphics/graphicsLayer.tsx
+++ b/pandora-client-web/src/graphics/graphicsLayer.tsx
@@ -1,19 +1,19 @@
 import { Container, Sprite, useApp } from '@pixi/react';
 import Delaunator from 'delaunator';
-import { AppearanceItems, Assert, BoneName, CharacterSize, CoordinatesCompressed, Item, LayerMirror, PointDefinition, Rectangle as PandoraRectangle, HexColorString, AssertNever, AssetFrameworkCharacterState } from 'pandora-common';
+import { AppearanceItems, Assert, AssertNever, AssetFrameworkCharacterState, BoneName, CharacterSize, CoordinatesCompressed, HexColorString, Item, LayerMirror, Rectangle as PandoraRectangle, PointDefinition } from 'pandora-common';
 import * as PIXI from 'pixi.js';
 import { IArrayBuffer, Rectangle, Texture } from 'pixi.js';
-import React, { createContext, ReactElement, useCallback, useContext, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { AssetGraphicsLayer, PointDefinitionCalculated, useLayerCalculatedPoints, useLayerDefinition, useLayerHasAlphaMasks, useLayerImageSource } from '../assets/assetGraphics';
+import React, { ReactElement, createContext, useCallback, useContext, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { AssetGraphicsLayer, PointDefinitionCalculated, useImageResolutionAlternative, useLayerCalculatedPoints, useLayerDefinition, useLayerHasAlphaMasks, useLayerImageSource } from '../assets/assetGraphics';
 import { ChildrenProps } from '../common/reactTypes';
 import { ConditionEvaluatorBase, useAppearanceConditionEvaluator } from './appearanceConditionEvaluator';
 import { LayerStateOverrides } from './def';
 import { GraphicsMaskLayer } from './graphicsMaskLayer';
 import { useGraphicsSettings } from './graphicsSettings';
 import { PixiMesh } from './pixiMesh';
+import { RoomDeviceRenderContext } from './room/roomDeviceContext';
 import { useTexture } from './useTexture';
 import { EvaluateCondition, useAppOptional } from './utility';
-import { RoomDeviceRenderContext } from './room/roomDeviceContext';
 
 export function useLayerPoints(layer: AssetGraphicsLayer): {
 	points: readonly PointDefinitionCalculated[];
@@ -166,7 +166,7 @@ export function GraphicsLayer({
 		indices: triangles,
 	}), [vertices, uv, triangles]);
 
-	const texture = useTexture(image, undefined, getTexture);
+	const texture = useTexture(useImageResolutionAlternative(image).image, undefined, getTexture);
 
 	const { color, alpha } = useItemColor(characterState.items, item, colorizationKey, state);
 

--- a/pandora-client-web/src/graphics/graphicsScene.tsx
+++ b/pandora-client-web/src/graphics/graphicsScene.tsx
@@ -1,15 +1,16 @@
-import React, { Context, ReactElement, ReactNode, Ref, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Application, Filter } from 'pixi.js';
 import { Sprite } from '@pixi/react';
+import classNames from 'classnames';
+import { CharacterSize } from 'pandora-common';
+import { Application, Filter } from 'pixi.js';
+import React, { Context, ReactElement, ReactNode, Ref, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useImageResolutionAlternative } from '../assets/assetGraphics';
 import { ChildrenProps } from '../common/reactTypes';
 import { useEvent } from '../common/useEvent';
-import { PixiViewport, PixiViewportRef, PixiViewportSetupCallback } from './pixiViewport';
-import { CharacterSize } from 'pandora-common';
-import { GraphicsSceneRendererDirect, GraphicsSceneRendererShared } from './graphicsSceneRenderer';
-import classNames from 'classnames';
-import { useGraphicsSettings } from './graphicsSettings';
-import { useTexture } from './useTexture';
 import { LocalErrorBoundary } from '../components/error/localErrorBoundary';
+import { GraphicsSceneRendererDirect, GraphicsSceneRendererShared } from './graphicsSceneRenderer';
+import { useGraphicsSettings } from './graphicsSettings';
+import { PixiViewport, PixiViewportRef, PixiViewportSetupCallback } from './pixiViewport';
+import { useTexture } from './useTexture';
 
 export type GraphicsSceneProps = {
 	viewportConfig?: PixiViewportSetupCallback;
@@ -180,7 +181,7 @@ export function GraphicsBackground({
 		};
 	}, [background]);
 
-	const backgroundTexture = useTexture(backgroundResult.backgroundImage, true);
+	const backgroundTexture = useTexture(useImageResolutionAlternative(backgroundResult.backgroundImage).image, true);
 
 	return (
 		<Sprite

--- a/pandora-client-web/src/graphics/graphicsScene.tsx
+++ b/pandora-client-web/src/graphics/graphicsScene.tsx
@@ -207,16 +207,16 @@ export function GraphicsScene({
 	sceneOptions?: GraphicsSceneProps;
 	divChildren?: ReactNode;
 } & React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>): ReactElement {
-	const { resolution } = useGraphicsSettings();
+	const { renderResolution } = useGraphicsSettings();
 
 	const [div, setDiv] = useState<HTMLDivElement | null>(null);
 
 	return (
 		<LocalErrorBoundary errorOverlayClassName={ className }>
-			<div className={ classNames({ disabled: resolution <= 0 }, className) } { ...divProps } ref={ setDiv }>
+			<div className={ classNames({ disabled: renderResolution <= 0 }, className) } { ...divProps } ref={ setDiv }>
 				{
-					div && resolution > 0 ? (
-						<GraphicsSceneCore { ...sceneOptions } div={ div } resolution={ resolution / 100 }>
+					div && renderResolution > 0 ? (
+						<GraphicsSceneCore { ...sceneOptions } div={ div } resolution={ renderResolution / 100 }>
 							{ children }
 						</GraphicsSceneCore>
 					) : null

--- a/pandora-client-web/src/graphics/graphicsSettings.tsx
+++ b/pandora-client-web/src/graphics/graphicsSettings.tsx
@@ -2,18 +2,20 @@ import { CloneDeepMutable } from 'pandora-common';
 import React, { ReactElement, useMemo } from 'react';
 import { z } from 'zod';
 import { BrowserStorage } from '../browserStorage';
+import { ContextHelpButton } from '../components/help/contextHelpButton';
 import { SelectSettingInput } from '../components/settings/helpers/settingsInputs';
 import { useObservable } from '../observable';
-import { ContextHelpButton } from '../components/help/contextHelpButton';
 
 export const GraphicsSettingsSchema = z.object({
 	renderResolution: z.number().int().min(0).max(100),
+	textureResolution: z.enum(['1', '0.5', '0.25']),
 	alphamaskEngine: z.enum(['pixi', 'customShader', 'disabled']),
 });
 export type GraphicsSettings = z.infer<typeof GraphicsSettingsSchema>;
 
 const GRAPHICS_SETTINGS_DEFAULT: GraphicsSettings = {
 	renderResolution: 100,
+	textureResolution: '1',
 	alphamaskEngine: 'disabled',
 };
 
@@ -50,8 +52,20 @@ export function GraphicsSettings(): ReactElement | null {
 	);
 }
 
+const GRAPHICS_TEXTURE_RESOLUTION_DESCRIPTIONS: Record<GraphicsSettings['textureResolution'], string> = {
+	'1': 'Full',
+	'0.5': '50%',
+	'0.25': '25%',
+};
+
+export const GRAPHICS_TEXTURE_RESOLUTION_SCALE: Record<GraphicsSettings['textureResolution'], number> = {
+	'1': 1,
+	'0.5': 2,
+	'0.25': 4,
+};
+
 function QualitySettings(): ReactElement {
-	const { renderResolution, alphamaskEngine } = useObservable(storage);
+	const { renderResolution, textureResolution, alphamaskEngine } = useObservable(storage);
 
 	const ALPHAMASK_ENGINES_DESCRIPTIONS: Record<GraphicsSettings['alphamaskEngine'], string> = {
 		pixi: 'Pixi.js',
@@ -65,7 +79,7 @@ function QualitySettings(): ReactElement {
 			<SelectSettingInput<string>
 				currentValue={ renderResolution?.toString() }
 				defaultValue={ GRAPHICS_SETTINGS_DEFAULT.renderResolution.toString() }
-				label='Resolution'
+				label='Render resolution'
 				stringify={
 					Object.fromEntries(
 						([100, 90, 80, 65, 50, 25, 0])
@@ -78,6 +92,15 @@ function QualitySettings(): ReactElement {
 					SetGraphicsSettings({ renderResolution: newValue });
 				} }
 				onReset={ () => ResetGraphicsSettings(['renderResolution']) }
+			/>
+			<SelectSettingInput<GraphicsSettings['textureResolution']>
+				currentValue={ textureResolution }
+				defaultValue={ GRAPHICS_SETTINGS_DEFAULT.textureResolution }
+				label='Texture resolution'
+				stringify={ GRAPHICS_TEXTURE_RESOLUTION_DESCRIPTIONS }
+				schema={ GraphicsSettingsSchema.shape.textureResolution }
+				onChange={ (v) => SetGraphicsSettings({ textureResolution: v }) }
+				onReset={ () => ResetGraphicsSettings(['textureResolution']) }
 			/>
 			<SelectSettingInput<GraphicsSettings['alphamaskEngine']>
 				currentValue={ alphamaskEngine }

--- a/pandora-client-web/src/graphics/graphicsSettings.tsx
+++ b/pandora-client-web/src/graphics/graphicsSettings.tsx
@@ -23,6 +23,14 @@ const GRAPHICS_SETTINGS_DEFAULT: GraphicsSettings = {
 };
 
 const storage = BrowserStorage.create<Partial<GraphicsSettings>>('settings.graphics', {}, GraphicsSettingsSchema.partial());
+// Add a hook to purge the current graphics loader cache when the graphics settins change in any way
+// (most of the changes cause different textures to be loaded, so get rid of old ones)
+storage.subscribe(() => {
+	// Do the cleanup asynchronously so things have time to unload if they were loaded
+	setTimeout(() => {
+		GraphicsManagerInstance.value?.loader.gc();
+	}, 500);
+});
 
 export function useGraphicsSettings(): GraphicsSettings {
 	const overrides = useObservable(storage);
@@ -51,9 +59,9 @@ function ResetGraphicsSettings(settings: readonly (keyof GraphicsSettings)[]): v
 
 export function GraphicsSettings(): ReactElement | null {
 	return (
-<>
-		<QualitySettings />
-<GraphicsDebug />
+		<>
+			<QualitySettings />
+			<GraphicsDebug />
 		</>
 	);
 }

--- a/pandora-client-web/src/graphics/graphicsSettings.tsx
+++ b/pandora-client-web/src/graphics/graphicsSettings.tsx
@@ -7,13 +7,13 @@ import { useObservable } from '../observable';
 import { ContextHelpButton } from '../components/help/contextHelpButton';
 
 export const GraphicsSettingsSchema = z.object({
-	resolution: z.number().int().min(0).max(100),
+	renderResolution: z.number().int().min(0).max(100),
 	alphamaskEngine: z.enum(['pixi', 'customShader', 'disabled']),
 });
 export type GraphicsSettings = z.infer<typeof GraphicsSettingsSchema>;
 
 const GRAPHICS_SETTINGS_DEFAULT: GraphicsSettings = {
-	resolution: 100,
+	renderResolution: 100,
 	alphamaskEngine: 'disabled',
 };
 
@@ -51,7 +51,7 @@ export function GraphicsSettings(): ReactElement | null {
 }
 
 function QualitySettings(): ReactElement {
-	const { resolution, alphamaskEngine } = useObservable(storage);
+	const { renderResolution, alphamaskEngine } = useObservable(storage);
 
 	const ALPHAMASK_ENGINES_DESCRIPTIONS: Record<GraphicsSettings['alphamaskEngine'], string> = {
 		pixi: 'Pixi.js',
@@ -63,8 +63,8 @@ function QualitySettings(): ReactElement {
 		<fieldset>
 			<legend>Quality</legend>
 			<SelectSettingInput<string>
-				currentValue={ resolution?.toString() }
-				defaultValue={ GRAPHICS_SETTINGS_DEFAULT.resolution.toString() }
+				currentValue={ renderResolution?.toString() }
+				defaultValue={ GRAPHICS_SETTINGS_DEFAULT.renderResolution.toString() }
 				label='Resolution'
 				stringify={
 					Object.fromEntries(
@@ -74,10 +74,10 @@ function QualitySettings(): ReactElement {
 				}
 				schema={ z.string() }
 				onChange={ (v) => {
-					const newValue = GraphicsSettingsSchema.shape.resolution.parse(Number.parseInt(v, 10));
-					SetGraphicsSettings({ resolution: newValue });
+					const newValue = GraphicsSettingsSchema.shape.renderResolution.parse(Number.parseInt(v, 10));
+					SetGraphicsSettings({ renderResolution: newValue });
 				} }
-				onReset={ () => ResetGraphicsSettings(['resolution']) }
+				onReset={ () => ResetGraphicsSettings(['renderResolution']) }
 			/>
 			<SelectSettingInput<GraphicsSettings['alphamaskEngine']>
 				currentValue={ alphamaskEngine }

--- a/pandora-client-web/src/graphics/useTexture.ts
+++ b/pandora-client-web/src/graphics/useTexture.ts
@@ -36,6 +36,7 @@ export function useTexture(
 	const [texture, setTexture] = useState<{
 		readonly image: string;
 		readonly texture: Texture;
+		readonly lock?: () => (() => void);
 	}>(RESULT_NO_TEXTURE);
 
 	useEffect(() => {
@@ -58,11 +59,12 @@ export function useTexture(
 			return;
 		}
 
-		const unregister = loader.useTexture(image, (t) => {
+		const unregister = loader.useTexture(image, (t, lock) => {
 			if (wanted.current === image) {
 				setTexture({
 					image,
 					texture: t,
+					lock,
 				});
 			}
 		});
@@ -75,6 +77,10 @@ export function useTexture(
 	}, [manager, image, customGetTexture]);
 
 	const suspenseAsset = useRegisterSuspenseAsset();
+
+	useEffect(() => {
+		return texture.lock?.();
+	}, [texture]);
 
 	// Special cases of textures
 

--- a/pandora-client-web/src/services/screenResolution/screenResolution.ts
+++ b/pandora-client-web/src/services/screenResolution/screenResolution.ts
@@ -36,8 +36,13 @@ export const ScreenResolutionSerice = new class ScreenResolutionSerice extends T
 	private readonly _screenSizeObserver: ResizeObserver;
 
 	public get automaticTextureResolution(): Exclude<GraphicsSettings['textureResolution'], 'auto'> {
+		if (this.forceFullResolution)
+			return '1';
+
 		return AUTOMATIC_TEXTURE_RESOLUTIONS[this._automaticResolutionIndex.value]?.[2] ?? '1';
 	}
+
+	public forceFullResolution: boolean = false;
 
 	private _screenWidth = 0;
 	private _screenHeight = 0;

--- a/pandora-client-web/test/setup.ts
+++ b/pandora-client-web/test/setup.ts
@@ -1,4 +1,5 @@
 /// <reference types="@types/node" />
+/// <reference types="@types/jest" />
 import '@testing-library/jest-dom';
 import { Assert, logConfig, LogLevel, SetConsoleOutput } from 'pandora-common';
 import { webcrypto } from 'crypto';
@@ -33,6 +34,14 @@ globalThis.Worker = class Worker {
 		throw new Error('Not implemented');
 	}
 };
+
+// Polyfill ResizeObserver as JSDom doesn't support it
+Assert(typeof globalThis.ResizeObserver === 'undefined');
+globalThis.ResizeObserver = jest.fn().mockImplementation(() => ({
+	observe: jest.fn(),
+	unobserve: jest.fn(),
+	disconnect: jest.fn(),
+}));
 
 // Logging setup
 SetConsoleOutput(LogLevel.FATAL);


### PR DESCRIPTION
**Depends on [pandora-assets#242](https://github.com/Project-Pandora-Game/pandora-assets/pull/242).**

Adds a support for using down-scaled textures.
At the moment resolutions 1 (no change), 1/2, and 1/4 can be selected. This applies to normal assets, room devices and room backgrounds; no matter which screen uses them (both room and wardrobe).

There is also an option for "auto", which tries to guess best resolution automatically (might need tweaking in the future). This is the default.
It works by looking at the true pixel size of the screen (so window size multiplied by DevicePixelRatio (a.k.a. factional scaling). It is tuned such that PC FHD (1080p) screen gets 1/2 resolution (it still looks rather good!), but QHD (1440p) gets full resolution.
For phones the logic works the exact same. To be specific there are thresholds for both width and height, combined with an 'OR'.
The automatic resolution is remembered and reused the next time. The screen is also observed for changes and the resolution might get automatically upgraded if the window is resized. It is never downgraded automatically.