### PR TITLE
[CHANGE] Saved items respect custom name settings

### DIFF
--- a/pandora-client-web/src/components/wardrobe/views/wardrobeOutfitEditView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobeOutfitEditView.tsx
@@ -6,9 +6,6 @@ import { Scrollbar } from '../../common/scrollbar/scrollbar';
 import { useWardrobeContext } from '../wardrobeContext';
 import { useAssetManager } from '../../../assets/assetManager';
 import { InventoryAssetPreview } from '../wardrobeComponents';
-import diskIcon from '../../../assets/icons/disk.svg';
-import deleteIcon from '../../../assets/icons/delete.svg';
-import exportIcon from '../../../assets/icons/export.svg';
 import { toast } from 'react-toastify';
 import { TOAST_OPTIONS_ERROR } from '../../../persistentToast';
 import { EvalItemPath } from 'pandora-common/dist/assets/appearanceHelpers';
@@ -17,6 +14,12 @@ import { WardrobeContextExtraItemActionComponent } from '../wardrobeTypes';
 import { useConfirmDialog } from '../../dialog/dialog';
 import { WardrobeTemplateEditMenu } from '../templateDetail/_wardrobeTemplateDetail';
 import { ExportDialog } from '../../exportImport/exportDialog';
+import { ResolveItemDisplayNameType } from '../itemDetail/wardrobeItemName';
+
+/* images */
+import diskIcon from '../../../assets/icons/disk.svg';
+import deleteIcon from '../../../assets/icons/delete.svg';
+import exportIcon from '../../../assets/icons/export.svg';
 
 export function OutfitEditView({ extraActions, outfit, updateOutfit, isTemporary = false }: {
 	extraActions?: ReactNode;
@@ -340,6 +343,7 @@ function OutfitEditViewItem({ itemTemplate, updateItemTemplate, reorderItemTempl
 }): ReactElement {
 	const confirm = useConfirmDialog();
 	const assetManager = useAssetManager();
+	const { itemDisplayNameType } = useWardrobeContext();
 
 	const asset = assetManager.getAssetById(itemTemplate.asset);
 
@@ -371,7 +375,7 @@ function OutfitEditViewItem({ itemTemplate, updateItemTemplate, reorderItemTempl
 		]
 	) : undefined;
 
-	const visibleName = asset.definition.name;
+	const visibleName = ResolveItemDisplayNameType(asset.definition.name, itemTemplate.name, itemDisplayNameType);
 
 	if (!asset.canBeSpawned()) {
 		return (

--- a/pandora-client-web/src/components/wardrobe/views/wardrobeOutfitView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobeOutfitView.tsx
@@ -42,6 +42,8 @@ import { usePlayerState } from '../../gameContext/playerContextProvider';
 import { InventoryAssetPreview, StorageUsageMeter, WardrobeActionButton } from '../wardrobeComponents';
 import { useWardrobeContext } from '../wardrobeContext';
 import { OutfitEditView } from './wardrobeOutfitEditView';
+import { ResolveItemDisplayNameType } from '../itemDetail/wardrobeItemName';
+// import { ResolveItemDisplayNameType } from '../itemDetail/wardrobeItemName';
 
 export function InventoryOutfitView({ targetContainer }: {
 	targetContainer: ItemContainerPath;
@@ -562,7 +564,7 @@ function OutfitEntryItem({ itemTemplate, targetContainer }: {
 	targetContainer: ItemContainerPath;
 }): ReactElement {
 	const assetManager = useAssetManager();
-	const { setHeldItem, targetSelector } = useWardrobeContext();
+	const { setHeldItem, targetSelector, itemDisplayNameType } = useWardrobeContext();
 
 	const asset = assetManager.getAssetById(itemTemplate.asset);
 
@@ -584,7 +586,8 @@ function OutfitEntryItem({ itemTemplate, targetContainer }: {
 		]
 	) : undefined;
 
-	const visibleName = asset.definition.name;
+	//const visibleName = (itemTemplate.name) ? itemTemplate.name : asset.definition.name;
+	const visibleName = ResolveItemDisplayNameType(asset.definition.name, itemTemplate.name, itemDisplayNameType);
 
 	if (!asset.canBeSpawned()) {
 		return (

--- a/pandora-client-web/src/components/wardrobe/views/wardrobeOutfitView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobeOutfitView.tsx
@@ -43,7 +43,6 @@ import { InventoryAssetPreview, StorageUsageMeter, WardrobeActionButton } from '
 import { useWardrobeContext } from '../wardrobeContext';
 import { OutfitEditView } from './wardrobeOutfitEditView';
 import { ResolveItemDisplayNameType } from '../itemDetail/wardrobeItemName';
-// import { ResolveItemDisplayNameType } from '../itemDetail/wardrobeItemName';
 
 export function InventoryOutfitView({ targetContainer }: {
 	targetContainer: ItemContainerPath;

--- a/pandora-client-web/src/components/wardrobe/views/wardrobeOutfitView.tsx
+++ b/pandora-client-web/src/components/wardrobe/views/wardrobeOutfitView.tsx
@@ -586,7 +586,6 @@ function OutfitEntryItem({ itemTemplate, targetContainer }: {
 		]
 	) : undefined;
 
-	//const visibleName = (itemTemplate.name) ? itemTemplate.name : asset.definition.name;
 	const visibleName = ResolveItemDisplayNameType(asset.definition.name, itemTemplate.name, itemDisplayNameType);
 
 	if (!asset.canBeSpawned()) {

--- a/pandora-common/src/assets/item/_internal.ts
+++ b/pandora-common/src/assets/item/_internal.ts
@@ -91,6 +91,8 @@ export abstract class ItemBase<Type extends AssetType = AssetType> implements It
 		return {
 			asset: this.asset.id,
 			color: this.exportColorToBundle(),
+			name: this.name,
+			description: this.description,
 			modules,
 		};
 	}

--- a/pandora-common/src/assets/item/base.ts
+++ b/pandora-common/src/assets/item/base.ts
@@ -67,6 +67,8 @@ export type ItemTemplate = {
 	asset: AssetId;
 	templateName?: string;
 	color?: ItemColorBundle;
+	name?: string;
+	description?: string;
 	modules?: Record<string, ItemModuleTemplate>;
 };
 

--- a/pandora-common/src/assets/item/unified.ts
+++ b/pandora-common/src/assets/item/unified.ts
@@ -48,6 +48,8 @@ export const ItemTemplateSchema: z.ZodType<ItemTemplate, ZodTypeDef, unknown> = 
 	asset: AssetIdSchema,
 	templateName: z.string().optional(),
 	color: ItemColorBundleSchema.optional(),
+	name: z.string().regex(LIMIT_ITEM_NAME_PATTERN).transform(ZodTruncate(LIMIT_ITEM_NAME_LENGTH)).optional(),
+	description: z.string().transform(ZodTruncate(LIMIT_ITEM_DESCRIPTION_LENGTH)).optional(),
 	modules: z.record(z.lazy(() => ItemModuleTemplateSchema)).optional(),
 });
 
@@ -89,6 +91,8 @@ export function CreateItemBundleFromTemplate(template: ItemTemplate, context: II
 		asset: asset.id,
 		spawnedBy: context.creator.id,
 		color: template.color,
+		name: template.name,
+		description: template.description,
 	};
 
 	// Load modules


### PR DESCRIPTION
## References

_None_

## About The Pull Request

Items with a custom name are listed within the saved items folder solely with their original asset name. Making it hard to distinguish them, in case of a shoe box, for instance.
This change makes the tab respect the user's settings for custom names instead of just using the name of the asset.


## Changelog

Authored by: Sandrine (with the help of Clare)

```md
Platform changes:
- Item templates now save item's name and description
- Makes the saved items tab respect the user's settings for custom names
```

## Checklist

<!-- Checklist for you to make sure you didn't miss something -->
- [X] The change has been tested locally
- [X] Added documentation to the new code and updated existing documentation where needed
- [X] I understand this patch is submitted under the [Pandora's Contributor Agreement](https://github.com/Project-Pandora-Game/pandora/blob/master/contributor-licence-agreement.md)
