### PR TITLE
[FIX] Move owner's list to BaseInfo object

### DIFF
--- a/pandora-client-web/src/ui/screens/spacesSearch/spacesSearch.tsx
+++ b/pandora-client-web/src/ui/screens/spacesSearch/spacesSearch.tsx
@@ -307,7 +307,6 @@ function SpaceDetailsDialog({ baseInfo, hide }: {
 			background: '',
 			isAdmin: false,
 			isAllowed: false,
-			owners: [],
 			characters: [],
 		};
 	}, [extendedInfo, baseInfo]);

--- a/pandora-common/src/space/space.ts
+++ b/pandora-common/src/space/space.ts
@@ -162,7 +162,7 @@ export type SpaceListInfo = SpaceBaseInfo & {
 	isOwner: boolean;
 	/** Whether there is a friend contact inside this space. Not filled if this account cannot see extended info of this space. */
 	hasFriend?: boolean;
-	/** List of the space's admin */
+	/** List of the space's owners */
 	owners: AccountId[];
 };
 

--- a/pandora-common/src/space/space.ts
+++ b/pandora-common/src/space/space.ts
@@ -162,6 +162,8 @@ export type SpaceListInfo = SpaceBaseInfo & {
 	isOwner: boolean;
 	/** Whether there is a friend contact inside this space. Not filled if this account cannot see extended info of this space. */
 	hasFriend?: boolean;
+	/** List of the space's admin */
+	owners: AccountId[];
 };
 
 /** Info sent to client when displaying details about a space */
@@ -170,7 +172,6 @@ export type SpaceListExtendedInfo = SpaceListInfo & Pick<SpaceDirectoryConfig, '
 	/** Whether the account that requested the info is admin of this space */
 	isAdmin: boolean;
 	isAllowed: boolean;
-	owners: AccountId[];
 	characters: {
 		id: CharacterId;
 		accountId: number;

--- a/pandora-server-directory/src/spaces/space.ts
+++ b/pandora-server-directory/src/spaces/space.ts
@@ -146,6 +146,7 @@ export class Space {
 			totalCharacters: this.characterCount,
 			isOwner: this.isOwner(queryingAccount),
 			hasFriend,
+			owners: Array.from(this._owners),
 		});
 	}
 
@@ -153,7 +154,6 @@ export class Space {
 		return ({
 			...this.getListInfo(queryingAccount, accountFriends),
 			...pick(this.config, ['features', 'admin']),
-			owners: Array.from(this._owners),
 			isAdmin: this.isAdmin(queryingAccount),
 			isAllowed: this.isAllowed(queryingAccount),
 			characters: Array.from(this.characters).map((c): SpaceListExtendedInfo['characters'][number] => ({


### PR DESCRIPTION
## References

Fixes #872 

## About The Pull Request

Added the space's admin list to the publicly available information so that blocked players see who to contact
 
## Changelog

Authored by: Sandrine

```md
Fixes:
- List of space owners can now be seen even for public spaces you do not have access to
```

## Checklist

<!-- Checklist for you to make sure you didn't miss something -->
- [X] The change has been tested locally
- [X] Added documentation to the new code and updated existing documentation where needed
- [X] I understand this patch is submitted under the [Pandora's Contributor Agreement](https://github.com/Project-Pandora-Game/pandora/blob/master/contributor-licence-agreement.md)
