### PR TITLE
[ADD] character preview in the header bar

### DIFF
--- a/pandora-client-web/src/components/header/Header.tsx
+++ b/pandora-client-web/src/components/header/Header.tsx
@@ -19,14 +19,13 @@ import { AccountContactContext, useAccountContacts } from '../accountContacts/ac
 import { IconHamburger } from '../common/button/domIcons.tsx';
 import { Column, Row } from '../common/container/container.tsx';
 import { DialogInPortal } from '../dialog/dialog.tsx';
+import { GetDirectoryUrl, useAuthTokenHeader } from '../gameContext/directoryConnectorContextProvider.tsx';
 import { useNotificationHeader } from '../gameContext/notificationProvider.tsx';
 import { usePlayerData } from '../gameContext/playerContextProvider.tsx';
 import { useShardConnectionInfo } from '../gameContext/shardConnectorContextProvider.tsx';
 import { HeaderButton } from './HeaderButton.tsx';
 import './header.scss';
 import { LeaveButton } from './leaveButton.tsx';
-import { GetDirectoryUrl, useAuthTokenHeader } from '../gameContext/directoryConnectorContextProvider.tsx';
-import { Link } from 'react-router';
 
 function LeftHeader(): ReactElement {
 	const connectionInfo = useShardConnectionInfo();
@@ -67,7 +66,7 @@ function LeftHeader(): ReactElement {
 				}
 			})
 			.catch((err) => {
-				GetLogger('CharacterListPreview').warning(`Error getting preview for character ${connectionInfo.characterId}:`, err);
+				GetLogger('LeftHeader').warning(`Error getting preview for character ${connectionInfo.characterId}:`, err);
 			});
 
 		return () => {
@@ -75,16 +74,23 @@ function LeftHeader(): ReactElement {
 		};
 	});
 
+	const navigate = useNavigatePandora();
+	const goToWardrobe = useCallback(() => {
+		if (connectionInfo != null) {
+			navigate(`/wardrobe/character/${connectionInfo.characterId}`);
+		}
+	}, [navigate, connectionInfo]);
+
 	return (
 		<div className='leftHeader flex'>
 			{ connectionInfo && (
-				<span>
-					<span className='label'>Current character:</span>
-					<Link to={ `/wardrobe/character/${connectionInfo.characterId}` } >
-						<img className='avatar' src={ preview ?? undefined } />
-					</Link>
-					{ characterName ?? `[Character ${connectionInfo.characterId}]` }
-				</span>
+				<button onClick={ goToWardrobe } title='Go to wardrobe' className='HeaderButton currentCharacter'>
+					{ preview ? (<img className='avatar' src={ preview } />) : null }
+					<span>
+						<span className='label'>Current character:</span>
+						{ characterName ?? `[Character ${connectionInfo.characterId}]` }
+					</span>
+				</button>
 			) }
 			{ !connectionInfo && (
 				<span>

--- a/pandora-client-web/src/components/header/header.scss
+++ b/pandora-client-web/src/components/header/header.scss
@@ -31,7 +31,7 @@
 				}
 
 				&:hover img {
-					filter: brightness(60%);
+					filter: brightness(80%);
 				}
 			}
 
@@ -128,7 +128,7 @@
 				}
 
 				&:hover img {
-					filter: brightness(60%);
+					filter: brightness(80%);
 				}
 			}
 		}

