### PR TITLE
[CHANGE] Replaced grphics with Unicode in asset tab

### DIFF
--- a/pandora-client-web/src/components/common/button/button.scss
+++ b/pandora-client-web/src/components/common/button/button.scss
@@ -62,6 +62,18 @@
 		padding: 0.1em 0.3em;
 	}
 
+	&.slim-fixed {
+		width: 1.8em;
+		height: 1.8em;
+		padding: 0;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 1.2em;
+		line-height: 1;
+	}
+
+
 	&.half-slim {
 		gap: 0.3em;
 		padding: 0.2em 0.6em;

--- a/pandora-client-web/src/editor/components/asset/asset.tsx
+++ b/pandora-client-web/src/editor/components/asset/asset.tsx
@@ -514,13 +514,13 @@ function AssetLayerListLayer({ layer }: { layer: EditorAssetGraphicsWornLayer | 
 			>
 				{ name }
 			</button>
-			<Button className='slim hideDisabled' aria-label='move' onClick={ () => layer.reorderOnAsset(-1) } title='Move layer up'>
-				🠉
+			<Button className='slim-fixed hideDisabled' aria-label='move' onClick={ () => layer.reorderOnAsset(-1) } title='Move layer up'>
+				{ '\u{2B06}' }
 			</Button>
-			<Button className='slim' aria-label='hide' onClick={ toggleAlpha } title="Cycle layers's opacity">
+			<Button className='slim-fixed' aria-label='hide' onClick={ toggleAlpha } title="Cycle layers's opacity">
 				{ EDITOR_ALPHA_ICONS[alphaIndex] }
 			</Button>
-			<Button className='slim hideDisabled' aria-label='delete' onClick={ () => {
+			<Button className='slim-fixed hideDisabled' aria-label='delete' onClick={ () => {
 				// eslint-disable-next-line no-alert
 				if (!confirm(`Are you sure you want to delete layer '${name}'?`))
 					return;
@@ -529,7 +529,7 @@ function AssetLayerListLayer({ layer }: { layer: EditorAssetGraphicsWornLayer | 
 				}
 				layer.deleteFromAsset();
 			} } title='DELETE this layer'>
-				🗑️
+				{ '\u{1F5D1}' }
 			</Button>
 		</li>
 	);

--- a/pandora-client-web/src/editor/editor.tsx
+++ b/pandora-client-web/src/editor/editor.tsx
@@ -31,7 +31,7 @@ import { PandoraInnerInstanceDriver } from './innerInstance/pandoraEditorInstanc
 const logger = GetLogger('Editor');
 
 export const EDITOR_ALPHAS = [1, 0.6, 0];
-export const EDITOR_ALPHA_ICONS = ['⯀', '⬕', '⬚'];
+export const EDITOR_ALPHA_ICONS = ['\u{2B1B}', '\u{2B15}', '\u{2B1A}'];
 
 export class Editor extends TypedEventEmitter<{
 	layerOverrideChange: EditorAssetGraphicsWornLayer | EditorAssetGraphicsRoomDeviceLayer;


### PR DESCRIPTION
## References

_None_

## About The Pull Request

Replaced built-in graphics with Unicode characters so the editor elements are usable universally 

## Changelog

Authored by: Sandrine

```md
Platform changes:
- Changed graphics to Unicode in the editor's asset tab
- Added a new CSS class to keep the Unicode buttons from 'jumping'
```

## Checklist

<!-- Checklist for you to make sure you didn't miss something -->
- [X] The change has been tested locally
- [X] Added documentation to the new code and updated existing documentation where needed
- [X] I understand this patch is submitted under the [Pandora's Contributor Agreement](https://github.com/Project-Pandora-Game/pandora/blob/master/contributor-license-agreement.md)
