### PR TITLE
[FIX] Avoid empty 'Slots' element

### DIFF
--- a/pandora-client-web/src/components/wardrobe/itemDetail/wardrobeItemRoomDevice.tsx
+++ b/pandora-client-web/src/components/wardrobe/itemDetail/wardrobeItemRoomDevice.tsx
@@ -165,6 +165,9 @@ export function WardrobeRoomDeviceSlots({ roomDevice, item }: {
 		contents = 'Device must be deployed to interact with slots';
 	}
 
+	if (Object.entries(roomDevice.asset.definition.slots).length === 0)
+		return null;
+
 	return (
 		<FieldsetToggle legend='Slots'>
 			<Column padding='medium'>


### PR DESCRIPTION
## References

_None_

## About The Pull Request

Removes the empty 'Slots' element, if no slots are defined for an asset e.g. the picture frame
<img width="448" alt="image" src="https://github.com/user-attachments/assets/10acefdc-15bc-494b-bdae-da1e2f694a3c">


## Changelog

Authored by: Sandrine


```md
Fixes:
- Fixed the room devices without a lot still showing empty "Slots" section
```

## Checklist

<!-- Checklist for you to make sure you didn't miss something -->
- [X] The change has been tested locally
- [X] Added documentation to the new code and updated existing documentation where needed
- [X] I understand this patch is submitted under the [Pandora's Contributor Agreement](https://github.com/Project-Pandora-Game/pandora/blob/master/contributor-licence-agreement.md)
