### PR TITLE
[ADD] Hearing impediment for long words

### DIFF
--- a/pandora-common/src/gameLogic/characterModifiers/modifierTypes/hearing_selective_deprivation.ts
+++ b/pandora-common/src/gameLogic/characterModifiers/modifierTypes/hearing_selective_deprivation.ts
@@ -54,21 +54,11 @@ You can, however, exclude characters or specific words from its effect or specif
 			},
 		},
 		wordLength: {
-			name: 'Distort words that are longer than a given value',
+			name: 'Distort only words that are longer than a given value',
 			type: 'number',
 			default: 8,
 			options: {
 				min: 0,
-			},
-		},
-		longWordDistortion: {
-			name: 'Intensity of long word scrambling',
-			type: 'number',
-			default: 9,
-			options: {
-				min: 0,
-				max: 10,
-				withSlider: true,
 			},
 		},
 	},
@@ -82,13 +72,6 @@ You can, however, exclude characters or specific words from its effect or specif
 			frequencyLoss: config.intensity,
 			middleLoss: config.intensity,
 			vowelLoss: config.intensity,
-		});
-
-		const longWordImpairment = new HearingImpairment(metadata.from, {
-			distortion: config.longWordDistortion,
-			frequencyLoss: config.longWordDistortion,
-			middleLoss: config.longWordDistortion,
-			vowelLoss: config.longWordDistortion,
 		});
 
 		const wordAllowlist = config.wordAllowlist.map((w) => w.trim().toLowerCase()).filter(Boolean);
@@ -106,8 +89,7 @@ You can, however, exclude characters or specific words from its effect or specif
 					return match;
 				}
 
-				return match.length >= config.wordLength ?
-					longWordImpairment.distortWord(match) : customImpairment.distortWord(match);
+				return match.length >= config.wordLength ? customImpairment.distortWord(match) : match;
 			});
 		}
 

--- a/pandora-common/src/gameLogic/characterModifiers/modifierTypes/hearing_selective_deprivation.ts
+++ b/pandora-common/src/gameLogic/characterModifiers/modifierTypes/hearing_selective_deprivation.ts
@@ -59,6 +59,7 @@ You can, however, exclude characters or specific words from its effect or specif
 			default: 0,
 			options: {
 				min: 0,
+				max: 100,
 			},
 		},
 	},
@@ -89,7 +90,7 @@ You can, however, exclude characters or specific words from its effect or specif
 					return match;
 				}
 
-				//Chaeck for length
+				//Check for length
 				return match.length > config.wordLength ? customImpairment.distortWord(match) : match;
 
 			});

--- a/pandora-common/src/gameLogic/characterModifiers/modifierTypes/hearing_selective_deprivation.ts
+++ b/pandora-common/src/gameLogic/characterModifiers/modifierTypes/hearing_selective_deprivation.ts
@@ -54,9 +54,9 @@ You can, however, exclude characters or specific words from its effect or specif
 			},
 		},
 		wordLength: {
-			name: 'Distort only words that are longer than a given value',
+			name: 'Words with at most this many letters can always be understood',
 			type: 'number',
-			default: 8,
+			default: 0,
 			options: {
 				min: 0,
 			},
@@ -89,7 +89,9 @@ You can, however, exclude characters or specific words from its effect or specif
 					return match;
 				}
 
-				return match.length >= config.wordLength ? customImpairment.distortWord(match) : match;
+				//Chaeck for length
+				return match.length > config.wordLength ? customImpairment.distortWord(match) : match;
+
 			});
 		}
 

--- a/pandora-common/src/gameLogic/characterModifiers/modifierTypes/hearing_selective_deprivation.ts
+++ b/pandora-common/src/gameLogic/characterModifiers/modifierTypes/hearing_selective_deprivation.ts
@@ -53,6 +53,24 @@ You can, however, exclude characters or specific words from its effect or specif
 				withSlider: true,
 			},
 		},
+		wordLength: {
+			name: 'Distort words that are longer than a given value',
+			type: 'number',
+			default: 8,
+			options: {
+				min: 0,
+			},
+		},
+		longWordDistortion: {
+			name: 'Intensity of long word scrambling',
+			type: 'number',
+			default: 9,
+			options: {
+				min: 0,
+				max: 10,
+				withSlider: true,
+			},
+		},
 	},
 
 	processReceivedChatMessageBeforeFilters(config, content, metadata) {
@@ -64,6 +82,13 @@ You can, however, exclude characters or specific words from its effect or specif
 			frequencyLoss: config.intensity,
 			middleLoss: config.intensity,
 			vowelLoss: config.intensity,
+		});
+
+		const longWordImpairment = new HearingImpairment(metadata.from, {
+			distortion: config.longWordDistortion,
+			frequencyLoss: config.longWordDistortion,
+			middleLoss: config.longWordDistortion,
+			vowelLoss: config.longWordDistortion,
 		});
 
 		const wordAllowlist = config.wordAllowlist.map((w) => w.trim().toLowerCase()).filter(Boolean);
@@ -81,7 +106,8 @@ You can, however, exclude characters or specific words from its effect or specif
 					return match;
 				}
 
-				return customImpairment.distortWord(match);
+				return match.length >= config.wordLength ?
+					longWordImpairment.distortWord(match) : customImpairment.distortWord(match);
 			});
 		}
 


### PR DESCRIPTION
## References

_None_

## About The Pull Request

Added a new option to the selective hearing modifier:
* Word length

This way long words, that are too complex for some characters can be scrambled with the set intensity.

## Changelog

Authored by: Sandrine

```md
Platform changes:
- Added a new configuration option "Words with at most this many letters can always be understood" to the already existing "Hearing: Selective hearing deprivation" character modifier

```

## Checklist

<!-- Checklist for you to make sure you didn't miss something -->
- [X] The change has been tested locally
- [X] Added documentation to the new code and updated existing documentation where needed
- [X] I understand this patch is submitted under the [Pandora's Contributor Agreement](https://github.com/Project-Pandora-Game/pandora/blob/master/contributor-licence-agreement.md)
