### PR TITLE
[FEATURE] Display space names in contact list

### DIFF
--- a/pandora-client-web/src/common/useSpaceList.ts
+++ b/pandora-client-web/src/common/useSpaceList.ts
@@ -1,0 +1,22 @@
+import { noop } from 'lodash-es';
+import { EMPTY, type SpaceListInfo } from 'pandora-common';
+import { useState, useCallback } from 'react';
+import { useDirectoryConnector, useDirectoryChangeListener } from '../components/gameContext/directoryConnectorContextProvider.tsx';
+
+export function useSpacesList(): SpaceListInfo[] | undefined {
+	const [data, setData] = useState<SpaceListInfo[]>();
+	const directoryConnector = useDirectoryConnector();
+
+	const fetchData = useCallback(async () => {
+		const result = await directoryConnector.awaitResponse('listSpaces', EMPTY);
+		if (result && result.spaces) {
+			setData(result.spaces);
+		}
+	}, [directoryConnector]);
+
+	useDirectoryChangeListener('spaceList', () => {
+		fetchData().catch(noop);
+	});
+
+	return data;
+}

--- a/pandora-client-web/src/components/accountContacts/accountContacts.tsx
+++ b/pandora-client-web/src/components/accountContacts/accountContacts.tsx
@@ -22,6 +22,7 @@ import { DirectMessages } from '../directMessages/directMessages.tsx';
 import { useDirectoryConnector } from '../gameContext/directoryConnectorContextProvider.tsx';
 import { AccountContactChangeHandleResult, useAccountContacts, useFriendStatus } from './accountContactContext.ts';
 import './accountContacts.scss';
+import { useSpacesList } from '../../common/useSpaceList.ts';
 
 export function AccountContacts() {
 	const navigate = useNavigatePandora();
@@ -272,6 +273,7 @@ function FriendRow({
 	const confirm = useConfirmDialog();
 	const navigate = useNavigatePandora();
 	const location = useLocation();
+	const spaceInfoMap = new Map((useSpacesList() ?? []).map((s) => [s.id, { ...s }]));
 
 	const [unfriend, processing] = useAsyncEvent(async () => {
 		if (await confirm('Confirm removal', `Are you sure you want to remove ${displayName} from your contacts list?`)) {
@@ -313,7 +315,7 @@ function FriendRow({
 					</span>
 				</Row>
 			</td>
-			<td>{ characters?.map((c) => c.name).join(', ') }</td>
+			<td>{ characters?.map((c) => `${c.name} (${c.space ? spaceInfoMap.get(c.space)?.name ?? 'Unknown' : 'Private Space'})`).join(', ') }</td>
 			<td>{ new Date(time).toLocaleDateString() }</td>
 			<td>
 				<DivContainer direction='row' gap='small'>

--- a/pandora-client-web/src/ui/screens/spacesSearch/spacesSearch.tsx
+++ b/pandora-client-web/src/ui/screens/spacesSearch/spacesSearch.tsx
@@ -1,13 +1,11 @@
 import classNames from 'classnames';
-import { noop } from 'lodash-es';
 import {
 	AssertNotNullable,
-	EMPTY,
 	SpaceListExtendedInfo,
 	SpaceListInfo,
 	type SpacePublicSetting,
 } from 'pandora-common';
-import { ReactElement, useCallback, useEffect, useMemo, useReducer, useState } from 'react';
+import { ReactElement, useEffect, useMemo, useReducer, useState } from 'react';
 import { Navigate } from 'react-router';
 import closedDoorLocked from '../../../assets/icons/closed-door-locked.svg';
 import closedDoor from '../../../assets/icons/closed-door.svg';
@@ -16,7 +14,7 @@ import publicDoor from '../../../assets/icons/public-door.svg';
 import { Button } from '../../../components/common/button/button.tsx';
 import { Column, Row } from '../../../components/common/container/container.tsx';
 import { ModalDialog } from '../../../components/dialog/dialog.tsx';
-import { useDirectoryChangeListener, useDirectoryConnector } from '../../../components/gameContext/directoryConnectorContextProvider.tsx';
+import { useDirectoryConnector } from '../../../components/gameContext/directoryConnectorContextProvider.tsx';
 import { useSpaceInfo } from '../../../components/gameContext/gameStateContextProvider.tsx';
 import { ContextHelpButton } from '../../../components/help/contextHelpButton.tsx';
 import { useObservable } from '../../../observable.ts';
@@ -26,6 +24,7 @@ import { useIsNarrowScreen } from '../../../styles/mediaQueries.ts';
 import { SpaceDetails } from './spaceDetails.tsx';
 import './spacesSearch.scss';
 import { useSpaceExtendedInfo } from './useSpaceExtendedInfo.tsx';
+import { useSpacesList } from '../../../common/useSpaceList.ts';
 
 const TIPS: readonly string[] = [
 	`You can move your character inside a room by dragging the character name below her.`,
@@ -314,22 +313,4 @@ function SpaceDetailsDialog({ baseInfo, hide }: {
 			<SpaceDetails info={ info } hasFullInfo={ extendedInfo?.result === 'success' } hide={ hide } />
 		</ModalDialog>
 	);
-}
-
-function useSpacesList(): SpaceListInfo[] | undefined {
-	const [data, setData] = useState<SpaceListInfo[]>();
-	const directoryConnector = useDirectoryConnector();
-
-	const fetchData = useCallback(async () => {
-		const result = await directoryConnector.awaitResponse('listSpaces', EMPTY);
-		if (result && result.spaces) {
-			setData(result.spaces);
-		}
-	}, [directoryConnector]);
-
-	useDirectoryChangeListener('spaceList', () => {
-		fetchData().catch(noop);
-	});
-
-	return data;
 }


### PR DESCRIPTION
## References

Fixes one bullet point from #70

## About The Pull Request

Shows the name of a space, a character currently is in, in the contacts list 

## Changelog

Added a feature to show the name of the character's current space in brackets behind its name, if the room is publicly accessible

Authored by: Sandrine

```md
Platform changes:
- Added name of spaces to contact list
```

## Checklist

<!-- Checklist for you to make sure you didn't miss something -->
- [X] The change has been tested locally
- [X] Added documentation to the new code and updated existing documentation where needed
- [X] I understand this patch is submitted under the [Pandora's Contributor Agreement](https://github.com/Project-Pandora-Game/pandora/blob/master/contributor-licence-agreement.md)
