### PR TITLE
[FIX] broken body tutorial in grid mode

### DIFF
--- a/pandora-client-web/src/ui/tutorial/tutorials/wardrobeBody.tsx
+++ b/pandora-client-web/src/ui/tutorial/tutorials/wardrobeBody.tsx
@@ -527,7 +527,7 @@ export const TUTORIAL_WARDROBE_BODY: TutorialConfig = {
 					),
 					conditions: [{
 						type: 'elementQuery',
-						query: '.inventoryView.wardrobeAssetList .listContainer .div-container .list .inventoryViewItem',
+						query: '.inventoryView.wardrobeAssetList .listContainer .inventoryViewItem',
 						filter: (e) => e.innerText.includes('Front hair 1'),
 					}],
 					highlight: [{


### PR DESCRIPTION
## References

_None_

## About The Pull Request

## Changelog

Authored by: Claudia

```md
Fixes:
- Fixed that the wardrobe/character interaction tutorial "Body" could not be completed while the wardrobe asset view was switched to grid mode.
```

## Checklist

<!-- Checklist for you to make sure you didn't miss something -->
- [x] The change has been tested locally
- [x] Added documentation to the new code and updated existing documentation where needed
- [x] I understand this patch is submitted under the [Pandora's Contributor Agreement](https://github.com/Project-Pandora-Game/pandora/blob/master/contributor-licence-agreement.md)
