### PR TITLE
[FIX] No sound is played when Pandora tab is not active

### DIFF
--- a/pandora-client-web/src/components/gameContext/notificationContextProvider.tsx
+++ b/pandora-client-web/src/components/gameContext/notificationContextProvider.tsx
@@ -115,7 +115,7 @@ class NotificationHandler extends NotificationHandlerBase {
 		this._updateNotifications();
 		if (alert.has(NotificationAlert.POPUP)) {
 			this._risePopup(full, audio);
-		} else if (alert.has(NotificationAlert.AUDIO)) {
+		} else if (alert.has(NotificationAlert.AUDIO) && document.visibilityState === 'hidden') {
 			/* TODO: Make the sound being played configurable */
 			new Audio(audioBing).play().catch(() => { /* ignore */ });
 		}


### PR DESCRIPTION
## References

Fixes a bug raised by Rosalyn on the Pandora Discord Server (hopefully):
https://discord.com/channels/872284471611760720/872568378190086174/1273018948497178695

The situation is
* The sound is 
** played when the Pandora tab is visible
** played when the browser, Pandora runs in, is hidden by another application
** not played, when the browser, Pandora runs in, is active and the Pandora tab isn't

## About The Pull Request

This change _should_ fix this problem. I tested it in all (for me) possible constellations, but always had to run two Pandora instances in different browsers, so that's not 100% the error situation.


## Changelog

Authored by: Sandrine

```md
Platform changes:

Fixes:
- Fixed the above mentioned bug

Technical changes:
```

## Checklist

<!-- Checklist for you to make sure you didn't miss something -->
- [X ] The change has been tested locally (see above)
- [X ] Added documentation to the new code and updated existing documentation where needed
- [ X] I understand this patch is submitted under the [Pandora's Contributor Agreement](https://github.com/Project-Pandora-Game/pandora/blob/master/contributor-licence-agreement.md)
