### PR TITLE
[FEATURE] Normals-based shading and specular lighting

### DIFF
--- a/pandora-client-web/src/assets/assetGraphicsCalculations.ts
+++ b/pandora-client-web/src/assets/assetGraphicsCalculations.ts
@@ -29,7 +29,7 @@ export function useLayerImageSource(
 	evaluator: AppearanceConditionEvaluator,
 	{ image: scalingBaseimage, scaling }: Pick<Immutable<Extract<GraphicsLayer, { type: 'mesh'; }>>, 'image' | 'scaling'>,
 	item: Item | null,
-): Immutable<{ setting: Immutable<LayerImageSetting>; image: string; depthComponent?: string; imageUv: Record<BoneName, number>; }> {
+): Immutable<{ setting: Immutable<LayerImageSetting>; image: string; normalMapImage?: string; imageUv: Record<BoneName, number>; }> {
 	const [setting, scalingUv] = useMemo((): Immutable<[LayerImageSetting, scalingUv: Record<BoneName, number>]> => {
 		if (scaling) {
 			const value = evaluator.getBoneLikeValue(scaling.scaleBone);
@@ -61,7 +61,7 @@ export function useLayerImageSource(
 		return {
 			setting,
 			image: resultSetting.image,
-			depthComponent: resultSetting.depthComponent,
+			normalMapImage: resultSetting.normalMapImage,
 			imageUv: resultSetting.uvPose ? {
 				...resultSetting.uvPose,
 				...scalingUv,

--- a/pandora-client-web/src/assets/assetGraphicsCalculations.ts
+++ b/pandora-client-web/src/assets/assetGraphicsCalculations.ts
@@ -29,7 +29,7 @@ export function useLayerImageSource(
 	evaluator: AppearanceConditionEvaluator,
 	{ image: scalingBaseimage, scaling }: Pick<Immutable<Extract<GraphicsLayer, { type: 'mesh'; }>>, 'image' | 'scaling'>,
 	item: Item | null,
-): Immutable<{ setting: Immutable<LayerImageSetting>; image: string; imageUv: Record<BoneName, number>; }> {
+): Immutable<{ setting: Immutable<LayerImageSetting>; image: string; depthComponent?: string; imageUv: Record<BoneName, number>; }> {
 	const [setting, scalingUv] = useMemo((): Immutable<[LayerImageSetting, scalingUv: Record<BoneName, number>]> => {
 		if (scaling) {
 			const value = evaluator.getBoneLikeValue(scaling.scaleBone);
@@ -61,6 +61,7 @@ export function useLayerImageSource(
 		return {
 			setting,
 			image: resultSetting.image,
+			depthComponent: resultSetting.depthComponent,
 			imageUv: resultSetting.uvPose ? {
 				...resultSetting.uvPose,
 				...scalingUv,

--- a/pandora-client-web/src/browserStorage.ts
+++ b/pandora-client-web/src/browserStorage.ts
@@ -40,7 +40,12 @@ export class BrowserStorage<T> extends Observable<T> {
 			const parsedValue = JSON.parse(value) as unknown;
 			const validated = this.validate.safeParse(parsedValue);
 			if (validated.success) {
-				this.value = validated.data;
+				try {
+					this._saveInhibit = true;
+					this.value = validated.data;
+				} finally {
+					this._saveInhibit = false;
+				}
 			}
 		}
 	}

--- a/pandora-client-web/src/components/common/container/container.tsx
+++ b/pandora-client-web/src/components/common/container/container.tsx
@@ -31,6 +31,10 @@ export interface DivContainerProps extends CommonProps {
 	padding?: Exclude<ScssSpacing, 'none'>;
 	/** Defaults to `medium` */
 	gap?: ScssSpacing;
+
+	// Global properties
+	/** @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert */
+	inert?: boolean;
 }
 
 export function DivContainer({
@@ -47,6 +51,7 @@ export function DivContainer({
 	overflowY,
 	padding,
 	gap = 'medium',
+	inert,
 }: DivContainerProps): ReactElement {
 	return (
 		<div
@@ -65,6 +70,7 @@ export function DivContainer({
 				`gap-${gap}`,
 				className,
 			) }
+			inert={ inert }
 		>
 			{ children }
 		</div>

--- a/pandora-client-web/src/components/dialog/dialog.scss
+++ b/pandora-client-web/src/components/dialog/dialog.scss
@@ -36,7 +36,7 @@
 	position: absolute;
 	inset: 0;
 	margin: 0;
-	overflow: hidden;
+	overflow: clip;
 
 	pointer-events: none;
 

--- a/pandora-client-web/src/components/header/Header.tsx
+++ b/pandora-client-web/src/components/header/Header.tsx
@@ -210,7 +210,7 @@ function StatusSelector({ open, close }: {
 	const directory = useDirectoryConnector();
 
 	return (
-		<div className={ open ? 'statusSelectorMenuContainer open' : 'statusSelectorMenuContainer' }>
+		<div className={ open ? 'statusSelectorMenuContainer open' : 'statusSelectorMenuContainer' } inert={ !open }>
 			<div className='statusSelectorMenu'>
 				{
 					AccountOnlineStatusSchema.options.map((o) => (
@@ -375,7 +375,7 @@ function OverlayHeader({ onClose: close, visible }: {
 }): ReactElement {
 	return (
 		<DialogInPortal priority={ 5 } location='mainOverlay'>
-			<Column className={ classNames('OverlayHeader', visible ? null : 'hide') }>
+			<Column className={ classNames('OverlayHeader', visible ? null : 'hide') } inert={ !visible }>
 				<Column className='content'>
 					<LeftHeader onAnyClick={ close } />
 					<hr />

--- a/pandora-client-web/src/components/header/notificationMenu.tsx
+++ b/pandora-client-web/src/components/header/notificationMenu.tsx
@@ -22,7 +22,7 @@ export function NotificationMenu({ visible, close, notifications, clearNotificat
 
 	return (
 		<DialogInPortal priority={ 6 } location='mainOverlay'>
-			<Column className={ classNames('OverlayNotificationMenu', visible ? null : 'hide') } padding='medium'>
+			<Column className={ classNames('OverlayNotificationMenu', visible ? null : 'hide') } inert={ !visible } padding='medium'>
 				<Row alignX='space-between'>
 					<IconButton
 						onClick={ clearNotifications }

--- a/pandora-client-web/src/components/settings/helpers/settingsInputs.tsx
+++ b/pandora-client-web/src/components/settings/helpers/settingsInputs.tsx
@@ -86,10 +86,11 @@ export function useValueMapDriver<const TIn, const TOut>(
 	}), [parentDriver, forwardMapping, backwardMapping]);
 }
 
-export function ToggleSettingInput({ driver, label, noReset = false, deps = EMPTY_ARRAY }: {
+export function ToggleSettingInput({ driver, label, disabled, noReset = false, deps = EMPTY_ARRAY }: {
 	driver: Readonly<SettingDriver<boolean>>;
-	label: string;
+	label: ReactNode;
 	noReset?: boolean;
+	disabled?: boolean;
 	deps?: DependencyList;
 }): ReactElement {
 	const [value, setValue] = useRemotelyUpdatedUserInput(driver.currentValue, deps, {
@@ -114,6 +115,7 @@ export function ToggleSettingInput({ driver, label, noReset = false, deps = EMPT
 				id={ id }
 				checked={ value ?? driver.defaultValue }
 				onChange={ setValue }
+				disabled={ disabled }
 			/>
 			<label
 				htmlFor={ id }

--- a/pandora-client-web/src/components/settings/interfaceSettings.tsx
+++ b/pandora-client-web/src/components/settings/interfaceSettings.tsx
@@ -128,10 +128,12 @@ function ChatroomSettings(): ReactElement {
 	return (
 		<fieldset>
 			<legend>Chatroom UI</legend>
-			<ChatroomGraphicsRatio />
-			<ChatroomChatFontSize />
-			<ChatroomChatCommandHintBehavior />
-			<SelectAccountSettings setting='interfaceChatroomItemDisplayNameType' label='Item name display' stringify={ ITEM_DISPLAY_NAME_TYPE_DESCRIPTION } />
+			<Column gap='large'>
+				<ChatroomGraphicsRatio />
+				<ChatroomChatFontSize />
+				<ChatroomChatCommandHintBehavior />
+				<SelectAccountSettings setting='interfaceChatroomItemDisplayNameType' label='Item name display' stringify={ ITEM_DISPLAY_NAME_TYPE_DESCRIPTION } />
+			</Column>
 		</fieldset>
 	);
 }
@@ -232,10 +234,12 @@ function RoomGraphicsSettings(): ReactElement {
 	return (
 		<fieldset>
 			<legend>Room graphics UI</legend>
-			<ChatroomCharacterAwayStatusIconDisplay />
-			<ChatroomCharacterNameFontSize />
-			<ChatroomOfflineCharacters />
-			<ChatroomCharacterPosintStyle />
+			<Column gap='large'>
+				<ChatroomCharacterAwayStatusIconDisplay />
+				<ChatroomCharacterNameFontSize />
+				<ChatroomOfflineCharacters />
+				<ChatroomCharacterPosintStyle />
+			</Column>
 		</fieldset>
 	);
 }
@@ -277,15 +281,17 @@ function WardrobeSettings(): ReactElement {
 	return (
 		<fieldset>
 			<legend>Wardrobe UI</legend>
-			<WardrobeShowExtraButtons />
-			<WardrobeHoverPreview />
-			<ToggleAccountSetting setting='wardrobePosePreview' label='Show previews in the "Pose" menu' />
-			<SelectAccountSettings setting='wardrobePosingCategoryDefault' label='Select the default category in the "Pose" menu' stringify={ WARDROBE_POSING_CATEGORY_DEFAULT } />
-			<SelectAccountSettings setting='wardrobeOutfitsPreview' label='Saved item collection previews' stringify={ WARDROBE_PREVIEWS_DESCRIPTION } />
-			<SelectAccountSettings setting='wardrobeSmallPreview' label='Item previews: List mode with small previews' stringify={ WARDROBE_PREVIEW_TYPE_DESCRIPTION } />
-			<SelectAccountSettings setting='wardrobeBigPreview' label='Item previews: Grid mode with big previews' stringify={ WARDROBE_PREVIEW_TYPE_DESCRIPTION } />
-			<SelectAccountSettings setting='wardrobeItemDisplayNameType' label='Item name display' stringify={ ITEM_DISPLAY_NAME_TYPE_DESCRIPTION } />
-			<SelectAccountSettings setting='wardrobeItemRequireFreeHandsToUseDefault' label='Bound usage pre-selection when creating new items' stringify={ WARDROBE_ITEM_REQUIRE_FREE_HANDS_TO_USE_DEFAULT } />
+			<Column gap='large'>
+				<WardrobeShowExtraButtons />
+				<WardrobeHoverPreview />
+				<ToggleAccountSetting setting='wardrobePosePreview' label='Show previews in the "Pose" menu' />
+				<SelectAccountSettings setting='wardrobePosingCategoryDefault' label='Select the default category in the "Pose" menu' stringify={ WARDROBE_POSING_CATEGORY_DEFAULT } />
+				<SelectAccountSettings setting='wardrobeOutfitsPreview' label='Saved item collection previews' stringify={ WARDROBE_PREVIEWS_DESCRIPTION } />
+				<SelectAccountSettings setting='wardrobeSmallPreview' label='Item previews: List mode with small previews' stringify={ WARDROBE_PREVIEW_TYPE_DESCRIPTION } />
+				<SelectAccountSettings setting='wardrobeBigPreview' label='Item previews: Grid mode with big previews' stringify={ WARDROBE_PREVIEW_TYPE_DESCRIPTION } />
+				<SelectAccountSettings setting='wardrobeItemDisplayNameType' label='Item name display' stringify={ ITEM_DISPLAY_NAME_TYPE_DESCRIPTION } />
+				<SelectAccountSettings setting='wardrobeItemRequireFreeHandsToUseDefault' label='Bound usage pre-selection when creating new items' stringify={ WARDROBE_ITEM_REQUIRE_FREE_HANDS_TO_USE_DEFAULT } />
+			</Column>
 		</fieldset>
 	);
 }

--- a/pandora-client-web/src/components/settings/notificationSettings.tsx
+++ b/pandora-client-web/src/components/settings/notificationSettings.tsx
@@ -40,41 +40,43 @@ function NotificationGlobalSettings(): ReactElement {
 	return (
 		<fieldset>
 			<legend>Global settings</legend>
-			<h2>Sound</h2>
-			<SelectSettingInput
-				driver={ defaultVolumeDriver }
-				label='Sound notifications volume'
-				stringify={ NOTIFICATION_AUDIO_VOLUME }
-				optionOrder={ ['100', '75', '50', '25', '0'] }
-				schema={ ClientNotificationSoundVolumeSchema }
-			/>
-			<SelectSettingInput
-				driver={ defaultSoundDriver }
-				label='Default notification sound'
-				stringify={ NOTIFICATION_AUDIO_NAMES }
-				schema={ ClientNotificationSoundSchema }
-			>
-				<Button
-					className='slim'
-					disabled={ defaultSound === '' }
-					onClick={ () => {
-						const sound = NOTIFICATION_AUDIO_SOUNDS[defaultSound];
-						if (sound != null) {
-							const audio = new Audio(sound);
-							audio.volume = Number(defaultVolume) / 100;
-							audio.play().catch(() => { /*ignore*/ });
-						}
-					} }
+			<Column gap='large'>
+				<h2>Sound</h2>
+				<SelectSettingInput
+					driver={ defaultVolumeDriver }
+					label='Sound notifications volume'
+					stringify={ NOTIFICATION_AUDIO_VOLUME }
+					optionOrder={ ['100', '75', '50', '25', '0'] }
+					schema={ ClientNotificationSoundVolumeSchema }
+				/>
+				<SelectSettingInput
+					driver={ defaultSoundDriver }
+					label='Default notification sound'
+					stringify={ NOTIFICATION_AUDIO_NAMES }
+					schema={ ClientNotificationSoundSchema }
 				>
-					Test
-				</Button>
-			</SelectSettingInput>
-			<h2>Popups</h2>
-			<ToggleSettingInput
-				driver={ useSubsettingDriver(globalSettingsDriver, 'usePlatformPopup') }
-				label='Use system popups, if available (requires additional browser permission)'
-			/>
-			<NotificationPermissionRequest />
+					<Button
+						className='slim'
+						disabled={ defaultSound === '' }
+						onClick={ () => {
+							const sound = NOTIFICATION_AUDIO_SOUNDS[defaultSound];
+							if (sound != null) {
+								const audio = new Audio(sound);
+								audio.volume = Number(defaultVolume) / 100;
+								audio.play().catch(() => { /*ignore*/ });
+							}
+						} }
+					>
+						Test
+					</Button>
+				</SelectSettingInput>
+				<h2>Popups</h2>
+				<ToggleSettingInput
+					driver={ useSubsettingDriver(globalSettingsDriver, 'usePlatformPopup') }
+					label='Use system popups, if available (requires additional browser permission)'
+				/>
+				<NotificationPermissionRequest />
+			</Column>
 		</fieldset>
 	);
 }

--- a/pandora-client-web/src/components/settings/settings.scss
+++ b/pandora-client-web/src/components/settings/settings.scss
@@ -82,9 +82,8 @@
 
 			.input-row, .input-section {
 				display: flex;
-				gap: common.spacing('medium');
+				gap: common.spacing('small');
 				justify-content: space-between;
-				margin-top: 1em;
 
 				&.input-row {
 					flex-direction: row;

--- a/pandora-client-web/src/editor/components/layer/layerAutoMesh.tsx
+++ b/pandora-client-web/src/editor/components/layer/layerAutoMesh.tsx
@@ -17,6 +17,7 @@ import { useCallback, useId, useState, type ReactElement } from 'react';
 import { useAssetManager } from '../../../assets/assetManager.tsx';
 import crossIcon from '../../../assets/icons/cross.svg';
 import { Checkbox } from '../../../common/userInteraction/checkbox.tsx';
+import { NumberInput } from '../../../common/userInteraction/input/numberInput.tsx';
 import { TextInput } from '../../../common/userInteraction/input/textInput.tsx';
 import { Select } from '../../../common/userInteraction/select/select.tsx';
 import { Button, IconButton } from '../../../components/common/button/button.tsx';
@@ -43,6 +44,8 @@ export function LayerAutoMeshUI({ asset, layer }: {
 			<LayerHeightAndWidthSetting layer={ layer } asset={ asset } />
 			<LayerOffsetSetting layer={ layer } asset={ asset } />
 			<hr />
+			<LayerNormalMapSettings layer={ layer } />
+			<hr />
 			<TabContainer allowWrap>
 				<Tab name='Template'>
 					<hr />
@@ -63,6 +66,92 @@ export function LayerAutoMeshUI({ asset, layer }: {
 					<LayerAutomeshImages layer={ layer } />
 				</Tab>
 			</TabContainer>
+		</>
+	);
+}
+
+function LayerNormalMapSettings({ layer }: { layer: EditorAssetGraphicsLayer<'autoMesh'>; }): ReactElement {
+	const { normalMap } = useObservable(layer.definition);
+
+	return (
+		<>
+			<label>
+				<Checkbox
+					checked={ normalMap != null }
+					onChange={ (newValue) => {
+						layer.modifyDefinition((d) => {
+							d.normalMap = newValue ? { specularStrength: 0.2, roughness: 0 } : undefined;
+						});
+					} }
+				/>
+				Layer has normal map
+			</label>
+			{
+				normalMap != null ? (
+					<>
+						<Row>
+							<label>Specular strength</label>
+							<NumberInput
+								rangeSlider
+								className='flex-6 zero-width'
+								value={ normalMap.specularStrength }
+								onChange={ (newValue) => {
+									layer.modifyDefinition((d) => {
+										Assert(d.normalMap != null);
+										d.normalMap.specularStrength = newValue;
+									});
+								} }
+								min={ 0 }
+								max={ 1 }
+								step={ 0.01 }
+							/>
+							<NumberInput
+								className='flex-grow-1'
+								value={ normalMap.specularStrength }
+								onChange={ (newValue) => {
+									layer.modifyDefinition((d) => {
+										Assert(d.normalMap != null);
+										d.normalMap.specularStrength = newValue;
+									});
+								} }
+								min={ 0 }
+								max={ 1 }
+								step={ 0.01 }
+							/>
+						</Row>
+						<Row>
+							<label>Roughness</label>
+							<NumberInput
+								rangeSlider
+								className='flex-6 zero-width'
+								value={ normalMap.roughness }
+								onChange={ (newValue) => {
+									layer.modifyDefinition((d) => {
+										Assert(d.normalMap != null);
+										d.normalMap.roughness = newValue;
+									});
+								} }
+								min={ 0 }
+								max={ 1 }
+								step={ 0.01 }
+							/>
+							<NumberInput
+								className='flex-grow-1'
+								value={ normalMap.roughness }
+								onChange={ (newValue) => {
+									layer.modifyDefinition((d) => {
+										Assert(d.normalMap != null);
+										d.normalMap.roughness = newValue;
+									});
+								} }
+								min={ 0 }
+								max={ 1 }
+								step={ 0.01 }
+							/>
+						</Row>
+					</>
+				) : null
+			}
 		</>
 	);
 }

--- a/pandora-client-web/src/editor/components/layer/layerAutoMesh.tsx
+++ b/pandora-client-web/src/editor/components/layer/layerAutoMesh.tsx
@@ -1,5 +1,5 @@
-import type { Draft, Immutable } from 'immer';
-import { capitalize } from 'lodash-es';
+import { produce, type Draft, type Immutable } from 'immer';
+import { capitalize, snakeCase } from 'lodash-es';
 import {
 	Assert,
 	AssertNever,
@@ -13,7 +13,7 @@ import {
 	type GraphicsSourceAutoMeshGraphicalLayer,
 	type GraphicsSourceAutoMeshLayerVariable,
 } from 'pandora-common';
-import { useCallback, useId, useState, type ReactElement } from 'react';
+import { useCallback, useEffect, useId, useMemo, useState, type ReactElement } from 'react';
 import { useAssetManager } from '../../../assets/assetManager.tsx';
 import crossIcon from '../../../assets/icons/cross.svg';
 import { Checkbox } from '../../../common/userInteraction/checkbox.tsx';
@@ -875,6 +875,9 @@ function LayerAutomeshImages({ layer }: { layer: EditorAssetGraphicsLayer<'autoM
 	const { variables, graphicalLayers, imageMap } = useObservable(layer.definition);
 	const imageList = useObservable(layer.asset.loadedTextures);
 
+	const [autofillDialogTarget, setAutofillDialogTarget] = useState<null | true | string>(null);
+	const [autofillPrefixes, setAutofillPrefixes] = useState<readonly string[]>([]);
+
 	if (asset == null)
 		return null;
 
@@ -931,6 +934,16 @@ function LayerAutomeshImages({ layer }: { layer: EditorAssetGraphicsLayer<'autoM
 			uiVariants.push(
 				<Column key={ combinationId }>
 					<strong>{ combinationName }</strong>
+					<Row alignX='start'>
+						<Button
+							slim
+							onClick={ () => {
+								setAutofillDialogTarget(combinationId);
+							} }
+						>
+							🪄 Auto-fill this combination
+						</Button>
+					</Row>
 					{
 						graphicalLayers.map((l, li) => (
 							<Row key={ li } alignY='center'>
@@ -962,7 +975,7 @@ function LayerAutomeshImages({ layer }: { layer: EditorAssetGraphicsLayer<'autoM
 	}
 
 	return (
-		<Column gap='medium'>
+		<Column gap='large'>
 			{
 				Object.keys(imageMap)
 					.filter((k) => !validCombinationIds.has(k))
@@ -1013,7 +1026,180 @@ function LayerAutomeshImages({ layer }: { layer: EditorAssetGraphicsLayer<'autoM
 						</Column>
 					))
 			}
+			<Row alignX='start'>
+				<Button
+					slim
+					onClick={ () => {
+						setAutofillDialogTarget(true);
+					} }
+				>
+					🪄 Auto-fill all images
+				</Button>
+			</Row>
 			{ uiVariants }
+			{
+				autofillDialogTarget != null ? (
+					<LayerAutomeshFillImagesDialog
+						layer={ layer }
+						asset={ asset }
+						close={ () => {
+							setAutofillDialogTarget(null);
+						} }
+						prefixes={ autofillPrefixes }
+						setPrefixes={ setAutofillPrefixes }
+						limitToCombination={ typeof autofillDialogTarget === 'string' && validCombinationIds.has(autofillDialogTarget) ? autofillDialogTarget : undefined }
+					/>
+				) : null
+			}
 		</Column>
+	);
+}
+
+function LayerAutomeshFillImagesDialog({ layer, asset, close, prefixes, setPrefixes, limitToCombination }: {
+	layer: EditorAssetGraphicsLayer<'autoMesh'>;
+	asset: Asset;
+	close: () => void;
+	prefixes: readonly string[];
+	setPrefixes: React.Dispatch<React.SetStateAction<readonly string[]>>;
+	limitToCombination?: string;
+}): ReactElement {
+	Assert(layer.asset.id === asset.id);
+
+	const [overwriteAll, setOverwriteAll] = useState(false);
+
+	const assetManager = useAssetManager();
+	const { variables, graphicalLayers } = useObservable(layer.definition);
+	const imageList = useObservable(layer.asset.loadedTextures);
+
+	useEffect(() => {
+		if (graphicalLayers.length !== prefixes.length) {
+			setPrefixes(graphicalLayers.map((l) => snakeCase(l.name)));
+		}
+	}, [graphicalLayers, prefixes, setPrefixes]);
+
+	const combinations = useMemo(() => {
+		const buildContext = EditorBuildAssetGraphicsContext(layer.asset, asset, assetManager);
+		const variants: AutoMeshLayerGenerateVariableValue[][] = [];
+
+		for (const variable of variables) {
+			const values = AutoMeshLayerGenerateVariableData(variable, buildContext);
+			Assert(values.length > 0, 'Generating variable variants returned empty result');
+			variants.push(values);
+		}
+		return (variants.length > 0 ? Array.from(GenerateMultipleListsFullJoin(variants)) : [[GRAPHICS_AUTOMESH_LAYER_DEFAULT_VARIANT]]);
+	}, [layer, asset, assetManager, variables]);
+
+	const apply = useCallback(() => {
+		if (prefixes.length !== graphicalLayers.length)
+			return;
+
+		const validCombinationIds = new Set<string>();
+
+		layer.modifyDefinition((d) => {
+			for (const combination of combinations) {
+				const combinationId = combination.map((c) => c.id).join(':');
+				validCombinationIds.add(combinationId);
+
+				if (limitToCombination != null && limitToCombination !== combinationId)
+					continue;
+
+				let imageLayers: string[] | undefined = d.imageMap[combinationId];
+				if (overwriteAll || imageLayers == null || imageLayers.length !== graphicalLayers.length) {
+					imageLayers = new Array<string>(graphicalLayers.length).fill('');
+				}
+
+				for (let gli = 0; gli < graphicalLayers.length; gli++) {
+					const image = [prefixes[gli], ...combination.map((s) => s.id)].join('_') + '.png';
+					if (!imageLayers[gli] && imageList.includes(image)) {
+						imageLayers[gli] = image;
+					}
+				}
+
+				d.imageMap[combinationId] = imageLayers;
+			}
+
+			if (limitToCombination == null) {
+				for (const key of Object.keys(d.imageMap)) {
+					if (!validCombinationIds.has(key)) {
+						delete d.imageMap[key];
+					}
+				}
+			}
+		});
+
+		close();
+	}, [combinations, graphicalLayers, imageList, layer, prefixes, overwriteAll, limitToCombination, close]);
+
+	return (
+		<ModalDialog>
+			<Column>
+				<h2>Automatically fill images based on name</h2>
+				<span className='contain-inline-size'>
+					This will take names of the layers below and ids of each variable and join them using '_' to try finding matching image.
+					Any wrongly-formatted combination will be reset, otherwise the setting bellow is followed.
+				</span>
+				<label>
+					<Checkbox
+						checked={ overwriteAll }
+						onChange={ setOverwriteAll }
+					/>
+					Reset all assignments
+				</label>
+				<table>
+					<thead>
+						<tr>
+							<th>Layer</th>
+							<th>Prefix</th>
+							<th>Matches</th>
+						</tr>
+					</thead>
+					<tbody>
+						{
+							graphicalLayers.map((l, i) => (
+								<tr key={ i }>
+									<td>{ l.name }</td>
+									<td>
+										<TextInput
+											value={ prefixes.length === graphicalLayers.length ? prefixes[i] : '' }
+											disabled={ prefixes.length !== graphicalLayers.length }
+											onChange={ (newValue) => {
+												setPrefixes((v) => produce(v, (d) => {
+													Assert(d.length === graphicalLayers.length);
+													d[i] = newValue;
+												}));
+											} }
+										/>
+									</td>
+									<td>
+										{
+											combinations.reduce<number>((count, c) => {
+												const prefix = prefixes.length === graphicalLayers.length ? prefixes[i] : '';
+												if (!prefix || limitToCombination != null && limitToCombination !== c.map((s) => s.id).join(':'))
+													return count;
+												const image = [prefix, ...c.map((s) => s.id)].join('_') + '.png';
+												return count + (imageList.includes(image) ? 1 : 0);
+											}, 0)
+										}
+									</td>
+								</tr>
+							))
+						}
+					</tbody>
+				</table>
+				<Row alignX='space-between'>
+					<Button
+						onClick={ close }
+					>
+						Cancel
+					</Button>
+					<Button
+						onClick={ apply }
+						disabled={ prefixes.length !== graphicalLayers.length }
+					>
+						Apply
+					</Button>
+				</Row>
+			</Column>
+		</ModalDialog>
 	);
 }

--- a/pandora-client-web/src/editor/graphics/layer/resultLayer.tsx
+++ b/pandora-client-web/src/editor/graphics/layer/resultLayer.tsx
@@ -45,7 +45,7 @@ export function ResultMeshLayer({
 
 	const evaluator = useAppearanceConditionEvaluator(characterState);
 
-	const vertices = useLayerVertices(evaluator, points, layer, item);
+	const vertices = useLayerVertices(evaluator, points, layer, item).vertices;
 
 	const drawWireFrame = useCallback((g: PIXI.GraphicsContext) => {
 		// Borders of the layer

--- a/pandora-client-web/src/editor/graphics/layer/setupLayer.tsx
+++ b/pandora-client-web/src/editor/graphics/layer/setupLayer.tsx
@@ -81,7 +81,7 @@ export function SetupMeshLayerSelected({
 	} = useLayerImageSource(evaluator, definition, item);
 
 	const evaluatorUvPose = useAppearanceConditionEvaluator(characterState, false, imageUv);
-	const uv = useLayerVertices(evaluatorUvPose, points, definition, item, true);
+	const uv = useLayerVertices(evaluatorUvPose, points, definition, item, true).vertices;
 
 	const asset = layer.asset;
 	const editorAssetTextures = useObservable(asset.textures);
@@ -189,7 +189,7 @@ export function SetupAlphaImageMeshLayerSelected({
 	} = useLayerImageSource(evaluator, definition, item);
 
 	const evaluatorUvPose = useAppearanceConditionEvaluator(characterState, false, imageUv);
-	const uv = useLayerVertices(evaluatorUvPose, points, definition, item, true);
+	const uv = useLayerVertices(evaluatorUvPose, points, definition, item, true).vertices;
 
 	const images = useMemo((): readonly string[] => {
 		const imagesTmp = new Set<string>();
@@ -307,7 +307,7 @@ export function SetupAutomeshLayerSelected({
 	});
 
 	const evaluatorUvPose = useAppearanceConditionEvaluator(characterState, false, SCALING_IMAGE_UV_EMPTY);
-	const uv = useLayerVertices(evaluatorUvPose, points, definition, item, true);
+	const uv = useLayerVertices(evaluatorUvPose, points, definition, item, true).vertices;
 
 	const images = useMemo((): readonly string[] => {
 		const imagesTmp = new Set<string>();

--- a/pandora-client-web/src/graphics/appearanceConditionEvaluator.ts
+++ b/pandora-client-web/src/graphics/appearanceConditionEvaluator.ts
@@ -96,6 +96,26 @@ export abstract class ConditionEvaluatorBase {
 		}
 		return [resX, resY];
 	}
+
+	public evalTransformAngle(transforms: Immutable<TransformDefinition[]>, item: Item | null): number {
+		let angle = 0;
+		for (const transform of transforms) {
+			const { type, condition } = transform;
+			if (this.valueOverrides != null && (type === 'const-shift' || type === 'const-rotate')) {
+				continue;
+			}
+			if (condition && !EvaluateCondition(condition, (c) => this.evalCondition(c, item))) {
+				continue;
+			}
+			if (type === 'const-rotate' || type === 'rotate') {
+				const boneName = transform.bone;
+				const rotation = this.valueOverrides ? (this.valueOverrides[boneName] ?? 0) : this.getBoneLikeValue(boneName);
+				const value = type === 'const-rotate' ? transform.value : transform.value * rotation;
+				angle += value;
+			}
+		}
+		return angle;
+	}
 	//#endregion
 
 	public evalBoneTransform(bone: string, matrix?: Matrix): Matrix {

--- a/pandora-client-web/src/graphics/baseComponents/customMesh.tsx
+++ b/pandora-client-web/src/graphics/baseComponents/customMesh.tsx
@@ -1,0 +1,126 @@
+import { Assert } from 'pandora-common';
+import { Mesh, State, type Geometry, type Shader } from 'pixi.js';
+import type { ReactNode } from 'react';
+import { RegisterPixiComponent } from '../reconciler/component.ts';
+import { CONTAINER_EVENTS, type ContainerEventMap } from './container.ts';
+
+export type PixiCustomMeshGeometryCreator<TGeometry extends Geometry> = (existingGeometry: TGeometry | null) => TGeometry;
+export type PixiCustomMeshShaderCreator<TShader extends Shader> = (existingShader: TShader | null) => TShader;
+
+export interface PixiCustomMeshProps<TGeometry extends Geometry, TShader extends Shader> {
+	geometry: PixiCustomMeshGeometryCreator<TGeometry>;
+	shader: PixiCustomMeshShaderCreator<TShader>;
+
+	state?: State;
+	tint?: number;
+	alpha?: number;
+}
+
+/**
+ * Mesh class that allows for custom geometry and shader.
+ *
+ * This class empowers you to have more than maximum flexibility to render any kind of WebGL visuals you can think of.
+ * This class assumes a lot of WebGL knowledge.
+ * If you know a bit this should abstract enough away to make your life easier!
+ *
+ * Pretty much ALL WebGL can be broken down into the following:
+ * - Geometry - The structure and data for the mesh. This can include anything from positions, uvs, normals, colors etc..
+ * - Shader - This is the shader that PixiJS will render the geometry with (attributes in the shader must match the geometry)
+ * - State - This is the state of WebGL required to render the mesh.
+ *
+ * Through a combination of the above elements you can render anything you want, 2D or 3D!
+ */
+export const PixiCustomMesh = RegisterPixiComponent<Mesh<Geometry, Shader>, never, ContainerEventMap, PixiCustomMeshProps<Geometry, Shader>>('PixiCustomMesh', {
+	create(props) {
+		const {
+			geometry,
+			shader,
+			state,
+			tint,
+			alpha,
+		} = props;
+
+		const geometryInstance = geometry(null);
+		const shaderInstance = shader(null);
+
+		const mesh = new Mesh({
+			geometry: geometryInstance,
+			shader: shaderInstance,
+			state,
+		});
+		mesh.tint = tint ?? 0xffffff;
+		mesh.alpha = alpha ?? 1;
+
+		return mesh;
+	},
+	destroy: (mesh) => {
+		// We need to manually destroy the geometry to clean up properly
+		const geometry = mesh.geometry;
+		const shader = mesh.shader;
+		mesh.destroy({
+			texture: false,
+			textureSource: false,
+			children: false,
+		});
+		geometry.destroy(true);
+		shader?.destroy();
+	},
+	applyCustomProps(mesh, oldProps, newProps) {
+		const {
+			geometry: oldGeometry,
+			shader: oldShader,
+			state: oldState,
+			tint: oldTint,
+			alpha: oldAlpha,
+		} = oldProps as Partial<typeof newProps>;
+		const {
+			geometry,
+			shader,
+			state,
+			tint,
+			alpha,
+		} = newProps;
+
+		let updated = false;
+
+		if (geometry !== oldGeometry) {
+			const geometryInstance = mesh.geometry;
+			const newGeometryInstance = geometry(geometryInstance);
+			if (newGeometryInstance !== geometryInstance) {
+				mesh.geometry = newGeometryInstance;
+				geometryInstance.destroy(true);
+			}
+			updated = true;
+		}
+
+		if (shader !== oldShader) {
+			const shaderInstance = mesh.shader;
+			Assert(shaderInstance != null);
+			const newShaderInstance = shader(shaderInstance);
+			if (newShaderInstance !== shaderInstance) {
+				mesh.shader = newShaderInstance;
+				shaderInstance.destroy();
+			}
+			updated = true;
+		}
+
+		if (state !== oldState) {
+			mesh.state = state ?? State.for2d();
+			updated = true;
+		}
+
+		if (tint !== oldTint) {
+			mesh.tint = tint ?? 0xffffff;
+			updated = true;
+		}
+
+		if (alpha !== oldAlpha) {
+			mesh.alpha = alpha ?? 1;
+			updated = true;
+		}
+
+		return updated;
+	},
+	autoProps: {},
+	events: CONTAINER_EVENTS,
+}) as (<TGeometry extends Geometry, TShader extends Shader>(props: PixiCustomMeshProps<TGeometry, TShader>) => ReactNode);

--- a/pandora-client-web/src/graphics/baseComponents/mesh.tsx
+++ b/pandora-client-web/src/graphics/baseComponents/mesh.tsx
@@ -1,4 +1,4 @@
-import { Mesh, MeshGeometry, State, Texture, type Shader, type TextureShader } from 'pixi.js';
+import { Mesh, MeshGeometry, State, Texture } from 'pixi.js';
 import { RegisterPixiComponent } from '../reconciler/component.ts';
 import { CONTAINER_EVENTS, type ContainerEventMap } from './container.ts';
 
@@ -7,7 +7,6 @@ export interface PixiMeshProps {
 	uvs: Float32Array;
 	indices: Uint32Array;
 	texture: Texture;
-	shader?: Shader;
 	state?: State;
 	tint?: number;
 	alpha?: number;
@@ -27,14 +26,13 @@ export interface PixiMeshProps {
  *
  * Through a combination of the above elements you can render anything you want, 2D or 3D!
  */
-export const PixiMesh = RegisterPixiComponent<Mesh<MeshGeometry, Shader>, never, ContainerEventMap, PixiMeshProps>('PixiMesh', {
+export const PixiMesh = RegisterPixiComponent<Mesh, never, ContainerEventMap, PixiMeshProps>('PixiMesh', {
 	create(props) {
 		const {
 			vertices,
 			uvs,
 			indices,
 			texture,
-			shader,
 			state,
 			tint,
 			alpha,
@@ -53,16 +51,9 @@ export const PixiMesh = RegisterPixiComponent<Mesh<MeshGeometry, Shader>, never,
 			geometry,
 			texture,
 			state,
-			shader,
 		});
 		mesh.tint = tint ?? 0xffffff;
 		mesh.alpha = alpha ?? 1;
-
-		if (shader != null) {
-			shader.resources.uTexture = texture.source;
-			shader.resources.uSampler = texture.source.style;
-			shader.resources.textureUniforms.uniforms.uTextureMatrix = texture.textureMatrix.mapCoord;
-		}
 
 		return mesh;
 	},
@@ -82,7 +73,6 @@ export const PixiMesh = RegisterPixiComponent<Mesh<MeshGeometry, Shader>, never,
 			uvs: oldUvs,
 			indices: oldIndices,
 			texture: oldTexture,
-			shader: oldShader,
 			state: oldState,
 			tint: oldTint,
 			alpha: oldAlpha,
@@ -92,7 +82,6 @@ export const PixiMesh = RegisterPixiComponent<Mesh<MeshGeometry, Shader>, never,
 			uvs,
 			indices,
 			texture,
-			shader,
 			state,
 			tint,
 			alpha,
@@ -113,15 +102,8 @@ export const PixiMesh = RegisterPixiComponent<Mesh<MeshGeometry, Shader>, never,
 			updated = true;
 		}
 
-		if (texture !== oldTexture || shader !== oldShader) {
-			mesh.shader = shader ?? null;
+		if (texture !== oldTexture) {
 			mesh.texture = texture;
-			if (shader != null) {
-				(shader as TextureShader).texture = texture;
-				shader.resources.uTexture = texture.source;
-				shader.resources.uSampler = texture.source.style;
-				shader.resources.textureUniforms.uniforms.uTextureMatrix = texture.textureMatrix.mapCoord;
-			}
 			updated = true;
 		}
 

--- a/pandora-client-web/src/graphics/baseComponents/mesh.tsx
+++ b/pandora-client-web/src/graphics/baseComponents/mesh.tsx
@@ -1,4 +1,4 @@
-import { Mesh, MeshGeometry, State, Texture } from 'pixi.js';
+import { Mesh, MeshGeometry, State, Texture, type Shader, type TextureShader } from 'pixi.js';
 import { RegisterPixiComponent } from '../reconciler/component.ts';
 import { CONTAINER_EVENTS, type ContainerEventMap } from './container.ts';
 
@@ -7,6 +7,7 @@ export interface PixiMeshProps {
 	uvs: Float32Array;
 	indices: Uint32Array;
 	texture: Texture;
+	shader?: Shader;
 	state?: State;
 	tint?: number;
 	alpha?: number;
@@ -26,13 +27,14 @@ export interface PixiMeshProps {
  *
  * Through a combination of the above elements you can render anything you want, 2D or 3D!
  */
-export const PixiMesh = RegisterPixiComponent<Mesh, never, ContainerEventMap, PixiMeshProps>('PixiMesh', {
+export const PixiMesh = RegisterPixiComponent<Mesh<MeshGeometry, Shader>, never, ContainerEventMap, PixiMeshProps>('PixiMesh', {
 	create(props) {
 		const {
 			vertices,
 			uvs,
 			indices,
 			texture,
+			shader,
 			state,
 			tint,
 			alpha,
@@ -51,9 +53,16 @@ export const PixiMesh = RegisterPixiComponent<Mesh, never, ContainerEventMap, Pi
 			geometry,
 			texture,
 			state,
+			shader,
 		});
 		mesh.tint = tint ?? 0xffffff;
 		mesh.alpha = alpha ?? 1;
+
+		if (shader != null) {
+			shader.resources.uTexture = texture.source;
+			shader.resources.uSampler = texture.source.style;
+			shader.resources.textureUniforms.uniforms.uTextureMatrix = texture.textureMatrix.mapCoord;
+		}
 
 		return mesh;
 	},
@@ -73,6 +82,7 @@ export const PixiMesh = RegisterPixiComponent<Mesh, never, ContainerEventMap, Pi
 			uvs: oldUvs,
 			indices: oldIndices,
 			texture: oldTexture,
+			shader: oldShader,
 			state: oldState,
 			tint: oldTint,
 			alpha: oldAlpha,
@@ -82,6 +92,7 @@ export const PixiMesh = RegisterPixiComponent<Mesh, never, ContainerEventMap, Pi
 			uvs,
 			indices,
 			texture,
+			shader,
 			state,
 			tint,
 			alpha,
@@ -102,8 +113,15 @@ export const PixiMesh = RegisterPixiComponent<Mesh, never, ContainerEventMap, Pi
 			updated = true;
 		}
 
-		if (texture !== oldTexture) {
+		if (texture !== oldTexture || shader !== oldShader) {
+			mesh.shader = shader ?? null;
 			mesh.texture = texture;
+			if (shader != null) {
+				(shader as TextureShader).texture = texture;
+				shader.resources.uTexture = texture.source;
+				shader.resources.uSampler = texture.source.style;
+				shader.resources.textureUniforms.uniforms.uTextureMatrix = texture.textureMatrix.mapCoord;
+			}
 			updated = true;
 		}
 

--- a/pandora-client-web/src/graphics/graphicsAppManager.ts
+++ b/pandora-client-web/src/graphics/graphicsAppManager.ts
@@ -3,6 +3,7 @@ import { GetLogger, TypedEventEmitter } from 'pandora-common';
 import { Application, ApplicationOptions } from 'pixi.js';
 import { DestroyGraphicsLoader } from '../assets/assetManager.tsx';
 import { USER_DEBUG } from '../config/Environment.ts';
+import { GetGraphicsEffectiveAntialias } from './graphicsSettings.tsx';
 
 const SHARED_APP_MAX_COUNT = 2;
 
@@ -11,8 +12,8 @@ export const PIXI_APPLICATION_OPTIONS: Readonly<Partial<ApplicationOptions>> = {
 	resolution: window.devicePixelRatio || 1,
 	// Alpha needs to start on a value < 1, otherwise it fails to initialize transparency correctly and cannot be enabled later on
 	backgroundAlpha: 0,
-	// Antialias **NEEDS** to be explicitly disabled - having it enabled causes seams when using filters (such as alpha masks)
-	antialias: false,
+	// Antialias is controlled by settings. See the settings for more details
+	antialias: GetGraphicsEffectiveAntialias(),
 };
 
 export async function CreatePixiApplication(multiView: boolean = false): Promise<Application> {

--- a/pandora-client-web/src/graphics/graphicsCharacter.tsx
+++ b/pandora-client-web/src/graphics/graphicsCharacter.tsx
@@ -20,6 +20,7 @@ import { ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 
 import { GraphicsManagerInstance } from '../assets/graphicsManager.ts';
 import { ChildrenProps } from '../common/reactTypes.ts';
 import { Observable, useObservable } from '../observable.ts';
+import type { ChatroomDebugConfig } from '../ui/screens/room/roomDebug.tsx';
 import { Container } from './baseComponents/container.ts';
 import { useAssetPreferenceVisibilityCheck } from './common/assetVisibilityCheck.ts';
 import type { PointLike } from './common/point.ts';
@@ -49,6 +50,7 @@ export interface GraphicsCharacterProps extends ChildrenProps {
 	eventMode?: PIXI.EventMode;
 	filters?: readonly Filter[];
 	zIndex?: number;
+	debugConfig?: Immutable<ChatroomDebugConfig>;
 
 	/**
 	 * Whether the blinking condition should be used for the graphics layer evaluators.
@@ -107,6 +109,7 @@ export function GraphicsCharacterWithManager({
 	children,
 	graphicsGetter,
 	layerStateOverrideGetter,
+	debugConfig,
 	useBlinking = false,
 	movementTransitionDuration = 0,
 	perPropertyMovementTransitionDuration,
@@ -293,13 +296,14 @@ export function GraphicsCharacterWithManager({
 					state={ layerState.state }
 					characterState={ effectiveCharacterState }
 					characterBlinking={ characterBlinking }
+					debugConfig={ debugConfig }
 				>
 					{ lowerLayer }
 				</LayerElement>
 			));
 		}
 		return result;
-	}, [Layer, effectiveCharacterState, layers, view, characterBlinking]);
+	}, [Layer, effectiveCharacterState, layers, view, characterBlinking, debugConfig]);
 
 	const pivot = useMemo<PointLike>(() => (pivotExtra ?? { x: CHARACTER_PIVOT_POSITION.x, y: 0 }), [pivotExtra]);
 	const scale = useMemo<PointLike>(() => (scaleExtra ?? { x: view === 'back' ? -1 : 1, y: 1 }), [view, scaleExtra]);

--- a/pandora-client-web/src/graphics/layers/graphicsLayerAlphaImageMesh.tsx
+++ b/pandora-client-web/src/graphics/layers/graphicsLayerAlphaImageMesh.tsx
@@ -42,8 +42,8 @@ export function GraphicsLayerAlphaImageMesh({
 
 	const evaluatorUvPose = useAppearanceConditionEvaluator(characterState, currentlyBlinking, imageUv);
 
-	const vertices = useLayerVertices(displayUvPose ? evaluatorUvPose : evaluator, points, layer, item, false);
-	const uv = useLayerVertices(evaluatorUvPose, points, layer, item, true);
+	const vertices = useLayerVertices(displayUvPose ? evaluatorUvPose : evaluator, points, layer, item, false).vertices;
+	const uv = useLayerVertices(evaluatorUvPose, points, layer, item, true).vertices;
 
 	const alphaImage = image;
 	const alphaMesh = useMemo(() => ({

--- a/pandora-client-web/src/graphics/layers/graphicsLayerCommon.tsx
+++ b/pandora-client-web/src/graphics/layers/graphicsLayerCommon.tsx
@@ -15,6 +15,7 @@ import { DEG_TO_RAD, Texture } from 'pixi.js';
 import { ReactElement, createContext, useContext, useMemo } from 'react';
 import { ChildrenProps } from '../../common/reactTypes.ts';
 import { useObservable, type ReadonlyObservable } from '../../observable.ts';
+import type { ChatroomDebugConfig } from '../../ui/screens/room/roomDebug.tsx';
 import { ConditionEvaluatorBase } from '../appearanceConditionEvaluator.ts';
 
 type TransformEvalCacheEntryValue = WeakMap<Immutable<PointDefinitionCalculated[]>, LayerVerticesResult>;
@@ -123,6 +124,7 @@ export interface GraphicsLayerProps<TLayerType extends GraphicsLayerType = Graph
 	characterBlinking?: ReadonlyObservable<boolean>;
 
 	getTexture?: (path: string) => Texture;
+	debugConfig?: Immutable<ChatroomDebugConfig>;
 }
 
 export const ContextCullClockwise = createContext<boolean>(false);

--- a/pandora-client-web/src/graphics/layers/graphicsLayerMesh.tsx
+++ b/pandora-client-web/src/graphics/layers/graphicsLayerMesh.tsx
@@ -1,9 +1,10 @@
 import * as PIXI from 'pixi.js';
-import { ReactElement, useContext, useMemo } from 'react';
+import { ReactElement, useCallback, useContext, useMemo } from 'react';
 import { useImageResolutionAlternative, useLayerImageSource, useLayerMeshPoints } from '../../assets/assetGraphicsCalculations.ts';
 import { useNullableObservable } from '../../observable.ts';
 import { useAppearanceConditionEvaluator } from '../appearanceConditionEvaluator.ts';
 import { Container } from '../baseComponents/container.ts';
+import { PixiCustomMesh, PixiCustomMeshGeometryCreator, type PixiCustomMeshShaderCreator } from '../baseComponents/customMesh.tsx';
 import { PixiMesh } from '../baseComponents/mesh.tsx';
 import { useTexture } from '../useTexture.ts';
 import { ContextCullClockwise, useItemColor, useLayerVertices, type GraphicsLayerProps } from './graphicsLayerCommon.tsx';
@@ -29,16 +30,16 @@ export function GraphicsLayerMesh({
 	const {
 		image,
 		imageUv,
-		depthComponent,
+		normalMapImage,
 	} = useLayerImageSource(evaluator, layer, item);
 
 	const evaluatorUvPose = useAppearanceConditionEvaluator(characterState, currentlyBlinking, imageUv);
 
-	const vertices = useLayerVertices(displayUvPose ? evaluatorUvPose : evaluator, points, layer, item, false);
-	const uv = useLayerVertices(evaluatorUvPose, points, layer, item, true);
+	const { vertices, vertexRotations } = useLayerVertices(displayUvPose ? evaluatorUvPose : evaluator, points, layer, item, false);
+	const uv = useLayerVertices(evaluatorUvPose, points, layer, item, true).vertices;
 
 	const texture = useTexture(useImageResolutionAlternative(image).image, undefined, getTexture);
-	const depthTexture = useTexture(useImageResolutionAlternative(depthComponent ?? '').image || '*', undefined, getTexture);
+	const normalMapTexture = useTexture(useImageResolutionAlternative(normalMapImage ?? '').image || '*', undefined, getTexture);
 
 	const { color, alpha } = useItemColor(characterState.items, item, layer.colorizationKey, state);
 
@@ -51,46 +52,133 @@ export function GraphicsLayerMesh({
 		return pixiState;
 	}, [cullClockwise]);
 
-	const shader = useMemo(() => {
-		if (depthTexture === PIXI.Texture.WHITE)
+	const geometry = useCallback<PixiCustomMeshGeometryCreator<PIXI.Geometry>>((existingGeometry) => {
+		if (existingGeometry) {
+			existingGeometry.getBuffer('aPosition').data = vertices;
+			existingGeometry.getBuffer('aUV').data = uv;
+			existingGeometry.getBuffer('aRotation').data = vertexRotations;
+			existingGeometry.indexBuffer.data = triangles;
+			return existingGeometry;
+		} else {
+			const positionBuffer = new PIXI.Buffer({
+				data: vertices,
+				label: 'attribute-mesh-positions',
+				shrinkToFit: true,
+				// eslint-disable-next-line no-bitwise
+				usage: PIXI.BufferUsage.VERTEX | PIXI.BufferUsage.COPY_DST,
+			});
+
+			const uvBuffer = new PIXI.Buffer({
+				data: uv,
+				label: 'attribute-mesh-uvs',
+				shrinkToFit: true,
+				// eslint-disable-next-line no-bitwise
+				usage: PIXI.BufferUsage.VERTEX | PIXI.BufferUsage.COPY_DST,
+			});
+
+			const vertexRotationBuffer = new PIXI.Buffer({
+				data: vertexRotations,
+				label: 'attribute-mesh-vertex-rotations',
+				shrinkToFit: true,
+				// eslint-disable-next-line no-bitwise
+				usage: PIXI.BufferUsage.VERTEX | PIXI.BufferUsage.COPY_DST,
+			});
+
+			const indexBuffer = new PIXI.Buffer({
+				data: triangles,
+				label: 'index-mesh-buffer',
+				shrinkToFit: true,
+				// eslint-disable-next-line no-bitwise
+				usage: PIXI.BufferUsage.INDEX | PIXI.BufferUsage.COPY_DST,
+			});
+
+			const geometryInstance = new PIXI.Geometry(({
+				attributes: {
+					aPosition: {
+						buffer: positionBuffer,
+						format: 'float32x2',
+						stride: 2 * 4,
+						offset: 0,
+					},
+					aUV: {
+						buffer: uvBuffer,
+						format: 'float32x2',
+						stride: 2 * 4,
+						offset: 0,
+					},
+					aRotation: {
+						buffer: vertexRotationBuffer,
+						format: 'float32',
+						stride: 1 * 4,
+						offset: 0,
+					},
+				},
+				indexBuffer,
+				topology: 'triangle-list',
+			}));
+
+			return geometryInstance;
+		}
+	}, [triangles, uv, vertices, vertexRotations]);
+
+	const shader = useMemo((): PixiCustomMeshShaderCreator<PIXI.Shader> | undefined => {
+		if (normalMapTexture === PIXI.Texture.WHITE)
 			return undefined;
 
-		depthTexture.source.format = 'r16float';
+		// normalTexture.source.format = 'rgba8unorm';
 
-		const uPix = new Float32Array(3);
-		uPix[0] = 1 / layer.width;
-		uPix[1] = 1 / layer.height;
-		uPix[2] = 0;
-
-		return new PIXI.Shader({
-			glProgram,
-			resources: {
-				uTexture: PIXI.Texture.EMPTY.source,
-				uDepthTexture: depthTexture.source,
-				uDepthSampler: depthTexture.source.style,
-				textureUniforms: new PIXI.UniformGroup({
-					uTextureMatrix: { type: 'mat3x3<f32>', value: new PIXI.Matrix() },
-					uPix: { type: 'vec3<f32>', value: uPix },
-				}),
-			},
-		});
-	}, [depthTexture, layer.height, layer.width]);
+		return (existingShader) => {
+			if (existingShader) {
+				existingShader.resources.uTexture = texture.source;
+				existingShader.resources.uSampler = texture.source.style;
+				existingShader.resources.uNormalMap = normalMapTexture.source;
+				existingShader.resources.uNormalSampler = normalMapTexture.source.style;
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+				existingShader.resources.textureUniforms.uniforms.uTextureMatrix = texture.textureMatrix.mapCoord;
+				return existingShader;
+			} else {
+				return new PIXI.Shader({
+					glProgram,
+					resources: {
+						uTexture: texture.source,
+						uSampler: texture.source.style,
+						uNormalMap: normalMapTexture.source,
+						uNormalSampler: normalMapTexture.source.style,
+						textureUniforms: new PIXI.UniformGroup({
+							uTextureMatrix: { type: 'mat3x3<f32>', value: texture.textureMatrix.mapCoord },
+						}),
+					},
+				});
+			}
+		};
+	}, [texture, normalMapTexture]);
 
 	return (
 		<Container
 			zIndex={ zIndex }
 			sortableChildren
 		>
-			<PixiMesh
-				state={ cullingState }
-				vertices={ vertices }
-				uvs={ uv }
-				indices={ triangles }
-				texture={ texture }
-				shader={ shader }
-				tint={ color }
-				alpha={ alpha }
-			/>
+			{
+			shader != null ? (
+				<PixiCustomMesh
+					geometry={ geometry }
+					shader={ shader }
+					state={ cullingState }
+					tint={ color }
+					alpha={ alpha }
+				/>
+			) : (
+				<PixiMesh
+					state={ cullingState }
+					vertices={ vertices }
+					uvs={ uv }
+					indices={ triangles }
+					texture={ texture }
+					tint={ color }
+					alpha={ alpha }
+				/>
+			)
+			}
 			<Container zIndex={ lowerZIndex }>
 				{ children }
 			</Container>
@@ -107,33 +195,60 @@ const glProgram = PIXI.compileHighShaderGlProgram({
 			vertex: {
 				header: /* glsl */`
 uniform mat3 uTextureMatrix;
+in float aRotation; // Rotation in radians per vertex
+out mat3 vTBN;
 		`,
 				main: /* glsl */`
 uv = (uTextureMatrix * vec3(uv, 1.0)).xy;
+
+float cosA = cos(aRotation);
+float sinA = sin(aRotation);
+mat2 rotateMatrix = mat2(
+	vec2(cosA, sinA),
+	vec2(-sinA, cosA)
+);
+
+vec3 T = vec3(1., 0., 0.);
+vec3 B = vec3(0., 1., 0.);
+vec3 N = vec3(0., 0., 1.);
+
+mat2 model2D = mat2(worldTransformMatrix * modelMatrix) * rotateMatrix;
+T.xy = normalize(model2D * T.xy);
+B.xy = normalize(model2D * B.xy);
+
+vTBN = mat3(T, B, N);
 		`,
 			},
 			fragment: {
 				header: /* glsl */`
-uniform sampler2D uTexture;
-uniform sampler2D uDepthTexture;
-uniform vec3 uPix; // normalized size of a pixel, zero in z for convenience
+#version 300 es
 
-float getHeight(vec2 pos) {
-	return 1. - texture(uDepthTexture, pos).x;
+uniform sampler2D uTexture;
+uniform sampler2D uNormalMap;
+
+in mat3 vTBN;
+
+vec3 unpackNormal(vec3 color) {
+	vec3 normal = color * 2. - 1.;
+	// We are working in Pixi's coordinate system - X is right, Y is down, Z toward camera
+	normal.y = -normal.y;
+	return normal;
+}
+
+vec3 packNormal(vec3 normal) {
+	normal.y = -normal.y;
+	return (normal + 1.) / 2.;
 }
 
 vec3 getNormal(vec2 pos) {
-	float h = 150.;
-	float l = h * getHeight(pos - uPix.xz);
-	float r = h * getHeight(pos + uPix.xz);
-	float d = h * getHeight(pos - uPix.zy);
-	float u = h * getHeight(pos + uPix.zy);
-
-	return normalize(vec3(l-r, d-u, 1.));
+	vec3 normal = unpackNormal(texture(uNormalMap, pos).rgb);
+	normal = normalize(vTBN * normal);
+	return normal;
 }
 
 float getNormalShadow(vec2 pos) {
-	return clamp(1. - (dot(getNormal(pos), normalize(vec3(2.7, -2.5, 3.7))) + 1.)/2., 0., 1.);
+	vec3 lightAngle = normalize(vec3(2.7, -2.5, 3.7));
+	return clamp(1. - (dot(getNormal(pos), lightAngle) + 1.)/2., 0., 1.);
 }
 
 		`,
@@ -141,7 +256,6 @@ float getNormalShadow(vec2 pos) {
 float lightStrength = 1. - (0.8 * getNormalShadow(vUV));
 
 outColor = texture(uTexture, vUV);
-outColor.xyz = vec3(outColor.w); // DEBUG
 outColor.xyz *= lightStrength;
 		`,
 			},

--- a/pandora-client-web/src/graphics/layers/graphicsLayerMesh.tsx
+++ b/pandora-client-web/src/graphics/layers/graphicsLayerMesh.tsx
@@ -19,6 +19,7 @@ export function GraphicsLayerMesh({
 	displayUvPose = false,
 	state,
 	getTexture,
+	debugConfig,
 	characterBlinking,
 }: GraphicsLayerProps<'mesh'>): ReactElement {
 
@@ -70,6 +71,7 @@ export function GraphicsLayerMesh({
 						state={ cullingState }
 						color={ color }
 						alpha={ alpha }
+						debugConfig={ debugConfig }
 					/>
 				) : (
 					<PixiMesh

--- a/pandora-client-web/src/graphics/layers/graphicsLayerMesh.tsx
+++ b/pandora-client-web/src/graphics/layers/graphicsLayerMesh.tsx
@@ -29,6 +29,7 @@ export function GraphicsLayerMesh({
 	const {
 		image,
 		imageUv,
+		depthComponent,
 	} = useLayerImageSource(evaluator, layer, item);
 
 	const evaluatorUvPose = useAppearanceConditionEvaluator(characterState, currentlyBlinking, imageUv);
@@ -37,6 +38,7 @@ export function GraphicsLayerMesh({
 	const uv = useLayerVertices(evaluatorUvPose, points, layer, item, true);
 
 	const texture = useTexture(useImageResolutionAlternative(image).image, undefined, getTexture);
+	const depthTexture = useTexture(useImageResolutionAlternative(depthComponent ?? '').image || '*', undefined, getTexture);
 
 	const { color, alpha } = useItemColor(characterState.items, item, layer.colorizationKey, state);
 
@@ -49,6 +51,31 @@ export function GraphicsLayerMesh({
 		return pixiState;
 	}, [cullClockwise]);
 
+	const shader = useMemo(() => {
+		if (depthTexture === PIXI.Texture.WHITE)
+			return undefined;
+
+		depthTexture.source.format = 'r16float';
+
+		const uPix = new Float32Array(3);
+		uPix[0] = 1 / layer.width;
+		uPix[1] = 1 / layer.height;
+		uPix[2] = 0;
+
+		return new PIXI.Shader({
+			glProgram,
+			resources: {
+				uTexture: PIXI.Texture.EMPTY.source,
+				uDepthTexture: depthTexture.source,
+				uDepthSampler: depthTexture.source.style,
+				textureUniforms: new PIXI.UniformGroup({
+					uTextureMatrix: { type: 'mat3x3<f32>', value: new PIXI.Matrix() },
+					uPix: { type: 'vec3<f32>', value: uPix },
+				}),
+			},
+		});
+	}, [depthTexture, layer.height, layer.width]);
+
 	return (
 		<Container
 			zIndex={ zIndex }
@@ -60,6 +87,7 @@ export function GraphicsLayerMesh({
 				uvs={ uv }
 				indices={ triangles }
 				texture={ texture }
+				shader={ shader }
 				tint={ color }
 				alpha={ alpha }
 			/>
@@ -69,3 +97,56 @@ export function GraphicsLayerMesh({
 		</Container>
 	);
 }
+
+const glProgram = PIXI.compileHighShaderGlProgram({
+	name: 'mesh',
+	bits: [
+		PIXI.localUniformBitGl,
+		{
+			name: 'texture-bit',
+			vertex: {
+				header: /* glsl */`
+uniform mat3 uTextureMatrix;
+		`,
+				main: /* glsl */`
+uv = (uTextureMatrix * vec3(uv, 1.0)).xy;
+		`,
+			},
+			fragment: {
+				header: /* glsl */`
+uniform sampler2D uTexture;
+uniform sampler2D uDepthTexture;
+uniform vec3 uPix; // normalized size of a pixel, zero in z for convenience
+
+float getHeight(vec2 pos) {
+	return 1. - texture(uDepthTexture, pos).x;
+}
+
+vec3 getNormal(vec2 pos) {
+	float h = 150.;
+	float l = h * getHeight(pos - uPix.xz);
+	float r = h * getHeight(pos + uPix.xz);
+	float d = h * getHeight(pos - uPix.zy);
+	float u = h * getHeight(pos + uPix.zy);
+
+	return normalize(vec3(l-r, d-u, 1.));
+}
+
+float getNormalShadow(vec2 pos) {
+	return clamp(1. - (dot(getNormal(pos), normalize(vec3(2.7, -2.5, 3.7))) + 1.)/2., 0., 1.);
+}
+
+		`,
+				main: /* glsl */`
+float lightStrength = 1. - (0.8 * getNormalShadow(vUV));
+
+outColor = texture(uTexture, vUV);
+outColor.xyz = vec3(outColor.w); // DEBUG
+outColor.xyz *= lightStrength;
+		`,
+			},
+		},
+		PIXI.roundPixelsBitGl,
+	],
+});
+

--- a/pandora-client-web/src/graphics/layers/graphicsLayerMesh.tsx
+++ b/pandora-client-web/src/graphics/layers/graphicsLayerMesh.tsx
@@ -1,14 +1,13 @@
-import { noop } from 'lodash-es';
 import * as PIXI from 'pixi.js';
-import { ReactElement, useCallback, useContext, useMemo } from 'react';
+import { ReactElement, useContext, useMemo } from 'react';
 import { useImageResolutionAlternative, useLayerImageSource, useLayerMeshPoints } from '../../assets/assetGraphicsCalculations.ts';
 import { useNullableObservable } from '../../observable.ts';
 import { useAppearanceConditionEvaluator } from '../appearanceConditionEvaluator.ts';
 import { Container } from '../baseComponents/container.ts';
-import { PixiCustomMesh, PixiCustomMeshGeometryCreator, type PixiCustomMeshShaderCreator } from '../baseComponents/customMesh.tsx';
 import { PixiMesh } from '../baseComponents/mesh.tsx';
 import { useTexture } from '../useTexture.ts';
 import { ContextCullClockwise, useItemColor, useLayerVertices, type GraphicsLayerProps } from './graphicsLayerCommon.tsx';
+import { GraphicsLayerMeshNormals } from './graphicsLayerMeshNormals.tsx';
 
 export function GraphicsLayerMesh({
 	characterState,
@@ -53,145 +52,36 @@ export function GraphicsLayerMesh({
 		return pixiState;
 	}, [cullClockwise]);
 
-	const geometry = useCallback<PixiCustomMeshGeometryCreator<PIXI.Geometry>>((existingGeometry) => {
-		if (existingGeometry) {
-			existingGeometry.getBuffer('aPosition').data = vertices;
-			existingGeometry.getBuffer('aUV').data = uv;
-			existingGeometry.getBuffer('aRotation').data = vertexRotations;
-			existingGeometry.indexBuffer.data = triangles;
-			return existingGeometry;
-		} else {
-			const positionBuffer = new PIXI.Buffer({
-				data: vertices,
-				label: 'attribute-mesh-positions',
-				shrinkToFit: true,
-				// eslint-disable-next-line no-bitwise
-				usage: PIXI.BufferUsage.VERTEX | PIXI.BufferUsage.COPY_DST,
-			});
-
-			const uvBuffer = new PIXI.Buffer({
-				data: uv,
-				label: 'attribute-mesh-uvs',
-				shrinkToFit: true,
-				// eslint-disable-next-line no-bitwise
-				usage: PIXI.BufferUsage.VERTEX | PIXI.BufferUsage.COPY_DST,
-			});
-
-			const vertexRotationBuffer = new PIXI.Buffer({
-				data: vertexRotations,
-				label: 'attribute-mesh-vertex-rotations',
-				shrinkToFit: true,
-				// eslint-disable-next-line no-bitwise
-				usage: PIXI.BufferUsage.VERTEX | PIXI.BufferUsage.COPY_DST,
-			});
-
-			const indexBuffer = new PIXI.Buffer({
-				data: triangles,
-				label: 'index-mesh-buffer',
-				shrinkToFit: true,
-				// eslint-disable-next-line no-bitwise
-				usage: PIXI.BufferUsage.INDEX | PIXI.BufferUsage.COPY_DST,
-			});
-
-			const geometryInstance = new PIXI.Geometry(({
-				attributes: {
-					aPosition: {
-						buffer: positionBuffer,
-						format: 'float32x2',
-						stride: 2 * 4,
-						offset: 0,
-					},
-					aUV: {
-						buffer: uvBuffer,
-						format: 'float32x2',
-						stride: 2 * 4,
-						offset: 0,
-					},
-					aRotation: {
-						buffer: vertexRotationBuffer,
-						format: 'float32',
-						stride: 1 * 4,
-						offset: 0,
-					},
-				},
-				indexBuffer,
-				topology: 'triangle-list',
-			}));
-
-			return geometryInstance;
-		}
-	}, [triangles, uv, vertices, vertexRotations]);
-
-	const shader = useMemo((): PixiCustomMeshShaderCreator<PIXI.Shader> | undefined => {
-		if (!layer.normalMap)
-			return undefined;
-
-		const normalMap = normalMapTexture === PIXI.Texture.WHITE ? DEFAULT_NORMAL_TEXTURE : normalMapTexture;
-		const ambientStrength = 0.1;
-		const { specularStrength, roughness } = layer.normalMap;
-
-		return (existingShader) => {
-			if (existingShader) {
-				existingShader.resources.uTexture = texture.source;
-				existingShader.resources.uSampler = texture.source.style;
-				existingShader.resources.uNormalMap = normalMap.source;
-				existingShader.resources.uNormalSampler = normalMap.source.style;
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				existingShader.resources.textureUniforms.uniforms.uTextureMatrix = texture.textureMatrix.mapCoord;
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				existingShader.resources.pbrUniforms.uniforms.uAmbientStrength = ambientStrength;
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				existingShader.resources.pbrUniforms.uniforms.uSpecularStrength = specularStrength;
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				existingShader.resources.pbrUniforms.uniforms.uRoughness = roughness;
-				return existingShader;
-			} else {
-				return new PIXI.Shader({
-					glProgram,
-					resources: {
-						uTexture: texture.source,
-						uSampler: texture.source.style,
-						uNormalMap: normalMap.source,
-						uNormalSampler: normalMap.source.style,
-						textureUniforms: new PIXI.UniformGroup({
-							uTextureMatrix: { type: 'mat3x3<f32>', value: texture.textureMatrix.mapCoord },
-						}),
-						pbrUniforms: new PIXI.UniformGroup({
-							uAmbientStrength: { type: 'f32', value: ambientStrength },
-							uSpecularStrength: { type: 'f32', value: specularStrength },
-							uRoughness: { type: 'f32', value: roughness },
-						}),
-					},
-				});
-			}
-		};
-	}, [texture, normalMapTexture, layer.normalMap]);
-
 	return (
 		<Container
 			zIndex={ zIndex }
 			sortableChildren
 		>
 			{
-			shader != null ? (
-				<PixiCustomMesh
-					geometry={ geometry }
-					shader={ shader }
-					state={ cullingState }
-					tint={ color }
-					alpha={ alpha }
-				/>
-			) : (
-				<PixiMesh
-					state={ cullingState }
-					vertices={ vertices }
-					uvs={ uv }
-					indices={ triangles }
-					texture={ texture }
-					tint={ color }
-					alpha={ alpha }
-				/>
-			)
+				layer.normalMap != null ? (
+					<GraphicsLayerMeshNormals
+						vertices={ vertices }
+						vertexRotations={ vertexRotations }
+						uvs={ uv }
+						triangles={ triangles }
+						texture={ texture }
+						normalMapTexture={ normalMapTexture }
+						normalMapData={ layer.normalMap }
+						state={ cullingState }
+						color={ color }
+						alpha={ alpha }
+					/>
+				) : (
+					<PixiMesh
+						state={ cullingState }
+						vertices={ vertices }
+						uvs={ uv }
+						indices={ triangles }
+						texture={ texture }
+						tint={ color }
+						alpha={ alpha }
+					/>
+				)
 			}
 			<Container zIndex={ lowerZIndex }>
 				{ children }
@@ -199,143 +89,3 @@ export function GraphicsLayerMesh({
 		</Container>
 	);
 }
-
-export const DEFAULT_NORMAL_TEXTURE = new PIXI.Texture({
-	source: new PIXI.BufferImageSource({
-		resource: new Uint8Array([127, 127, 255, 255]),
-		width: 1,
-		height: 1,
-		alphaMode: 'premultiply-alpha-on-upload',
-		label: 'DEFAULT_NORMAL',
-	}),
-	label: 'DEFAULT_NORMAL',
-});
-DEFAULT_NORMAL_TEXTURE.destroy = noop;
-
-/* TODO: Helpers
-
-// Normals from height
-float getHeight(vec2 pos) {
-	return 1. - texture(uDepthTexture, pos).x;
-}
-
-float h = 150.;
-float l = h * getHeight(pos - uPix.xz);
-float r = h * getHeight(pos + uPix.xz);
-float d = h * getHeight(pos - uPix.zy);
-float u = h * getHeight(pos + uPix.zy);
-return normalize(vec3(l-r, u-d, 1.));
-
-// Display normals
-outColor.xyz = packNormal(getNormal(vUV)) * outColor.w;
-
-*/
-
-const glProgram = PIXI.compileHighShaderGlProgram({
-	name: 'mesh',
-	bits: [
-		PIXI.localUniformBitGl,
-		{
-			name: 'texture-bit',
-			vertex: {
-				header: /* glsl */`
-uniform mat3 uTextureMatrix;
-in float aRotation; // Rotation in radians per vertex
-out mat3 vTBN;
-		`,
-				main: /* glsl */`
-uv = (uTextureMatrix * vec3(uv, 1.0)).xy;
-
-float cosA = cos(aRotation);
-float sinA = sin(aRotation);
-mat2 rotateMatrix = mat2(
-	vec2(cosA, sinA),
-	vec2(-sinA, cosA)
-);
-
-vec3 T = vec3(1., 0., 0.);
-vec3 B = vec3(0., 1., 0.);
-vec3 N = vec3(0., 0., 1.);
-
-mat2 model2D = mat2(worldTransformMatrix * modelMatrix) * rotateMatrix;
-T.xy = normalize(model2D * T.xy);
-B.xy = normalize(model2D * B.xy);
-
-vTBN = mat3(T, B, N);
-		`,
-			},
-			fragment: {
-				header: /* glsl */`
-#version 300 es
-
-uniform sampler2D uTexture;
-uniform sampler2D uNormalMap;
-
-vec3 ambientColour = vec3(1., 1., 1.);
-vec3 lightColour = vec3(1., 1., 1.);
-
-vec3 lightDir = normalize(vec3(2.7, -2.5, 3.7));
-
-uniform float uAmbientStrength;
-uniform float uSpecularStrength;
-uniform float uRoughness;
-
-in mat3 vTBN;
-
-vec3 unpackNormal(vec3 color) {
-	vec3 normal = color * 2. - 1.;
-	// We are working in Pixi's coordinate system - X is right, Y is down, Z toward camera
-	normal.y = -normal.y;
-	return normal;
-}
-
-vec3 packNormal(vec3 normal) {
-	normal.y = -normal.y;
-	return (normal + 1.) / 2.;
-}
-
-vec3 getNormal(vec2 pos) {
-	vec3 normal = unpackNormal(texture(uNormalMap, pos).rgb);
-	normal = normalize(vTBN * normal);
-	return normal;
-}
-		`,
-				main: /* glsl */`
-vec3 normal = getNormal(vUV);
-outColor = texture(uTexture, vUV);
-
-vec3 ambient = clamp(ambientColour * uAmbientStrength, 0., 1.);
-
-float lambertian = clamp(dot(lightDir, normal), 0., 1.);
-vec3 diffuse = (0.4 + 0.6 * lambertian) * lightColour;
-
-vec3 specular = vec3(0.);
-if (lambertian > 0.) {
-	vec3 viewDir = normalize(vec3(0., 0., 1.));
-	float shininess = pow(2., (1.0 - uRoughness) * 4.);
-
-	vec3 reflection = 2.0 * dot(normal, lightDir) * normal - lightDir;
-	float specularStrength = clamp(dot(reflection, viewDir), 0.0, 1.0);
-	specularStrength = pow(specularStrength, shininess);
-	specularStrength *= uSpecularStrength;
-
-	// The specular color is from the light source, not the object
-	if (specularStrength > 0.) {
-		specular = lightColour * specularStrength;
-		diffuse *= 1. - specularStrength;
-	}
-}
-
-outColor *= vColor;
-outColor.xyz *= (ambient + diffuse);
-outColor.xyz += specular * outColor.w;
-		`,
-				// Skip Pixi's final tint step (with vColor) in here. We do it manually in a way it ignores specular light
-				end: `
-finalColor = outColor;
-		`,
-			},
-		},
-		PIXI.roundPixelsBitGl,
-	],
-});

--- a/pandora-client-web/src/graphics/layers/graphicsLayerMeshNormals.tsx
+++ b/pandora-client-web/src/graphics/layers/graphicsLayerMeshNormals.tsx
@@ -1,8 +1,10 @@
+import type { Immutable } from 'immer';
 import type { LayerNormalData } from 'pandora-common';
 import * as PIXI from 'pixi.js';
 import { ReactElement, useCallback, useMemo } from 'react';
+import type { ChatroomDebugConfig } from '../../ui/screens/room/roomDebug.tsx';
 import { PixiCustomMesh, PixiCustomMeshGeometryCreator, type PixiCustomMeshShaderCreator } from '../baseComponents/customMesh.tsx';
-import { DEFAULT_NORMAL_TEXTURE, NORMAL_MESH_GL_PROGRAM } from './graphicsLayerMeshNormalsShader.ts';
+import { DEFAULT_NORMAL_TEXTURE, NORMAL_MESH_DEBUG_NORMALS_GL_PROGRAM, NORMAL_MESH_GL_PROGRAM } from './graphicsLayerMeshNormalsShader.ts';
 
 export interface GraphicsLayerMeshNormalsProps {
 	vertices: Float32Array;
@@ -15,6 +17,7 @@ export interface GraphicsLayerMeshNormalsProps {
 	state: PIXI.State;
 	color: number;
 	alpha: number;
+	debugConfig?: Immutable<ChatroomDebugConfig>;
 }
 
 export function GraphicsLayerMeshNormals({
@@ -28,6 +31,7 @@ export function GraphicsLayerMeshNormals({
 	state,
 	color,
 	alpha,
+	debugConfig,
 }: GraphicsLayerMeshNormalsProps): ReactElement {
 
 	const geometry = useCallback<PixiCustomMeshGeometryCreator<PIXI.Geometry>>((existingGeometry) => {
@@ -100,6 +104,8 @@ export function GraphicsLayerMeshNormals({
 	}, [triangles, uvs, vertices, vertexRotations]);
 
 	const shader = useMemo((): PixiCustomMeshShaderCreator<PIXI.Shader> => {
+		const program = debugConfig?.displayNormalMap ? NORMAL_MESH_DEBUG_NORMALS_GL_PROGRAM : NORMAL_MESH_GL_PROGRAM;
+
 		const normalMap = normalMapTexture === PIXI.Texture.WHITE ? DEFAULT_NORMAL_TEXTURE : normalMapTexture;
 		const ambientStrength = 0.1;
 		const { specularStrength, roughness } = normalMapData;
@@ -107,43 +113,62 @@ export function GraphicsLayerMeshNormals({
 		const colorAlpha = PIXI.Color.shared.setValue(color).toBgrNumber() + (((255) | 0) << 24);
 
 		return (existingShader) => {
-			if (existingShader) {
+			if (existingShader && existingShader.glProgram === program) {
 				/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 				existingShader.resources.uTexture = texture.source;
 				existingShader.resources.uSampler = texture.source.style;
 				existingShader.resources.uNormalMap = normalMap.source;
 				existingShader.resources.uNormalSampler = normalMap.source.style;
 				existingShader.resources.textureUniforms.uniforms.uTextureMatrix = texture.textureMatrix.mapCoord;
-				PIXI.color32BitToUniform(colorAlpha, existingShader.resources.textureUniforms.uniforms.uBaseColor as Float32Array, 0);
-				existingShader.resources.pbrUniforms.uniforms.uAmbientStrength = ambientStrength;
-				existingShader.resources.pbrUniforms.uniforms.uSpecularStrength = specularStrength;
-				existingShader.resources.pbrUniforms.uniforms.uRoughness = roughness;
+				if (!debugConfig?.displayNormalMap) {
+					PIXI.color32BitToUniform(colorAlpha, existingShader.resources.textureUniforms.uniforms.uBaseColor as Float32Array, 0);
+					existingShader.resources.pbrUniforms.uniforms.uAmbientStrength = ambientStrength;
+					existingShader.resources.pbrUniforms.uniforms.uSpecularStrength = specularStrength;
+					existingShader.resources.pbrUniforms.uniforms.uRoughness = roughness;
+				}
 				/* eslint-enable @typescript-eslint/no-unsafe-member-access */
 				return existingShader;
 			} else {
-				const uBaseColor = new Float32Array([1, 1, 1, 1]);
-				PIXI.color32BitToUniform(colorAlpha, uBaseColor, 0);
-				return new PIXI.Shader({
-					glProgram: NORMAL_MESH_GL_PROGRAM,
-					resources: {
-						uTexture: texture.source,
-						uSampler: texture.source.style,
-						uNormalMap: normalMap.source,
-						uNormalSampler: normalMap.source.style,
-						textureUniforms: new PIXI.UniformGroup({
-							uTextureMatrix: { type: 'mat3x3<f32>', value: texture.textureMatrix.mapCoord },
-							uBaseColor: { value: uBaseColor, type: 'vec4<f32>' },
-						}),
-						pbrUniforms: new PIXI.UniformGroup({
-							uAmbientStrength: { type: 'f32', value: ambientStrength },
-							uSpecularStrength: { type: 'f32', value: specularStrength },
-							uRoughness: { type: 'f32', value: roughness },
-						}),
-					},
-				});
+				if (debugConfig?.displayNormalMap) {
+					const uBaseColor = new Float32Array([1, 1, 1, 1]);
+					PIXI.color32BitToUniform(colorAlpha, uBaseColor, 0);
+					return new PIXI.Shader({
+						glProgram: program,
+						resources: {
+							uTexture: texture.source,
+							uSampler: texture.source.style,
+							uNormalMap: normalMap.source,
+							uNormalSampler: normalMap.source.style,
+							textureUniforms: new PIXI.UniformGroup({
+								uTextureMatrix: { type: 'mat3x3<f32>', value: texture.textureMatrix.mapCoord },
+							}),
+						},
+					});
+				} else {
+					const uBaseColor = new Float32Array([1, 1, 1, 1]);
+					PIXI.color32BitToUniform(colorAlpha, uBaseColor, 0);
+					return new PIXI.Shader({
+						glProgram: program,
+						resources: {
+							uTexture: texture.source,
+							uSampler: texture.source.style,
+							uNormalMap: normalMap.source,
+							uNormalSampler: normalMap.source.style,
+							textureUniforms: new PIXI.UniformGroup({
+								uTextureMatrix: { type: 'mat3x3<f32>', value: texture.textureMatrix.mapCoord },
+								uBaseColor: { value: uBaseColor, type: 'vec4<f32>' },
+							}),
+							pbrUniforms: new PIXI.UniformGroup({
+								uAmbientStrength: { type: 'f32', value: ambientStrength },
+								uSpecularStrength: { type: 'f32', value: specularStrength },
+								uRoughness: { type: 'f32', value: roughness },
+							}),
+						},
+					});
+				}
 			}
 		};
-	}, [texture, normalMapTexture, normalMapData, color]);
+	}, [texture, normalMapTexture, normalMapData, color, debugConfig]);
 
 	return (
 		<PixiCustomMesh

--- a/pandora-client-web/src/graphics/layers/graphicsLayerMeshNormals.tsx
+++ b/pandora-client-web/src/graphics/layers/graphicsLayerMeshNormals.tsx
@@ -1,0 +1,153 @@
+import type { LayerNormalData } from 'pandora-common';
+import * as PIXI from 'pixi.js';
+import { ReactElement, useCallback, useMemo } from 'react';
+import { PixiCustomMesh, PixiCustomMeshGeometryCreator, type PixiCustomMeshShaderCreator } from '../baseComponents/customMesh.tsx';
+import { DEFAULT_NORMAL_TEXTURE, NORMAL_MESH_GL_PROGRAM } from './graphicsLayerMeshNormalsShader.ts';
+
+export interface GraphicsLayerMeshNormalsProps {
+	vertices: Float32Array;
+	vertexRotations: Float32Array;
+	uvs: Float32Array;
+	triangles: Uint32Array;
+	texture: PIXI.Texture;
+	normalMapTexture: PIXI.Texture;
+	normalMapData: LayerNormalData;
+	state: PIXI.State;
+	color: number;
+	alpha: number;
+}
+
+export function GraphicsLayerMeshNormals({
+	vertices,
+	vertexRotations,
+	uvs,
+	triangles,
+	texture,
+	normalMapTexture,
+	normalMapData,
+	state,
+	color,
+	alpha,
+}: GraphicsLayerMeshNormalsProps): ReactElement {
+
+	const geometry = useCallback<PixiCustomMeshGeometryCreator<PIXI.Geometry>>((existingGeometry) => {
+		if (existingGeometry) {
+			existingGeometry.getBuffer('aPosition').data = vertices;
+			existingGeometry.getBuffer('aUV').data = uvs;
+			existingGeometry.getBuffer('aRotation').data = vertexRotations;
+			existingGeometry.indexBuffer.data = triangles;
+			return existingGeometry;
+		} else {
+			const positionBuffer = new PIXI.Buffer({
+				data: vertices,
+				label: 'attribute-mesh-positions',
+				shrinkToFit: true,
+				// eslint-disable-next-line no-bitwise
+				usage: PIXI.BufferUsage.VERTEX | PIXI.BufferUsage.COPY_DST,
+			});
+
+			const uvBuffer = new PIXI.Buffer({
+				data: uvs,
+				label: 'attribute-mesh-uvs',
+				shrinkToFit: true,
+				// eslint-disable-next-line no-bitwise
+				usage: PIXI.BufferUsage.VERTEX | PIXI.BufferUsage.COPY_DST,
+			});
+
+			const vertexRotationBuffer = new PIXI.Buffer({
+				data: vertexRotations,
+				label: 'attribute-mesh-vertex-rotations',
+				shrinkToFit: true,
+				// eslint-disable-next-line no-bitwise
+				usage: PIXI.BufferUsage.VERTEX | PIXI.BufferUsage.COPY_DST,
+			});
+
+			const indexBuffer = new PIXI.Buffer({
+				data: triangles,
+				label: 'index-mesh-buffer',
+				shrinkToFit: true,
+				// eslint-disable-next-line no-bitwise
+				usage: PIXI.BufferUsage.INDEX | PIXI.BufferUsage.COPY_DST,
+			});
+
+			const geometryInstance = new PIXI.Geometry(({
+				attributes: {
+					aPosition: {
+						buffer: positionBuffer,
+						format: 'float32x2',
+						stride: 2 * 4,
+						offset: 0,
+					},
+					aUV: {
+						buffer: uvBuffer,
+						format: 'float32x2',
+						stride: 2 * 4,
+						offset: 0,
+					},
+					aRotation: {
+						buffer: vertexRotationBuffer,
+						format: 'float32',
+						stride: 1 * 4,
+						offset: 0,
+					},
+				},
+				indexBuffer,
+				topology: 'triangle-list',
+			}));
+
+			return geometryInstance;
+		}
+	}, [triangles, uvs, vertices, vertexRotations]);
+
+	const shader = useMemo((): PixiCustomMeshShaderCreator<PIXI.Shader> => {
+		const normalMap = normalMapTexture === PIXI.Texture.WHITE ? DEFAULT_NORMAL_TEXTURE : normalMapTexture;
+		const ambientStrength = 0.1;
+		const { specularStrength, roughness } = normalMapData;
+
+		return (existingShader) => {
+			if (existingShader) {
+				existingShader.resources.uTexture = texture.source;
+				existingShader.resources.uSampler = texture.source.style;
+				existingShader.resources.uNormalMap = normalMap.source;
+				existingShader.resources.uNormalSampler = normalMap.source.style;
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+				existingShader.resources.textureUniforms.uniforms.uTextureMatrix = texture.textureMatrix.mapCoord;
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+				existingShader.resources.pbrUniforms.uniforms.uAmbientStrength = ambientStrength;
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+				existingShader.resources.pbrUniforms.uniforms.uSpecularStrength = specularStrength;
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+				existingShader.resources.pbrUniforms.uniforms.uRoughness = roughness;
+				return existingShader;
+			} else {
+				return new PIXI.Shader({
+					glProgram: NORMAL_MESH_GL_PROGRAM,
+					resources: {
+						uTexture: texture.source,
+						uSampler: texture.source.style,
+						uNormalMap: normalMap.source,
+						uNormalSampler: normalMap.source.style,
+						textureUniforms: new PIXI.UniformGroup({
+							uTextureMatrix: { type: 'mat3x3<f32>', value: texture.textureMatrix.mapCoord },
+						}),
+						pbrUniforms: new PIXI.UniformGroup({
+							uAmbientStrength: { type: 'f32', value: ambientStrength },
+							uSpecularStrength: { type: 'f32', value: specularStrength },
+							uRoughness: { type: 'f32', value: roughness },
+						}),
+					},
+				});
+			}
+		};
+	}, [texture, normalMapTexture, normalMapData]);
+
+	return (
+		<PixiCustomMesh
+			geometry={ geometry }
+			shader={ shader }
+			state={ state }
+			tint={ color }
+			alpha={ alpha }
+		/>
+	);
+}

--- a/pandora-client-web/src/graphics/layers/graphicsLayerMeshNormalsShader.ts
+++ b/pandora-client-web/src/graphics/layers/graphicsLayerMeshNormalsShader.ts
@@ -74,6 +74,7 @@ uniform sampler2D uNormalMap;
 
 vec3 ambientColour = vec3(1., 1., 1.);
 vec3 lightColour = vec3(1., 1., 1.);
+uniform vec4 uBaseColor;
 
 vec3 lightDir = normalize(vec3(2.7, -2.5, 3.7));
 
@@ -127,13 +128,9 @@ if (lambertian > 0.) {
 	}
 }
 
-outColor *= vColor;
+outColor *= uBaseColor;
 outColor.xyz *= (ambient + diffuse);
 outColor.xyz += specular * outColor.w;
-		`,
-				// Skip Pixi's final tint step (with vColor) in here. We do it manually in a way it ignores specular light
-				end: `
-finalColor = outColor;
 		`,
 			},
 		},

--- a/pandora-client-web/src/graphics/layers/graphicsLayerMeshNormalsShader.ts
+++ b/pandora-client-web/src/graphics/layers/graphicsLayerMeshNormalsShader.ts
@@ -1,0 +1,142 @@
+import { noop } from 'lodash-es';
+import * as PIXI from 'pixi.js';
+
+export const DEFAULT_NORMAL_TEXTURE = new PIXI.Texture({
+	source: new PIXI.BufferImageSource({
+		resource: new Uint8Array([127, 127, 255, 255]),
+		width: 1,
+		height: 1,
+		alphaMode: 'premultiply-alpha-on-upload',
+		label: 'DEFAULT_NORMAL',
+	}),
+	label: 'DEFAULT_NORMAL',
+});
+DEFAULT_NORMAL_TEXTURE.destroy = noop;
+
+/* TODO: Helpers
+
+// Normals from height
+float getHeight(vec2 pos) {
+	return 1. - texture(uDepthTexture, pos).x;
+}
+
+float h = 150.;
+float l = h * getHeight(pos - uPix.xz);
+float r = h * getHeight(pos + uPix.xz);
+float d = h * getHeight(pos - uPix.zy);
+float u = h * getHeight(pos + uPix.zy);
+return normalize(vec3(l-r, u-d, 1.));
+
+// Display normals
+outColor.xyz = packNormal(getNormal(vUV)) * outColor.w;
+
+*/
+
+export const NORMAL_MESH_GL_PROGRAM = PIXI.compileHighShaderGlProgram({
+	name: 'mesh',
+	bits: [
+		PIXI.localUniformBitGl,
+		{
+			name: 'texture-bit',
+			vertex: {
+				header: /* glsl */`
+uniform mat3 uTextureMatrix;
+in float aRotation; // Rotation in radians per vertex
+out mat3 vTBN;
+		`,
+				main: /* glsl */`
+uv = (uTextureMatrix * vec3(uv, 1.0)).xy;
+
+float cosA = cos(aRotation);
+float sinA = sin(aRotation);
+mat2 rotateMatrix = mat2(
+	vec2(cosA, sinA),
+	vec2(-sinA, cosA)
+);
+
+vec3 T = vec3(1., 0., 0.);
+vec3 B = vec3(0., 1., 0.);
+vec3 N = vec3(0., 0., 1.);
+
+mat2 model2D = mat2(worldTransformMatrix * modelMatrix) * rotateMatrix;
+T.xy = normalize(model2D * T.xy);
+B.xy = normalize(model2D * B.xy);
+
+vTBN = mat3(T, B, N);
+		`,
+			},
+			fragment: {
+				header: /* glsl */`
+#version 300 es
+
+uniform sampler2D uTexture;
+uniform sampler2D uNormalMap;
+
+vec3 ambientColour = vec3(1., 1., 1.);
+vec3 lightColour = vec3(1., 1., 1.);
+
+vec3 lightDir = normalize(vec3(2.7, -2.5, 3.7));
+
+uniform float uAmbientStrength;
+uniform float uSpecularStrength;
+uniform float uRoughness;
+
+in mat3 vTBN;
+
+vec3 unpackNormal(vec3 color) {
+	vec3 normal = color * 2. - 1.;
+	// We are working in Pixi's coordinate system - X is right, Y is down, Z toward camera
+	normal.y = -normal.y;
+	return normal;
+}
+
+vec3 packNormal(vec3 normal) {
+	normal.y = -normal.y;
+	return (normal + 1.) / 2.;
+}
+
+vec3 getNormal(vec2 pos) {
+	vec3 normal = unpackNormal(texture(uNormalMap, pos).rgb);
+	normal = normalize(vTBN * normal);
+	return normal;
+}
+		`,
+				main: /* glsl */`
+vec3 normal = getNormal(vUV);
+outColor = texture(uTexture, vUV);
+
+vec3 ambient = clamp(ambientColour * uAmbientStrength, 0., 1.);
+
+float lambertian = clamp(dot(lightDir, normal), 0., 1.);
+vec3 diffuse = (0.4 + 0.6 * lambertian) * lightColour;
+
+vec3 specular = vec3(0.);
+if (lambertian > 0.) {
+	vec3 viewDir = normalize(vec3(0., 0., 1.));
+	float shininess = pow(2., (1.0 - uRoughness) * 4.);
+
+	vec3 reflection = 2.0 * dot(normal, lightDir) * normal - lightDir;
+	float specularStrength = clamp(dot(reflection, viewDir), 0.0, 1.0);
+	specularStrength = pow(specularStrength, shininess);
+	specularStrength *= uSpecularStrength;
+
+	// The specular color is from the light source, not the object
+	if (specularStrength > 0.) {
+		specular = lightColour * specularStrength;
+		diffuse *= 1. - specularStrength;
+	}
+}
+
+outColor *= vColor;
+outColor.xyz *= (ambient + diffuse);
+outColor.xyz += specular * outColor.w;
+		`,
+				// Skip Pixi's final tint step (with vColor) in here. We do it manually in a way it ignores specular light
+				end: `
+finalColor = outColor;
+		`,
+			},
+		},
+		PIXI.roundPixelsBitGl,
+	],
+});

--- a/pandora-client-web/src/graphics/room/roomCharacter.tsx
+++ b/pandora-client-web/src/graphics/room/roomCharacter.tsx
@@ -415,6 +415,7 @@ function RoomCharacterDisplay({
 				angle={ rotationAngle }
 				useBlinking
 				movementTransitionDuration={ movementTransitionDuration }
+				debugConfig={ debugConfig }
 			>
 				{
 					!debugConfig?.characterDebugOverlay ? null : (

--- a/pandora-client-web/src/index.scss
+++ b/pandora-client-web/src/index.scss
@@ -33,8 +33,11 @@ div.main-container {
 	position: relative;
 	background: common.$theme-normal-background;
 	color: common.$theme-normal-text;
-	flex: 1;
+	height: 100%;
+	width: 100%;
+	contain: strict;
 	overflow: hidden;
+	overflow: clip;
 
 	> .Toastify {
 		position: relative;

--- a/pandora-client-web/src/styles/globalUtils.scss
+++ b/pandora-client-web/src/styles/globalUtils.scss
@@ -193,6 +193,10 @@
 	contain: size;
 }
 
+.contain-inline-size {
+	contain: inline-size;
+}
+
 .pointer-events-disable {
 	pointer-events: none;
 }

--- a/pandora-client-web/src/styles/globalUtils.scss
+++ b/pandora-client-web/src/styles/globalUtils.scss
@@ -211,6 +211,14 @@
 	p {
 		margin: 0.25em 0;
 	}
+
+	&.inline {
+		display: inline-flex;
+	}
+
+	&.slim {
+		padding: 0.1em 0.3em;
+	}
 }
 
 .warning-box {

--- a/pandora-client-web/src/ui/screens/room/roomDebug.tsx
+++ b/pandora-client-web/src/ui/screens/room/roomDebug.tsx
@@ -19,6 +19,7 @@ const ChatroomDebugConfigSchema = z.object({
 	roomScalingHelperData: RoomBackgroundCalibrationDataSchema.omit({ imageSize: true }).nullable(),
 	characterDebugOverlay: z.boolean().catch(false),
 	deviceDebugOverlay: z.boolean().catch(false),
+	displayNormalMap: z.boolean().catch(false),
 });
 
 const DEFAULT_DEBUG_CONFIG: z.infer<typeof ChatroomDebugConfigSchema> = {
@@ -27,6 +28,7 @@ const DEFAULT_DEBUG_CONFIG: z.infer<typeof ChatroomDebugConfigSchema> = {
 	roomScalingHelperData: null,
 	characterDebugOverlay: false,
 	deviceDebugOverlay: false,
+	displayNormalMap: false,
 };
 
 export type ChatroomDebugConfig = z.infer<typeof ChatroomDebugConfigSchema> | undefined;
@@ -325,6 +327,18 @@ export function ChatroomDebugConfigView(): ReactElement {
 					onChange={ (newValue) => {
 						applyChange({
 							deviceDebugOverlay: newValue,
+						});
+					} }
+				/>
+			</div>
+			<div>
+				<label htmlFor='chatroom-debug-normal-map-override'>Display normal map for assets with it</label>
+				<Checkbox
+					id='chatroom-debug-normal-map-override'
+					checked={ chatroomDebugConfig.displayNormalMap }
+					onChange={ (newValue) => {
+						applyChange({
+							displayNormalMap: newValue,
 						});
 					} }
 				/>

--- a/pandora-common/src/assets/graphics/layers/common.ts
+++ b/pandora-common/src/assets/graphics/layers/common.ts
@@ -3,7 +3,7 @@ import { BoneNameSchema, ConditionSchema } from '../conditions.ts';
 
 export const LayerImageOverrideSchema = z.object({
 	image: z.string(),
-	depthComponent: z.string().optional(),
+	normalMapImage: z.string().optional(),
 	/**
 	 * Pose to use for calculating UV coordinates of vertices.
 	 *
@@ -100,7 +100,7 @@ export enum LayerSide {
 
 export const LayerImageSettingSchema = z.object({
 	image: z.string(),
-	depthComponent: z.string().optional(),
+	normalMapImage: z.string().optional(),
 	/**
 	 * Pose to use for calculating UV coordinates of vertices.
 	 *

--- a/pandora-common/src/assets/graphics/layers/common.ts
+++ b/pandora-common/src/assets/graphics/layers/common.ts
@@ -121,3 +121,9 @@ export function MirrorPriority(priority: LayerPriority): LayerPriority {
 	const mirrorPriority = PRIORITY_ORDER_MIRROR[priority];
 	return mirrorPriority != null ? mirrorPriority : priority;
 }
+
+export const LayerNormalDataSchema = z.object({
+	specularStrength: z.number().nonnegative(),
+	roughness: z.number().nonnegative(),
+});
+export type LayerNormalData = z.infer<typeof LayerNormalDataSchema>;

--- a/pandora-common/src/assets/graphics/layers/common.ts
+++ b/pandora-common/src/assets/graphics/layers/common.ts
@@ -3,6 +3,7 @@ import { BoneNameSchema, ConditionSchema } from '../conditions.ts';
 
 export const LayerImageOverrideSchema = z.object({
 	image: z.string(),
+	depthComponent: z.string().optional(),
 	/**
 	 * Pose to use for calculating UV coordinates of vertices.
 	 *
@@ -99,6 +100,7 @@ export enum LayerSide {
 
 export const LayerImageSettingSchema = z.object({
 	image: z.string(),
+	depthComponent: z.string().optional(),
 	/**
 	 * Pose to use for calculating UV coordinates of vertices.
 	 *

--- a/pandora-common/src/assets/graphics/layers/mesh.ts
+++ b/pandora-common/src/assets/graphics/layers/mesh.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { ZodBase64Regex } from '../../../validation.ts';
 import { RectangleSchema } from '../common.ts';
 import { BoneNameSchema } from '../conditions.ts';
-import { LayerImageSettingSchema, LayerPrioritySchema, LayerStateOverridesSchema } from './common.ts';
+import { LayerImageSettingSchema, LayerNormalDataSchema, LayerPrioritySchema, LayerStateOverridesSchema } from './common.ts';
 
 export const GraphicsMeshLayerSchema = RectangleSchema.extend({
 	type: z.literal('mesh'),
@@ -14,6 +14,7 @@ export const GraphicsMeshLayerSchema = RectangleSchema.extend({
 	previewOverrides: LayerStateOverridesSchema.optional(),
 	colorizationKey: z.string().optional(),
 
+	normalMap: LayerNormalDataSchema.optional(),
 	image: LayerImageSettingSchema,
 	scaling: z.object({
 		scaleBone: BoneNameSchema,

--- a/pandora-common/src/assets/graphics/mirroring.ts
+++ b/pandora-common/src/assets/graphics/mirroring.ts
@@ -92,8 +92,8 @@ export function MirrorTransform(transform: Immutable<TransformDefinition>): Tran
 	}
 }
 
-export function MirrorImageOverride({ image, condition }: Immutable<LayerImageOverride>): LayerImageOverride {
-	return { image, condition: MirrorCondition(condition) };
+export function MirrorImageOverride({ condition, ...rest }: Immutable<LayerImageOverride>): LayerImageOverride {
+	return { ...rest, condition: MirrorCondition(condition) };
 }
 
 export function MirrorLayerImageSetting(setting: Immutable<LayerImageSetting>): LayerImageSetting {

--- a/pandora-common/src/assets/graphicsBuilding/graphicsBuildAutoMeshLayer.ts
+++ b/pandora-common/src/assets/graphicsBuilding/graphicsBuildAutoMeshLayer.ts
@@ -170,7 +170,7 @@ export async function LoadAssetAutoMeshLayer(
 
 				imageVariants.push({
 					image,
-					depthComponent: (layer.withDepth && image) ? `Depth${image}` : undefined,
+					normalMapImage: (layer.withNormalMap && image) ? `Normal${image}` : undefined,
 					condition: [combinationCondition],
 				});
 			}

--- a/pandora-common/src/assets/graphicsBuilding/graphicsBuildAutoMeshLayer.ts
+++ b/pandora-common/src/assets/graphicsBuilding/graphicsBuildAutoMeshLayer.ts
@@ -170,7 +170,7 @@ export async function LoadAssetAutoMeshLayer(
 
 				imageVariants.push({
 					image,
-					normalMapImage: (layer.withNormalMap && image) ? `Normal${image}` : undefined,
+					normalMapImage: (layer.normalMap != null && image) ? `normal_map/${image}` : undefined,
 					condition: [combinationCondition],
 				});
 			}
@@ -188,6 +188,7 @@ export async function LoadAssetAutoMeshLayer(
 				previewOverrides: graphicalLayer.previewOverrides,
 				mirror: templatePart.mirror ?? LayerMirror.NONE,
 				colorizationKey: graphicalLayer.colorizationKey,
+				normalMap: layer.normalMap,
 				image: {
 					image: '',
 					overrides: imageVariants,

--- a/pandora-common/src/assets/graphicsBuilding/graphicsBuildAutoMeshLayer.ts
+++ b/pandora-common/src/assets/graphicsBuilding/graphicsBuildAutoMeshLayer.ts
@@ -170,6 +170,7 @@ export async function LoadAssetAutoMeshLayer(
 
 				imageVariants.push({
 					image,
+					depthComponent: (layer.withDepth && image) ? `Depth${image}` : undefined,
 					condition: [combinationCondition],
 				});
 			}

--- a/pandora-common/src/assets/graphicsBuilding/graphicsBuildImageLayer.ts
+++ b/pandora-common/src/assets/graphicsBuilding/graphicsBuildImageLayer.ts
@@ -253,6 +253,7 @@ async function LoadAssetImageLayerSingle(
 		Assert(result.type === 'mesh');
 		result.previewOverrides = layer.previewOverrides;
 		result.colorizationKey = layer.colorizationKey;
+		result.normalMap = layer.normalMap;
 	}
 
 	// Adjust layer size of we trimmed it down

--- a/pandora-common/src/assets/graphicsBuilding/graphicsBuildImageResource.ts
+++ b/pandora-common/src/assets/graphicsBuilding/graphicsBuildImageResource.ts
@@ -63,14 +63,14 @@ export function LoadLayerImageSetting(setting: Immutable<LayerImageSetting>, con
 	const overrides: LayerImageOverride[] = setting.overrides
 		.map((override): LayerImageOverride => ({
 			image: override.image && LoadLayerImage(override.image, context, imageTrimArea),
-			depthComponent: override.depthComponent && LoadLayerImage(override.depthComponent, context, imageTrimArea),
+			normalMapImage: override.normalMapImage && LoadLayerImage(override.normalMapImage, context, imageTrimArea),
 			uvPose: override.uvPose,
 			condition: CloneDeepMutable(override.condition),
 		}));
 	return {
 		...setting,
 		image: setting.image && LoadLayerImage(setting.image, context, imageTrimArea),
-		depthComponent: setting.depthComponent && LoadLayerImage(setting.depthComponent, context, imageTrimArea),
+		normalMapImage: setting.normalMapImage && LoadLayerImage(setting.normalMapImage, context, imageTrimArea),
 		overrides,
 	};
 }

--- a/pandora-common/src/assets/graphicsBuilding/graphicsBuildImageResource.ts
+++ b/pandora-common/src/assets/graphicsBuilding/graphicsBuildImageResource.ts
@@ -63,12 +63,14 @@ export function LoadLayerImageSetting(setting: Immutable<LayerImageSetting>, con
 	const overrides: LayerImageOverride[] = setting.overrides
 		.map((override): LayerImageOverride => ({
 			image: override.image && LoadLayerImage(override.image, context, imageTrimArea),
+			depthComponent: override.depthComponent && LoadLayerImage(override.depthComponent, context, imageTrimArea),
 			uvPose: override.uvPose,
 			condition: CloneDeepMutable(override.condition),
 		}));
 	return {
 		...setting,
 		image: setting.image && LoadLayerImage(setting.image, context, imageTrimArea),
+		depthComponent: setting.depthComponent && LoadLayerImage(setting.depthComponent, context, imageTrimArea),
 		overrides,
 	};
 }

--- a/pandora-common/src/assets/graphicsSource/layers/autoMesh.ts
+++ b/pandora-common/src/assets/graphicsSource/layers/autoMesh.ts
@@ -61,6 +61,7 @@ export const GraphicsSourceAutoMeshLayerSchema = RectangleSchema.extend({
 	graphicalLayers: GraphicsSourceAutoMeshGraphicalLayerSchema.array(),
 	variables: GraphicsSourceAutoMeshLayerVariableSchema.array(),
 
+	withDepth: z.boolean().optional(),
 	imageMap: z.record(z.string(), z.string().array()),
 }).strict();
 export type GraphicsSourceAutoMeshLayer = z.infer<typeof GraphicsSourceAutoMeshLayerSchema>;

--- a/pandora-common/src/assets/graphicsSource/layers/autoMesh.ts
+++ b/pandora-common/src/assets/graphicsSource/layers/autoMesh.ts
@@ -61,7 +61,7 @@ export const GraphicsSourceAutoMeshLayerSchema = RectangleSchema.extend({
 	graphicalLayers: GraphicsSourceAutoMeshGraphicalLayerSchema.array(),
 	variables: GraphicsSourceAutoMeshLayerVariableSchema.array(),
 
-	withDepth: z.boolean().optional(),
+	withNormalMap: z.boolean().optional(),
 	imageMap: z.record(z.string(), z.string().array()),
 }).strict();
 export type GraphicsSourceAutoMeshLayer = z.infer<typeof GraphicsSourceAutoMeshLayerSchema>;

--- a/pandora-common/src/assets/graphicsSource/layers/autoMesh.ts
+++ b/pandora-common/src/assets/graphicsSource/layers/autoMesh.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { RectangleSchema } from '../../graphics/common.ts';
 import { AttributeNameSchema } from '../../graphics/conditions.ts';
-import { LayerImageOverrideSchema, LayerMirrorSchema, LayerPrioritySchema, LayerStateOverridesSchema } from '../../graphics/layers/common.ts';
+import { LayerImageOverrideSchema, LayerMirrorSchema, LayerNormalDataSchema, LayerPrioritySchema, LayerStateOverridesSchema } from '../../graphics/layers/common.ts';
 
 export const GraphicsSourceAutoMeshTemplateSchema = z.object({
 	name: z.string(),
@@ -61,7 +61,7 @@ export const GraphicsSourceAutoMeshLayerSchema = RectangleSchema.extend({
 	graphicalLayers: GraphicsSourceAutoMeshGraphicalLayerSchema.array(),
 	variables: GraphicsSourceAutoMeshLayerVariableSchema.array(),
 
-	withNormalMap: z.boolean().optional(),
+	normalMap: LayerNormalDataSchema.optional(),
 	imageMap: z.record(z.string(), z.string().array()),
 }).strict();
 export type GraphicsSourceAutoMeshLayer = z.infer<typeof GraphicsSourceAutoMeshLayerSchema>;

--- a/pandora-common/src/assets/graphicsSource/layers/mesh.ts
+++ b/pandora-common/src/assets/graphicsSource/layers/mesh.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { RectangleSchema } from '../../graphics/common.ts';
 import { BoneNameSchema } from '../../graphics/conditions.ts';
-import { LayerImageSettingSchema, LayerMirrorSchema, LayerPrioritySchema, LayerStateOverridesSchema } from '../../graphics/layers/common.ts';
+import { LayerImageSettingSchema, LayerMirrorSchema, LayerNormalDataSchema, LayerPrioritySchema, LayerStateOverridesSchema } from '../../graphics/layers/common.ts';
 
 export const GraphicsSourceMeshLayerSchema = RectangleSchema.extend({
 	type: z.literal('mesh'),
@@ -14,6 +14,7 @@ export const GraphicsSourceMeshLayerSchema = RectangleSchema.extend({
 	mirror: LayerMirrorSchema,
 	colorizationKey: z.string().optional(),
 
+	normalMap: LayerNormalDataSchema.optional(),
 	image: LayerImageSettingSchema,
 	scaling: z.object({
 		scaleBone: BoneNameSchema,

--- a/pandora-common/src/assets/modules/typed.ts
+++ b/pandora-common/src/assets/modules/typed.ts
@@ -24,14 +24,6 @@ export interface IModuleTypedOption<TProperties> {
 	/** If this variant should be autoselected as default; otherwise first one is used */
 	default?: true;
 
-	/**
-	 * Message to show when switching to this variant.
-	 * Can be either:
-	 * - string, which is shown always
-	 * - Object which maps previous setting to message to switch from it (with `_` usable as default)
-	 */
-	switchMessage?: string | Partial<Record<string | '_', string>>;
-
 	/** Variant will store the time it was selected */
 	storeTime?: true;
 	/** Variant will store the the character that selected it */
@@ -224,25 +216,10 @@ export class ItemModuleTyped<out TProperties = unknown, out TStaticData = unknow
 				false;
 	}
 
-	public doAction({ messageHandler, processingContext }: AppearanceModuleActionContext, action: ItemModuleTypedAction): ItemModuleTyped<TProperties, TStaticData> | null {
+	public doAction({ processingContext }: AppearanceModuleActionContext, action: ItemModuleTypedAction): ItemModuleTyped<TProperties, TStaticData> | null {
 		const newVariant = this.config.variants.find((v) => v.id === action.setVariant);
 		if (!newVariant)
 			return null;
-
-		// Get chat message about switching to this variant
-		const switchMessage = newVariant.switchMessage == null ? undefined :
-			// If switch message is a string, use it
-			typeof newVariant.switchMessage === 'string' ? newVariant.switchMessage :
-				// Otherwise try to get message for previous variant, falling back to default
-				(newVariant.switchMessage[this.activeVariant.id] ?? newVariant.switchMessage._);
-
-		// If we have non-empty switch message, queue it
-		if (switchMessage) {
-			messageHandler({
-				id: 'custom',
-				customText: switchMessage,
-			});
-		}
 
 		return this.withProps({
 			activeVariant: newVariant,


### PR DESCRIPTION
<!--
Thank you for your pull request!

These comments will guide you through creating a pull request and filling in all that is required. You don't need to remove the comments when you are done.
You can view CONTRIBUTING.md for a detailed description of the pull request process.

Title for the pull request should be in the following form: [TYPE] Short name that is understandable by itself
TYPE should be one of the following: FEATURE, ADD, CHANGE, REMOVE, FIX, REFACTOR, DEV, CHORE
The rest of the title should describe what the PR changes mainly, doesn't need to describe the details of the change (someone looking at the list of PRs should be able to tell which part of Pandora it touches, not necessarily how).
Use past tense.
-->

## References

<!--
Add references to issues or other pull requests here, for example:
fixes #42
resolves #69
ref #123   (use to reference related things within Pandora's repositories, without special meaning)
xref #666   (use to reference _external_ resources; use full https URL)
-->

_None_

## About The Pull Request

<!--
Describe *what* you are trying to do.
This sets expectation for the reviewer, making it easier to get into reviewing it.

[optional]
If the change is more complex, then try to explain why and how is it accomplished.
This is, however, much less important than the "what", as that is more easily seen from code than the aim is, usually.
-->

This PR experiments with new way to dynamically shade and highlight assets that have normal maps (which are easy to get for assets generated from 3D models). It also includes a few fixes and Editor improvements.

## Changelog

```md
Platform changes:
- Added a new, experimental method of drawing assets that generates shading and highlights dynamically based on character's angle and pose. All assets added with this update are based on this new drawing. Note, that we do expect more improvements to this in the future.
- Added support for antialiasing and enabled it by default.
  - Note: Antialiasing conflicts with our current implementation of alphamasks, so they cannot be used at the same time
  - Note: Our antialiasing support relies fully on your browser and as this is an optional extension to drawing, it might not do anything depending on your browser and OS.

Fixes:
- Fixed that [Tab] would focus invisible elements, such as status selectors or notification menu while they are closed.
- Removed chat messages on module change altogether, as only two assets were using those and both of them were broken in some cases. We have plans for a more generic replacement mechanic in the future.

Asset creation changes:
- Asset Editor now supports specifying normal maps and associated metadata for automatic image layer. For manual image layer this isn't yet supported.
- Asset Editor Automesh Layer has a new feature to auto-fill images, if they are in the format `graphicslayer_variable1_variable2.png` to cut down on the most annoying part of adding layers.
```

## Checklist

<!-- Checklist for you to make sure you didn't miss something -->
- [x] The change has been tested locally
- [x] Added documentation to the new code and updated existing documentation where needed
- [x] I understand this patch is submitted under the [Pandora's Contributor Agreement](https://github.com/Project-Pandora-Game/pandora/blob/master/contributor-licence-agreement.md)