--- a/pandora-client-web/src/components/header/header.scss
+++ b/pandora-client-web/src/components/header/header.scss
@@ -15,6 +15,19 @@
 
 		&.rightHeader, &.leftHeader {
 			align-items: stretch;
+
+			.avatar {
+				object-fit: contain;
+				width: 2.2em;
+				height: 2.2em;
+				filter: saturate(110%) brightness(80%);
+				padding-right: 0.5em;
+				margin-bottom: -0.3em;
+
+				&:hover {
+					filter: brightness(60%);
+				}
+			}
 		}
 
 		.label {
@@ -26,7 +39,7 @@
 		@include common.center-flex;
 		min-width: 6em;
 		min-height: HeaderButton.$header-button-height;
-		padding: 0 1em;
+		padding: 0 0.5em;
 	}
 
 	.collapsableHeaderButton {

--- a/pandora-client-web/src/components/header/header.scss
+++ b/pandora-client-web/src/components/header/header.scss
@@ -16,18 +16,25 @@
 		&.rightHeader, &.leftHeader {
 			align-items: stretch;
 
-			.avatar {
-				object-fit: contain;
-				width: 2.2em;
-				height: 2.2em;
-				filter: saturate(110%) brightness(80%);
-				padding-right: 0.5em;
-				margin-bottom: -0.3em;
+			.currentCharacter {
+				display: flex;
+				height: 100%;
+				padding: 1px;
+				gap: 1px;
+				border-width: 1px;
 
-				&:hover {
+				.avatar {
+					height: 100%;
+					aspect-ratio: 1;
+					object-fit: contain;
+					contain: size;
+				}
+
+				&:hover img {
 					filter: brightness(60%);
 				}
 			}
+
 		}
 
 		.label {
@@ -102,11 +109,27 @@
 			}
 
 			> span {
-				justify-content: center;
+				padding: 0 1em 0 3.7em;
 			}
 
 			.label {
 				padding: 0 0.2em;
+			}
+
+			.currentCharacter {
+				display: flex;
+
+				.avatar {
+					height: 2.1em;
+					aspect-ratio: 1;
+					margin: 0 0.2em;
+					object-fit: contain;
+					contain: size;
+				}
+
+				&:hover img {
+					filter: brightness(60%);
+				}
 			}
 		}
 	}

--- a/pandora-client-web/src/styles/_theming.scss
+++ b/pandora-client-web/src/styles/_theming.scss
@@ -313,7 +313,7 @@ $theme-characterselect-card-text-dim: #333;
 $theme-characterselect-card-visiblefocus-outline: color-mix(in srgb, #fff, $theme-accent-color 65%);
 $theme-characterselect-card-extrainfo-background: #053bb1;
 $theme-characterselect-card-extrainfo-text: #eee;
-$theme-characterselect-card-frame-background: #fff;
+$theme-characterselect-card-frame-background: #ddd;
 $theme-characterselect-card-frame-border: #778b9d;
 $theme-characterselect-card-frame-shadow: inset -0.1em 0.15em 0.3em #00000077, inset 0 0 0.15em #00000077;
 

--- a/pandora-client-web/src/ui/screens/room/characterPreviewGeneration.tsx
+++ b/pandora-client-web/src/ui/screens/room/characterPreviewGeneration.tsx
@@ -79,7 +79,8 @@ async function CreateAndSaveCharacterPreview(
 			width: CHARACTER_PREVIEW_SIZE,
 			height: CHARACTER_PREVIEW_SIZE,
 		},
-		0xffffff,
+		0,
+		0,
 	);
 
 	await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## References

_None_

## About The Pull Request

n/a

## Changelog

Authored by: Clare & Claudia

```md
Platform changes:
- Made the background of character preview icons transparent for usage of the icon in other parts of Pandora. Note that if you have set some to not automatically update, you may need to update those icons manually to not make them show up with a white background in future usage scenarios.
- Added the character preview icon of the currently active character to the front of the header navigation bar in order to make it easier to identify a browser tab more easily when using multiple characters in parallel. It also doubles as a button to navigate to the wardrobe.
```

## Checklist

<!-- Checklist for you to make sure you didn't miss something -->
- [x] The change has been tested locally
- [x] Added documentation to the new code and updated existing documentation where needed
- [x] I understand this patch is submitted under the [Pandora's Contributor Agreement](https://github.com/Project-Pandora-Game/pandora/blob/master/contributor-licence-agreement.md)
