### PR TITLE
[FIX] Allow scrolling in the remaining Contacts tabs

### DIFF
--- a/pandora-client-web/src/components/accountContacts/accountContacts.tsx
+++ b/pandora-client-web/src/components/accountContacts/accountContacts.tsx
@@ -66,21 +66,23 @@ function ClearIncoming() {
 function ShowAccountContacts({ type }: { type: IAccountContact['type']; }) {
 	const rel = useAccountContacts(type);
 	return (
-		<table>
-			<thead>
-				<tr>
-					<th>ID</th>
-					<th>Name</th>
-					<th>Created</th>
-					<th>Actions</th>
-				</tr>
-			</thead>
-			<tbody>
-				{ rel.map((r) => (
-					<AccountContactsRow key={ r.id } { ...r } />
-				)) }
-			</tbody>
-		</table>
+		<Scrollable color='dark'>
+			<table className='fill-x'>
+				<thead>
+					<tr>
+						<th>ID</th>
+						<th>Name</th>
+						<th>Created</th>
+						<th>Actions</th>
+					</tr>
+				</thead>
+				<tbody>
+					{ rel.map((r) => (
+						<AccountContactsRow key={ r.id } { ...r } />
+					)) }
+				</tbody>
+			</table>
+		</Scrollable>
 	);
 }
 

--- a/pandora-client-web/src/components/directMessages/directMessages.scss
+++ b/pandora-client-web/src/components/directMessages/directMessages.scss
@@ -16,10 +16,10 @@
 		}
 
 		ul {
-			padding: 0 0.5em;
+			margin: 0;
+			padding: 0.5em;
 			list-style-type: none;
-			overflow-x: hidden;
-			overflow-y: scroll;
+			flex: 1;
 		}
 
 		li {
@@ -45,13 +45,6 @@
 				background-color: $grey-mid;
 				font-style: italic;
 			}
-		}
-
-		.input-line {
-			display: flex;
-			flex-flow: row;
-			position: absolute;
-			bottom: 0;
 		}
 	}
 

--- a/pandora-client-web/src/components/directMessages/directMessages.tsx
+++ b/pandora-client-web/src/components/directMessages/directMessages.tsx
@@ -5,7 +5,8 @@ import { useCurrentAccount, useDirectoryConnector } from '../gameContext/directo
 import { DirectMessage } from '../directMessage/directMessage';
 import './directMessages.scss';
 import { Button } from '../common/button/button';
-import { Scrollbar } from '../common/scrollbar/scrollbar';
+import { Scrollable } from '../common/scrollbar/scrollbar';
+import { Column, Row } from '../common/container/container';
 
 export function DirectMessages(): React.ReactElement {
 	const directory = useDirectoryConnector();
@@ -26,18 +27,18 @@ export function DirectMessages(): React.ReactElement {
 
 	return (
 		<div className='direct-messages'>
-			<div className='direct-messages__list'>
+			<Column className='direct-messages__list' gap='none'>
 				<input type='text' value={ filter } onChange={ (e) => setFilter(e.target.value) } placeholder='Filter' />
-				<Scrollbar color='dark' tag='ul'>
+				<Scrollable color='dark' tag='ul'>
 					{ selected == null ? null : (
 						<Suspense>
 							<DirectMessageTempInfo selected={ selected } filtered={ filtered } />
 						</Suspense>
 					) }
 					{ filtered.map((i) => <DirectMessageInfo key={ i.id } info={ i } selected={ i.id === selected } />) }
-				</Scrollbar>
+				</Scrollable>
 				<OpenConversation />
-			</div>
+			</Column>
 			{ selected != null && <DirectMessage accountId={ selected } key={ selected } /> }
 		</div>
 	);
@@ -97,9 +98,9 @@ function OpenConversation(): React.ReactElement {
 	}, [onClick]);
 
 	return (
-		<div className='input-line'>
+		<Row gap='none'>
 			<input type='text' inputMode='numeric' pattern='\d*' ref={ ref } onKeyDown={ onKeyDown } placeholder='Account ID' />
 			<Button className='slim' onClick={ onClick }>Start</Button>
-		</div>
+		</Row>
 	);
 }


### PR DESCRIPTION
This is a followup to #786, which added scrolling to the current contacts lists.
This PR adds scrolling to the remaining tabs, including fixing scrolling of the open DMs list.

Changelog:
```md
Fixes:
- The remaining tabs in the contacts screen now support scrolling
- Fixed some open Direct Messaging entries possibly being hidden while scrolling
```