### PR TITLE
[CHANGE] Allow reordering locked items

### DIFF
--- a/pandora-common/src/character/restrictionTypes.ts
+++ b/pandora-common/src/character/restrictionTypes.ts
@@ -47,7 +47,7 @@ export enum ItemInteractionType {
 	 */
 	MODIFY = 'MODIFY',
 	/**
-	 * Item being added, removed or reordered.
+	 * Item being added or removed.
 	 *
 	 * Requirements:
 	 * - Requires all `ACCESS_ONLY` requirements
@@ -60,6 +60,18 @@ export enum ItemInteractionType {
 	 *   - If asset has `blockSelfAddRemove`, then cannot happen on self
 	 */
 	ADD_REMOVE = 'ADD_REMOVE',
+	/**
+	 * Item being reordered.
+	 *
+	 * Requirements:
+	 * - Requires all `ACCESS_ONLY` requirements
+	 * - If asset __is__ bodypart:
+	 *   - Must not be in room or the room must allow body modification
+	 *   - Must be targetting herself
+	 * - If asset __is not__ bodypart:
+	 *   - Player must be able to use hands
+	 */
+	REORDER = 'REORDER',
 	/**
 	 * Character is entering or leaving a room device.
 	 * This action happens on _both_ the device itself and the wearable part.

--- a/pandora-common/src/character/restrictionsManager.ts
+++ b/pandora-common/src/character/restrictionsManager.ts
@@ -432,7 +432,8 @@ export class CharacterRestrictionsManager {
 		if (
 			interaction === ItemInteractionType.STYLING ||
 			interaction === ItemInteractionType.MODIFY ||
-			interaction === ItemInteractionType.ADD_REMOVE
+			interaction === ItemInteractionType.ADD_REMOVE ||
+			interaction === ItemInteractionType.REORDER
 		) {
 			if (!this.canUseHands() && !forceAllowItemActions)
 				return {


### PR DESCRIPTION
<!--
Thank you for your pull request!

These comments will guide you through creating a pull request and filling in all that is required. You don't need to remove the comments when you are done.
You can view CONTRIBUTING.md for a detailed description of the pull request process.

Title for the pull request should be in the following form: [TYPE] Short name that is understandable by itself
TYPE should be one of the following: FEATURE, ADD, CHANGE, REMOVE, FIX, REFACTOR, DEV, CHORE
The rest of the title should describe what the PR changes mainly, doesn't need to describe the details of the change (someone looking at the list of PRs should be able to tell which part of Pandora it touches, not necessarily how).
Use past tense.
-->

## References

<!--
Add references to issues or other pull requests here, for example:
fixes #42
resolves #69
ref #123   (use to reference related things within Pandora's repositories, without special meaning)
xref #666   (use to reference _external_ resources; use full https URL)
-->

_None_

## About The Pull Request

<!--
Describe *what* you are trying to do.
This sets expectation for the reviewer, making it easier to get into reviewing it.

[optional]
If the change is more complex, then try to explain why and how is it accomplished.
This is, however, much less important than the "what", as that is more easily seen from code than the aim is, usually.
-->

This PR changes the restrictions logic of `transfer` and `move` actions so that reordering of items within a single container is not treated as removing and re-adding the item. In this change it allows reordering items even if they cannot be removed.

Reordering locked item with relation to unlocked ones was possible before by simply reordering the unlocked ones freely, so this change only affects relative position of two locked items.

The reasoning behind this change is, that if two locked items shouldn't be reorder-able, there should already be a blocking relationship between them which prevents interactions with the item below. If the two items don't have attribute-based relationship, then they can be treated as separate and can be freely reordered.
Furthermore there is no real effect on restrictiveness, as the items still cannot be actually removed - the most common reason for reordering items is to fix layering problems, which we consider more important than the little bit of strictness from restricting this.

## Changelog

<!--
Write a changelog following the examples below.
The changelog should be aimed at players - it shouldn't contain technical details and it should be concise.
Use past tense. For more complex changes you can write several points or include links to where interested people can find more details.
Leave the changelog wrapped in a codeblock.

If the PR doesn't change anything users or asset developers can notice, it is fine to remove this section altogether.
-->

```md
Platform changes:
- Allowed reordering worn items that cannot be removed (e.g. locked items)
```

## Checklist

<!-- Checklist for you to make sure you didn't miss something -->
- [x] The change has been tested locally
- [x] Added documentation to the new code and updated existing documentation where needed
- [x] I understand this patch is submitted under the [Pandora's Contributor Agreement](https://github.com/Project-Pandora-Game/pandora/blob/master/contributor-licence-agreement.md)
